### PR TITLE
refactor: Altera o navegador para Chrome nos testes do Cypress e ajus…

### DIFF
--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -42,7 +42,7 @@ jobs:
         uses: cypress-io/github-action@v5
         with:
           working-directory: ./next 
-          browser: edge
+          browser: chrome
           headless: true
           config-file: cypress.config.js
           config: baseUrl=${{ vars.NEXT_PUBLIC_BASE_URL_FRONTEND }}

--- a/next/cypress/e2e/payment.cy.js
+++ b/next/cypress/e2e/payment.cy.js
@@ -223,15 +223,15 @@ describe('Área do Usuário e Sistema de pagamento', () => {
       cy.fillStripeInput('cardExpiry', '12/30');
       cy.fillStripeInput('cardCvc', '123');
 
+      cy.intercept('POST', 'https://api.stripe.com/v1/payment_intents/pi_*/confirm')
+        .as('stripeConfirmation');
+
       cy.contains('button', 'Confirmar pagamento', { timeout: 1500 })
         .should('be.visible')
         .click();
 
-      cy.intercept('POST', 'https://api.stripe.com/v1/payment_intents/pi_*/confirm')
-        .as('stripeConfirmation');
-
-      cy.wait('@stripeConfirmation').then((interception) => {
-        expect(interception.response.statusCode).to.eq(200);
+      cy.wait('@stripeConfirmation', { timeout: 30000 }).then((interception) => {
+        expect(interception.response.statusCode).to.be.oneOf([200, 201]);
         expect(interception.response.body.status).to.eq('succeeded');
       });
     });
@@ -349,15 +349,15 @@ describe('Área do Usuário e Sistema de pagamento', () => {
       cy.fillStripeInput('cardExpiry', '12/30');
       cy.fillStripeInput('cardCvc', '123');
 
+      cy.intercept('POST', 'https://api.stripe.com/v1/payment_intents/pi_*/confirm')
+        .as('stripeConfirmation');
+
       cy.contains('button', 'Confirmar pagamento', { timeout: 1500 })
         .should('be.visible')
         .click();
 
-      cy.intercept('POST', 'https://api.stripe.com/v1/payment_intents/pi_*/confirm')
-        .as('stripeConfirmation');
-
-      cy.wait('@stripeConfirmation').then((interception) => {
-        expect(interception.response.statusCode).to.eq(200);
+      cy.wait('@stripeConfirmation', { timeout: 30000 }).then((interception) => {
+        expect(interception.response.statusCode).to.be.oneOf([200, 201]);
         expect(interception.response.body.status).to.eq('succeeded');
       });
     });

--- a/next/cypress/support/commands.js
+++ b/next/cypress/support/commands.js
@@ -143,8 +143,8 @@ Cypress.Commands.add('fillStripeInput', (fieldName, value) => {
 
 Cypress.Commands.add('applyCoupon', (coupon, text) => {
   cy.get('input[placeholder="Digite o cupom"]', { timeout: 15000 })
-    .clear()
-    .type(coupon);
+    .clear({ force: true })
+    .type(coupon, { force: true });
 
   cy.contains('button', 'Aplicar', { timeout: 30000 })
     .should('be.visible')


### PR DESCRIPTION
…ta as esperas para a confirmação de pagamento, permitindo status de resposta 200 ou 201, melhorando a robustez dos testes