### PR TITLE
[infra] add pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ repos:
     # - id: fix-byte-order-marker # fixes BOM
     # - id: fix-encoding-pragma # fixes encoding pragma
     - id: no-commit-to-branch # prevents committing to protected branches
+      args: ['-b', 'develop', '-b', 'master']
     - id: trailing-whitespace # prevents trailing whitespace
 -   repo: https://github.com/psf/black
     rev: 22.1.0


### PR DESCRIPTION
## Changelog

- Restringe branches `develop` e `master` para não ser possível realizar commit nas mesmas 
- Adiciona verificação do código (Python) no padrão `black`
- Checa se existem chaves expostas
- Checa se são adicionados arquivos muito grandes no commit

---

- [ ] Adicionar instruções de uso: 

```
pip install pre-commit
pre-commit install
```
