### PR TITLE
Add warning box for deprecated tables

### DIFF
--- a/next/components/organisms/TablePage.js
+++ b/next/components/organisms/TablePage.js
@@ -21,6 +21,7 @@ import ObservationLevel from "../atoms/ObservationLevelTable";
 import { TemporalCoverageBar } from "../molecules/TemporalCoverageDisplay";
 import DataInformationQuery from "../molecules/DataInformationQuery";
 import FourOFour from "../templates/404";
+import { AlertDiscalimerBox } from "../molecules/DisclaimerBox";
 
 import EmailIcon from "../../public/img/icons/emailIcon";
 import GithubIcon from "../../public/img/icons/githubIcon";
@@ -242,13 +243,20 @@ export default function TablePage({ id, isBDSudo }) {
   }
 
   if (isError) return <FourOFour/>;
-  
+
   return (
     <Stack
       flex={1}
       overflow="hidden"
       spacing={0}
     >
+      {resource?.isDeprecated ? (
+        <Box marginBottom={"1.5rem"}>
+          <AlertDiscalimerBox type="warning">
+            <BodyText typography="small">{t('table.deprecated')}</BodyText>
+          </AlertDiscalimerBox>
+        </Box>
+      ) : null}
       <StackSkeleton
         display="flex"
         height="fit-content"

--- a/next/public/locales/en/dataset.json
+++ b/next/public/locales/en/dataset.json
@@ -143,7 +143,8 @@
         "warningPaidPlanRequired": ["The download of tables with size between 100 MB and 1 GB is available only for ", "subscribers of our paid plans", ". However, you can access the table for free using SQL, Python, R, or Stata. Consider updating to a paid plan to make the download."],
         "errorTableTooLarge": "The table size has exceeded the allowed limit for download, of 1 GB. You can access the data in SQL, Python, R, or Stata.",
         "bigQueryAndPackages": "BigQuery and Packages",
-        "download": "Download"
+        "download": "Download",
+        "deprecated": "This table has been discontinued for some reason. Examples: outdated data source, publication restriction due to LGPD, etc."
     },
     "temporalCoverageBar": {
         "title": "Temporal coverage",

--- a/next/public/locales/es/dataset.json
+++ b/next/public/locales/es/dataset.json
@@ -143,7 +143,8 @@
         "warningPaidPlanRequired": ["La descarga de tablas con tamaño entre 100 MB y 1 GB está disponible solo para ", "suscriptores de nuestros planes de pago", ". Sin embargo, puedes acceder a la tabla gratis utilizando SQL, Python, R o Stata. Considera actualizar a un plan de pago para hacer la descarga."],
         "errorTableTooLarge": "El tamaño de la tabla ha excedido el límite permitido para descarga, de 1 GB. Puedes acceder a los datos en SQL, Python, R o Stata.",
         "bigQueryAndPackages": "BigQuery y Paquetes",
-        "download": "Descargar"
+        "download": "Descargar",
+        "deprecated": "Esta tabla fue descontinuada por algún motivo. Ejemplos: fuentes de datos desactualizadas, restricción en la publicación debido a la LGPD, etc."
     },
     "temporalCoverageBar": {
         "title": "Cobertura temporal",

--- a/next/public/locales/pt/dataset.json
+++ b/next/public/locales/pt/dataset.json
@@ -143,7 +143,8 @@
         "warningPaidPlanRequired": ["O download de tabelas com tamanho entre 100 MB e 1 GB está disponível apenas para ", "assinantes dos nossos planos pagos", ". No entanto, você pode acessar a tabela gratuitamente utilizando SQL, Python, R ou Stata. Considere atualizar para um plano pago para fazer o download."],
         "errorTableTooLarge": "O tamanho da tabela ultrapassou o limite permitido para download, de 1 GB. Você pode acessar os dados em SQL, Python, R ou Stata.",
         "bigQueryAndPackages": "BigQuery e Pacotes",
-        "download": "Download"
+        "download": "Download",
+        "deprecated": "Essa tabela foi descontinuada por algum motivo. Exemplos: fonte de dados desatualizadas, restrição na publicação devido a LGPD, etc."
     },
     "temporalCoverageBar": {
         "title": "Cobertura temporal",


### PR DESCRIPTION
# Resumo

Temos um campo para marcar tabelas descontinuadas/obsoletas mas até agora não foi utilizado

# Proposta

Esse PR adiciona um caixa de alerta acima do nome da tabela.

![image](https://github.com/user-attachments/assets/5b9a88cc-d74c-4549-90e0-df563216ebf0)
