### PR TITLE
feat: translated search filter tags

### DIFF
--- a/next/pages/search.js
+++ b/next/pages/search.js
@@ -326,13 +326,49 @@ export default function SearchDatasetPage() {
   }
 
   function FilterTags() {
+    function getLocalizedName(key, value) {
+      // Handle special case for contains filters
+      if (key === "contains") {
+        const containsMap = {
+          "tables": t('tables'),
+          "raw_data_sources": t('rawDataSources'),
+          "information_requests": t('informationRequests'),
+          "open_data": t('openData'),
+          "closed_data": t('closedData')
+        };
+        return containsMap[value] || value;
+      }
+
+      // Look up the display name in aggregations
+      const aggregationKey = {
+        "theme": "themes",
+        "organization": "organizations",
+        "spatial_coverage": "spatial_coverages",
+        "tag": "tags",
+        "observation_level": "observation_levels"
+      }[key];
+
+      if (aggregationKey && aggregations[aggregationKey]) {
+        const item = aggregations[aggregationKey].find(item => item.key === value);
+        return item?.name || value;
+      }
+
+      return value;
+    }
+
     function mapArrayProps(obj) {
       let newObj = {}
       for (let key in obj) {
         if (Array.isArray(obj[key])) {
-          newObj[key] = obj[key].map(item => ({ name: item }))
+          newObj[key] = obj[key].map(item => ({ 
+            name: item,
+            displayName: getLocalizedName(key, item)
+          }))
         } else {
-          newObj[key] = obj[key]
+          newObj[key] = {
+            name: obj[key],
+            displayName: getLocalizedName(key, obj[key])
+          }
         }
       }
       return newObj
@@ -350,14 +386,14 @@ export default function SearchDatasetPage() {
             value.map((tag, i) => (
               <TagFilter
                 key={`${key}_${i}`}
-                text={tag.name}
-                handleClick={() => handleSelectFilter([`${key}`,`${tag.name}`])}
+                text={tag.displayName}
+                handleClick={() => handleSelectFilter([`${key}`, tag.name])}
               />
             ))
           ) : (
             <TagFilter
               key={key}
-              text={value}
+              text={value.displayName}
               handleClick={() => handleSelectFilter([`${key}`,`${value}`])}
             />
           )


### PR DESCRIPTION
- Traduz os botões de "filtros selecionados" no topo da busca de `slug` para os nomes já traduzidos.