### PR TITLE
[metadata] removing data_cleaning_code_url field

### DIFF
--- a/ckanext-basedosdados/ckanext/basedosdados/validator/resources/bdm/table/__init__.py
+++ b/ckanext-basedosdados/ckanext/basedosdados/validator/resources/bdm/table/__init__.py
@@ -39,7 +39,6 @@ class BdmTable(_CkanDefaultResource):
     published_by              : Optional[PublishedBy]                                     = PUBLISHED_BY_FIELD
     data_cleaned_by           : Optional[DataCleanedBy]                                   = DATA_CLEANED_BY_FIELD
     data_cleaning_description : Optional[Str]                                             = DATA_CLEANING_DESCRIPTION_FIELD
-    data_cleaning_code_url    : Optional[Str]                                             = DATA_CLEANING_CODE_URL_FIELD
     partner_organization      : Optional[PartnerOrganization]                             = PARTNER_ORGANIZATION_FIELD
     raw_files_url             : Optional[Str]                                             = RAW_FILES_URL_FIELD
     auxiliary_files_url       : Optional[Str]                                             = AUXILIARY_FILES_URL_FIELD

--- a/ckanext-basedosdados/ckanext/basedosdados/validator/resources/bdm/table/fields_definitions.py
+++ b/ckanext-basedosdados/ckanext/basedosdados/validator/resources/bdm/table/fields_definitions.py
@@ -185,15 +185,6 @@ DATA_CLEANING_DESCRIPTION_FIELD = Field(
     ),
     yaml_order={
         "id_before": "data_cleaned_by",
-        "id_after": "data_cleaning_code_url",
-    },
-)
-
-DATA_CLEANING_CODE_URL_FIELD = Field(
-    title="Url do Código de Limpeza dos Dados",
-    description=to_line(["Url do código de limpeza dos dados."]),
-    yaml_order={
-        "id_before": "data_cleaning_description",
         "id_after": "partner_organization",
     },
 )
@@ -204,7 +195,7 @@ PARTNER_ORGANIZATION_FIELD = Field(
         ["Organização que ajudou institucionalmente na disponibilização dos dados."]
     ),
     yaml_order={
-        "id_before": "data_cleaning_code_url",
+        "id_before": "data_cleaning_description",
         "id_after": "raw_files_url",
     },
 )

--- a/utils/migration/2022-12-10-migration-data-cleaning-url.ipynb
+++ b/utils/migration/2022-12-10-migration-data-cleaning-url.ipynb
@@ -1,0 +1,251 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f501b1d9-7d9c-444c-a740-ab64c9c4e436",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Importing modules\n",
+    "from tqdm           import tqdm\n",
+    "from ckanapi        import RemoteCKAN\n",
+    "from basedosdados   import read_sql\n",
+    "from ckanapi.errors import NotFound, ValidationError\n",
+    "\n",
+    "import os\n",
+    "import json\n",
+    "import requests\n",
+    "import pandas as pd\n",
+    "import ckanapi.errors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ea2f9c6c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Creating migration class \n",
+    "\n",
+    "class Migrator:\n",
+    "    def __init__(self, ckan_remote: RemoteCKAN, package_dict):\n",
+    "        self.ckan_remote  = ckan_remote\n",
+    "        self.package_dict = package_dict\n",
+    "\n",
+    "    def update(self):\n",
+    "        try:\n",
+    "            self.ckan_remote.action.package_update(**self.package_dict)\n",
+    "        except NotFound as e:\n",
+    "            print(e)\n",
+    "\n",
+    "    def validate(self):\n",
+    "        try:\n",
+    "            self.ckan_remote.action.bd_dataset_validate(**self.package_dict)\n",
+    "        except NotFound as e:\n",
+    "            print(e)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0a5a525f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "def download_packages(ORIGINAL_CKAN_URL, env):\n",
+    "    \"\"\"Downloads packages from CKAN\"\"\"\n",
+    "\n",
+    "    api_url       = ORIGINAL_CKAN_URL + \"/api/3/action/package_search?q=&rows=3000\"\n",
+    "    packages_list = requests.get(api_url, verify=False).json()[\"result\"][\"results\"]\n",
+    "\n",
+    "    for package in packages_list:\n",
+    "\n",
+    "        if not os.path.isdir(f\"/tmp/packages/\"):\n",
+    "\n",
+    "            os.mkdir(f\"/tmp/packages/\")\n",
+    "\n",
+    "        if not os.path.isdir(f\"/tmp/packages/{env}\"):\n",
+    "\n",
+    "            os.mkdir(f\"/tmp/packages/{env}\")\n",
+    "\n",
+    "        name = package[\"name\"]\n",
+    "\n",
+    "        json.dump(package, open(f\"/tmp/packages/{env}/{name}\", \"w\"))\n",
+    "\n",
+    "    return packages_list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0708ebea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def remove_data_cleaning_url(package):\n",
+    "    \"\"\"Remove data cleaning url from package dict\"\"\"\n",
+    "\n",
+    "    for i, resource in enumerate(package[\"resources\"]):\n",
+    "\n",
+    "        if resource[\"resource_type\"] == \"bdm_table\":\n",
+    "\n",
+    "            if \"data_cleaning_code_url\" in resource:\n",
+    "\n",
+    "                del resource[\"data_cleaning_code_url\"]         \n",
+    "                \n",
+    "    return package"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b9858866",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Global variables \n",
+    "\n",
+    "LOCAL_CKAN_URL = \"http://localhost\"\n",
+    "DEV_CKAN_URL   = \"https://staging.basedosdados.org\"\n",
+    "PROD_CKAN_URL  = \"https://basedosdados.org\"\n",
+    "\n",
+    "CKAN_API_KEY_LOCAL = os.environ[\"CKAN_API_KEY_LOCAL\"]\n",
+    "CKAN_API_KEY_DEV   = os.environ[\"CKAN_API_KEY_DEV\"  ]\n",
+    "CKAN_API_KEY_PROD  = os.environ[\"CKAN_API_KEY_PROD\" ]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3b532eac-addd-47ce-92a9-49335854977b",
+   "metadata": {
+    "scrolled": true,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Downloading packages\n",
+    "\n",
+    "local_packages = download_packages(LOCAL_CKAN_URL, \"local\")\n",
+    "dev_packages   = download_packages(DEV_CKAN_URL  , \"dev\"  )\n",
+    "prod_packages  = download_packages(PROD_CKAN_URL , \"prod\" )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "885815cb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Removing data cleaning url from local packages\n",
+    "\n",
+    "update_packages = []\n",
+    "for package in tqdm(local_packages):\n",
+    "        update_packages.append(remove_data_cleaning_url(package))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2a718f63",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Instantiating ckanapi RemoteCKAN object\n",
+    "\n",
+    "ckan_remote = RemoteCKAN(LOCAL_CKAN_URL, apikey=CKAN_API_KEY_LOCAL)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aba4529c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Validating and updating packages changes\n",
+    "\n",
+    "for i, package in tqdm(enumerate(update_packages)):\n",
+    "    try:\n",
+    "        migration = Migrator(ckan_remote, package)\n",
+    "        migration.validate()\n",
+    "        migration.update()\n",
+    "    except:\n",
+    "        print(i)\n",
+    "        break"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "416cff49",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Dev packages \n",
+    "\n",
+    "update_packages = []\n",
+    "for package in tqdm(dev_packages):\n",
+    "        update_packages.append(remove_data_cleaning_url(package))\n",
+    "\n",
+    "ckan_remote = RemoteCKAN(DEV_CKAN_URL, apikey=CKAN_API_KEY_DEV)\n",
+    "\n",
+    "for i, package in tqdm(enumerate(update_packages)):\n",
+    "    migration = Migrator(ckan_remote, package)\n",
+    "    migration.validate()\n",
+    "    migration.update()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5163f92a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Prod packages\n",
+    "\n",
+    "update_packages = []\n",
+    "for package in tqdm(prod_packages):\n",
+    "        update_packages.append(remove_data_cleaning_url(package))\n",
+    "\n",
+    "ckan_remote = RemoteCKAN(PROD_CKAN_URL, apikey=CKAN_API_KEY_PROD)\n",
+    "\n",
+    "for i, package in tqdm(enumerate(update_packages)):\n",
+    "    migration = Migrator(ckan_remote, package)\n",
+    "    migration.validate()\n",
+    "    migration.update()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "916dbcbb3f70747c44a77c7bcd40155683ae19c65e1c03b4aa3499c5328201f1"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Deu certo reproduzir localmente:

![image](https://user-images.githubusercontent.com/58278652/206881448-158b18b7-1253-457f-8829-16a27242bccc.png)

Mas recebo esse erro ao tentar reproduzir em dev:
É preciso usar uma chave diferente da que está no config.toml ?

```bash
Output exceeds the size limit. Open the full output data in a text editor
---------------------------------------------------------------------------
NotAuthorized                             Traceback (most recent call last)
Cell In [11], line 12
     10 migration = Migrator(ckan_remote, package)
     11 migration.validate()
---> 12 migration.update()

Cell In [2], line 10, in Migrator.update(self)
      8 def update(self):
      9     try:
---> 10         self.ckan_remote.action.package_update(**self.package_dict)
     11     except NotFound as e:
     12         print(e)

File ~/.local/lib/python3.10/site-packages/ckanapi/common.py:51, in ActionShortcut.__getattr__.<locals>.action(**kwargs)
     46     nonfiles = dict((k, v) for k, v in kwargs.items()
     47         if k not in files)
     48     return self._ckan.call_action(name,
     49         data_dict=nonfiles,
     50         files=files)
---> 51 return self._ckan.call_action(name, data_dict=kwargs)

File ~/.local/lib/python3.10/site-packages/ckanapi/remoteckan.py:93, in RemoteCKAN.call_action(self, action, data_dict, context, apikey, files, requests_kwargs)
     91 else:
     92     status, response = self._request_fn(url, data, headers, files, requests_kwargs)
...
--> 130     raise NotAuthorized(err)
    132 # don't recognize the error
    133 raise CKANAPIError(repr([url, status, response]))
NotAuthorized: {'__type': 'Authorization Error', 'message': 'Acesso negado: Usuário  não autorizado a editar o pacote 25c304d6-40e2-4f37-b214-00dffeca0206'}
```
