### PR TITLE
Dataset table: increase height using vh unit

### DIFF
--- a/next/components/molecules/ColumnsTable.js
+++ b/next/components/molecules/ColumnsTable.js
@@ -532,7 +532,7 @@ export default function ColumnsTable({
         isLoaded={!isLoading}
       >
         <TableContainer
-          height="100%"
+          style={{maxHeight: "50vh"}}
           maxHeight="300px"
           overflowY="auto"
           border="1px solid #DEDFE0"


### PR DESCRIPTION
Proposta para aumentar a quantidade de linhas na tabela de acesso aos dados. Atualmente mostra cinco linhas. 

O problema de meu ponto de visto é quando tem muitas linhas.

`maxHeight` foi fixado em `300px`, então vc tem uma área pequena e a rolagem fica sensível (scrollbar pequena). Isso cansa um pouco os olhos pq tem que rolar pouco e devagar para não passar por várias linhas.

Adicionei uma altura máxima `maxHeight` variável (`vh`) no atributo `style` do elemento porque usei a unidade `vh` (viewport height). No attr do elemento tem prioridade maior, se o navegador não suportar `vh`, `maxHeight: 300px` continua lá como fallback.

- [viewport unit support](https://caniuse.com/viewport-units)

Se o navegador suportar (grande maioria), a altura máxima vai ser `50%` na altura da janela.

Atualmente:
![image](https://github.com/user-attachments/assets/92c3e5de-f999-44c8-838a-59ae81fbc974)

Com essa alteração:
![image](https://github.com/user-attachments/assets/ef2ecf29-c247-4632-b2ad-cb6f21aa575a)