### PR TITLE
requested_by

### DIFF
--- a/next/components/organisms/InformationRequestPage.js
+++ b/next/components/organisms/InformationRequestPage.js
@@ -300,7 +300,7 @@ export function InformationRequestPage({
               <UserIcon alt="Pedido feito por" width="22px" height="22px" fill="#D0D0D0"/>
               <AddInfoTextBase
                 title="Pedido feito por"
-                text={resource.requested_by.name}
+                text={resource.requested_by?.name || "Não listado"}
               />
             </GridItem>
           </Grid>


### PR DESCRIPTION
Correção de bug em `informationRequest`, onde o metadado `requested_by` esta ausente fazendo a informação retorna como nula, acusando erro na pagina e quebrando ela