### PR TITLE
[infra] add link checker

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,0 +1,33 @@
+name: check-links
+
+on:
+  schedule:
+    - cron: "00 00 01 * *"
+  workflow_dispatch:
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install wheel scrapy
+      - name: Search for broken links and fill report
+        uses: ./.github/workflows/check-links/
+      - name: Continue if report exists
+        id: report
+        run: test -f ./report.md && echo ::set-output name=continue::1 || echo ::set-output name=continue::0
+      - name: Create Issue From File
+        if: ${{ steps.report.outputs.continue == 1 }}
+        uses: peter-evans/create-issue-from-file@v2
+        with:
+          title: "[infra] corrigir links quebrados"
+          content-filepath: ./report.md
+          labels: report, automated issue

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -31,3 +31,4 @@ jobs:
           title: "[infra] corrigir links quebrados"
           content-filepath: ./report.md
           labels: report, automated issue
+          assignees: rdahis

--- a/.github/workflows/check-links/action.yml
+++ b/.github/workflows/check-links/action.yml
@@ -1,0 +1,10 @@
+name: "Check Links"
+description: "Check basedosdados.org for broken links"
+author: "Base dos Dados"
+runs:
+  using: composite
+  steps:
+    - run: scrapy runspider -o report.csv ${{ github.action_path }}/crawler.py
+      shell: bash
+    - run: python ${{ github.action_path }}/to_markdown.py
+      shell: bash

--- a/.github/workflows/check-links/crawler.py
+++ b/.github/workflows/check-links/crawler.py
@@ -30,16 +30,16 @@ class LinkSpider(CrawlSpider):
         Rule(
             # Deny links with more than one question mark with
             #   "(?<!\?)\?(?!\?)"
-            # Deny https://basedosdados.org/dataset/activity/<dataset> page with
-            #   ".*\/dataset\/activity\/.*"
-            #   ".*\/dataset\/.*\?activity_id.*"
+            # Deny https://basedosdados.org/<entity>/activity/ pages with
+            #   ".*\/activity\/.*"
+            #   ".*\/activity_id.*"
             #   ".*\/dataset\/changes\/.*"
             # Allow only https://basedosdados.org/ pages with
             #   "basedosdados\.org.*"
             LinkExtractor(
                 deny=[
                     "(?<!\?)\?(?!\?)",
-                    ".*\/dataset\/activity\/.*",
+                    ".*\/activity\/.*",
                     ".*\/activity_id.*",
                     ".*\/dataset\/changes\/.*",
                 ],
@@ -63,7 +63,9 @@ class LinkSpider(CrawlSpider):
             item["url"] = response.url
             item["status"] = response.status
             item["link_text"] = self._format(response.meta["link_text"])
-            item["referer"] = response.request.headers.get("Referer", self.start_urls[0])
+            item["referer"] = response.request.headers.get(
+                "Referer", "https://no.referer"
+            )
             yield item
         yield None
 

--- a/.github/workflows/check-links/crawler.py
+++ b/.github/workflows/check-links/crawler.py
@@ -15,6 +15,11 @@ class LinkSpider(CrawlSpider):
     name = "link-checker"
     report_if = set(range(400, 600))
     handle_httpstatus_list = list(report_if)
+    
+    # Send referrer headers to every URL
+    custom_settings = {
+        "REFERRER_POLICY": "unsafe-url"
+    }
 
     start_urls = [
         "https://basedosdados.org/",

--- a/.github/workflows/check-links/crawler.py
+++ b/.github/workflows/check-links/crawler.py
@@ -1,0 +1,57 @@
+from scrapy.item import Field, Item
+from scrapy.linkextractors import LinkExtractor
+from scrapy.selector import Selector
+from scrapy.spiders import CrawlSpider, Rule
+
+
+class LinkStatus(Item):
+    url = Field()
+    status = Field()
+    referer = Field()
+    link_text = Field()
+
+
+class LinkSpider(CrawlSpider):
+    name = "link-checker"
+    report_if = set(range(400, 600))
+    handle_httpstatus_list = list(report_if)
+
+    start_urls = [
+        "https://basedosdados.org/",
+        "https://basedosdados.org/dataset/",
+        "https://basedosdados.org/organization/",
+        "https://basedosdados.org/group/",
+        "https://basedosdados.org/about",
+    ]
+
+    rules = [
+        Rule(
+            LinkExtractor(deny=".*?.*", allow_domains="basedosdados.org"),
+            callback="parse",
+            follow=True,
+        ),
+        Rule(
+            LinkExtractor(allow=".*?page.*", allow_domains="basedosdados.org"),
+            callback="parse",
+            follow=True,
+        ),
+        Rule(LinkExtractor(), callback="parse", follow=False),
+    ]
+
+    def parse(self, response):
+        if response.status in self.report_if:
+            item = LinkStatus()
+            item["url"] = response.url
+            item["status"] = response.status
+            item["link_text"] = response.meta["link_text"].strip()
+            item["referer"] = response.request.headers.get(
+                "Referer", self.start_urls[0]
+            )
+            yield item
+        yield None
+
+
+# References
+# https://gist.github.com/mdamien/7b71ef06f49de1189fb75f8fed91ae82
+# https://matthewhoelter.com/2018/11/27/finding-broken-links-on-website.html
+# https://dev.to/pjcalvo/broken-links-checker-with-python-and-scrapy-webcrawler-1gom

--- a/.github/workflows/check-links/to_markdown.py
+++ b/.github/workflows/check-links/to_markdown.py
@@ -21,7 +21,9 @@ def gen_report(csvpath, mdpath):
                 referer = link["referer"]
                 domain = referer.split("//")[1]
                 file.write(f"\n\n**[{domain}]({referer})**  \n")
-            file.write(f"- Failed: HTTP Status {link['status']} at [{link['link_text']}]({link['url']})  \n")
+            file.write(
+                f"- Failed: HTTP Status {link['status']} at [{link['link_text']}]({link['url']})  \n"
+            )
 
 
 if __name__ == "__main__":

--- a/.github/workflows/check-links/to_markdown.py
+++ b/.github/workflows/check-links/to_markdown.py
@@ -1,0 +1,41 @@
+import argparse
+import csv
+
+
+def gen_report(csvpath, mdpath):
+    with open(csvpath, "r") as file:
+        reader = csv.DictReader(file)
+        links = [row for row in reader]
+        links = sorted(links, key=lambda x: x["referer"])
+
+    if not links:
+        return None
+
+    with open(mdpath, "w") as file:
+        file.write(f"Broken Links\n")
+        file.write(f"---")
+
+        referer = ""
+        for link in links:
+            if link["referer"] != referer:
+                referer = link["referer"]
+                domain = referer.split("//")[1]
+                file.write(f"\n\n**[{domain}]({referer})**  \n")
+            file.write(f"- Failed: HTTP Status {link['status']} at [{link['link_text']}]({link['url']})  \n")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Generate markdown report for a broken links search"
+    )
+
+    parser.add_argument(
+        "--csvpath", default="./report.csv", type=str, help="csv input filepath"
+    )
+    parser.add_argument(
+        "--mdpath", default="./report.md", type=str, help="markdown output filepath"
+    )
+
+    args = parser.parse_args()
+
+    gen_report(args.csvpath, args.mdpath)


### PR DESCRIPTION
Proposta de checagem dos links da `basedosdados.org`. Usa a biblioteca scrapy para procurar links que tenham códigos entre 400~599, e então cria um relatório dos links encontrados, como visto nesta [issue](https://github.com/vncsna/website/issues/1). Por enquanto eu não tenho absoluta certeza que está funcionando como esperado. Também decidi ignorar query paths, com a exceção das que são da forma `?page`. Decidi isso porque estava bem lento, mas não sei se é a decisão correta. Para verificar quais links são acessados durante o crawling basta checar o detalhes da [action](https://github.com/vncsna/website/runs/2798408077?check_suite_focus=true).