### PR TITLE
fix: set empty as default search placeholder

### DIFF
--- a/next/pages/index.js
+++ b/next/pages/index.js
@@ -42,7 +42,7 @@ import BDLogoPlusImage from "../public/img/logos/bd_logo_plus";
 import BDLogoEduImage from "../public/img/logos/bd_logo_edu";
 
 function Hero() {
-  const [search, setSearch] = useState();
+  const [search, setSearch] = useState("");
   const [tags, setTags] = useState([])
   const [mediumQuery] = useMediaQuery("(max-width: 1366px)")
 


### PR DESCRIPTION
What? Set empty as default search placeholder, that turns

- this

![image](https://github.com/basedosdados/website/assets/4673693/8f3ab77c-6315-4ca7-b50e-679aeeb9e4e1)

- into this

![image](https://github.com/basedosdados/website/assets/4673693/a03dcfe4-4514-444d-8920-3b16d46b6804)
