### PR TITLE
[infra] Remove input hint do campo partitions do pydantic 

### DIFF
--- a/ckanext-basedosdados/ckanext/basedosdados/validator/resources/bdm/table/fields_definitions.py
+++ b/ckanext-basedosdados/ckanext/basedosdados/validator/resources/bdm/table/fields_definitions.py
@@ -247,7 +247,6 @@ PROJECT_ID_STAGING_FIELD = Field(
 
 PARTITIONS_FIELD = Field(
     title="Partições",
-    user_input_hint=["ex. ano, sigla_uf"],
     description=to_line(
         [
             "Liste as colunas da tabela que representam partições.",


### PR DESCRIPTION
Esse PR remove a input hint do campo `partitions` nos modelos do pydantic, que atrapalhava a geração dos YAMLs desenvolvidas aqui: https://github.com/basedosdados/mais/pull/675