### PR TITLE
[bugfix]: hyperlinks para documentação quebrados

### DIFF
--- a/next/components/molecules/DataInformationQuery.js
+++ b/next/components/molecules/DataInformationQuery.js
@@ -649,9 +649,9 @@ read_sql(query, billing_project_id = get_billing_id())`, [sqlCode]);
                     display="inline"
                     target="_blank"
                     href={
-                      locale === "en" ? "https://basedosdados.org/en/docs/colab_data/" :
-                      locale === "es" ? "https://basedosdados.org/es/docs/colab_data/" :
-                      "https://basedosdados.org/docs/colab_data/"
+                      locale === "en" ? "/en/docs/colab_data/" :
+                      locale === "es" ? "/es/docs/colab_data/" :
+                      "/docs/colab_data/"
                     }
                     fontWeight="400"
                     color="#0068C5"

--- a/next/content/docs/en/access_data_bq.md
+++ b/next/content/docs/en/access_data_bq.md
@@ -196,7 +196,7 @@ To understand more about the BigQuery interface and how to explore the data, we 
 ### Understand the data
 
 BigQuery has a search mechanism that allows you to search by *datasets* (sets), *tables* (tables), or *labels* (groups).
-We created simple naming rules and practices to facilitate your search - [see more](style_data.md).
+We created simple naming rules and practices to facilitate your search - [see more](style_data).
 
 ### Understand the use of BigQuery (BQ) for free
 

--- a/next/content/docs/en/colab_data.md
+++ b/next/content/docs/en/colab_data.md
@@ -110,19 +110,19 @@ The RAIS architecture tables [can be consulted here](https://docs.google.com/spr
 
 #### To fill in each table of your dataset, follow these steps:
 
-<Tip caption="A each beginning and end of step, consult our [style guide](style_data.md) to ensure you're following the BD standardization"/>
+<Tip caption="A each beginning and end of step, consult our [style guide](style_data) to ensure you're following the BD standardization"/>
 
 1. List all the variables in the data in the `original_name` column
     - Obs: If the base changes the name of the variables over time (like RAIS), it's necessary to make compatibilities between years for all the variables by filling in the `original_name_YYYY` column for each year or month available
-2. Rename the variables according to our [manual](style_data.md) in the `name` column
+2. Rename the variables according to our [manual](style_data) in the `name` column
 3. Understand the type of variable and fill in the `bigquery_type` column
-4. Fill in the description in the `description` column according to the [manual](style_data.md)
+4. Fill in the description in the `description` column according to the [manual](style_data)
 5. From the compatibilities between years and/or queries to the raw data, fill in the temporal coverage in `temporal_coverage` for each variable
     - Obs: If the variables have the same temporal coverage as the table, fill in only with '(1)'
 6. Indicate with 'yes' or 'no' if there's a dictionary for the variables in `covered_by_dictionary`
 7. Check if the variables represent any entity present in the [directories](https://basedosdados.org/dataset?q=diret%C3%B3rio&datasets_with=open_tables&organization=bd&page=1) to fill in the `directory_column`
 8. For variables of type `int64` or `float64`, check if it's necessary to include a [measurement unit](https://github.com/basedosdados/website/blob/master/ckanext-basedosdados/ckanext/basedosdados/validator/available_options/measurement_unit.py)
-9. Reorder the variables according to the [manual](style_data.md)
+9. Reorder the variables according to the [manual](style_data)
 
 <Tip caption="When you finish filling in the architecture tables, contact the Data Basis team to validate everything. It's necessary that it's clear what the final format of the data should be _before_ starting to write the code. This way we avoid redoing the work."/>
 
@@ -148,7 +148,7 @@ The `microdados_vinculos` table from RAIS, for example, is a very large table (+
 - File paths must be shortcuts _relative_ to the root folder
   (`<dataset_id>`), that is, they must not depend on the paths of your
   computer.
-- The cleaning must follow our [style guide](style_data.md) and the [best programming practices](https://en.wikipedia.org/wiki/Best_coding_practices).
+- The cleaning must follow our [style guide](style_data) and the [best programming practices](https://en.wikipedia.org/wiki/Best_coding_practices).
 
 #### Example: PNAD Continuous - Cleaning Code
 

--- a/next/content/docs/es/access_data_bq.md
+++ b/next/content/docs/es/access_data_bq.md
@@ -217,7 +217,7 @@ datos de [RAIS - Ministerio de Economía](https://dev.to/basedosdados/bigquery-1
 BigQuery tiene un mecanismo de búsqueda que permite buscar por nombres
 de *datasets* (conjuntos), *tables* (tablas) o *labels* (grupos).
 Construimos reglas de nomenclatura simples y prácticas para facilitar tu
-búsqueda - [ver más](style_data.md).
+búsqueda - [ver más](style_data).
 
 ### Conectando con PowerBI
 

--- a/next/content/docs/es/colab_data.md
+++ b/next/content/docs/es/colab_data.md
@@ -111,19 +111,19 @@ Las tablas de arquitectura de RAIS [pueden ser consultadas aquí](https://docs.g
 
 #### Para completar cada tabla de tu conjunto sigue este paso a paso:
 
-<Tip caption="Al inicio y final de cada etapa consulta nuestro [manual de estilo](style_data.md) para garantizar que estás siguiendo la estandarización de BD"/>
+<Tip caption="Al inicio y final de cada etapa consulta nuestro [manual de estilo](style_data) para garantizar que estás siguiendo la estandarización de BD"/>
 
 1. Listar todas las variables de los datos en la columna `original_name`
     - Obs: Si la base cambia el nombre de las variables a lo largo de los años (como RAIS), es necesario hacer la compatibilización entre años para todas las variables completando la columna de `original_name_YYYY` para cada año o mes disponible
-2. Renombrar las variables según nuestro [manual](style_data.md) en la columna `name`
+2. Renombrar las variables según nuestro [manual](style_data) en la columna `name`
 3. Entender el tipo de variable y completar la columna `bigquery_type`
-4. Completar la descripción en `description` según el [manual](style_data.md)
+4. Completar la descripción en `description` según el [manual](style_data)
 5. A partir de la compatibilización entre años y/o consultas a los datos brutos, completar la cobertura temporal en `temporal_coverage` de cada variable
     - Obs: Si las variables tienen la misma cobertura temporal que la tabla completar solo con '(1)'
 6. Indicar con 'yes' o 'no' si hay diccionario para las variables en `covered_by_dictionary`
 7. Verificar si las variables representan alguna entidad presente en los [directorios](https://basedosdados.org/dataset?q=diret%C3%B3rio&datasets_with=open_tables&organization=bd&page=1) para completar el `directory_column`
 8. Para las variables del tipo `int64` o `float64` verificar si es necesario incluir una [unidad de medida](https://github.com/basedosdados/website/blob/master/ckanext-basedosdados/ckanext/basedosdados/validator/available_options/measurement_unit.py)
-9. Reordenar las variables según el [manual](style_data.md)
+9. Reordenar las variables según el [manual](style_data)
 
 <Tip caption="Cuando termines de completar las tablas de arquitectura, contacta con el equipo de Base de los Datos para validar todo. Es necesario que esté claro el formato final que los datos deben tener _antes_ de empezar a escribir el código. Así evitamos el retrabajo."/>
 
@@ -150,7 +150,7 @@ La tabla `microdados_vinculos` de RAIS, por ejemplo, es una tabla muy grande (+2
 - Las rutas de archivos deben ser atajos _relativos_ a la carpeta raíz
   (`<dataset_id>`), es decir, no deben depender de las rutas de tu
   computadora.
-- La limpieza debe seguir nuestro [manual de estilo](style_data.md) y las [mejores prácticas de programación](https://en.wikipedia.org/wiki/Best_coding_practices).
+- La limpieza debe seguir nuestro [manual de estilo](style_data) y las [mejores prácticas de programación](https://en.wikipedia.org/wiki/Best_coding_practices).
 
 #### Ejemplo: PNAD Continua - Código de limpieza
 

--- a/next/content/docs/es/home.md
+++ b/next/content/docs/es/home.md
@@ -16,7 +16,7 @@ recursos importantes de diversos conjuntos de datos públicos**, como:
 - **Datos originales**: Enlaces con información útil para explorar más
   sobre el conjunto de datos, como la fuente original y otros.
 
-> Tenemos un equipo de Datos y voluntarios(as) de todo Brasil que ayudan a limpiar y mantener las tablas procesadas. [Aprende cómo formar parte](colab_data.md)
+> Tenemos un equipo de Datos y voluntarios(as) de todo Brasil que ayudan a limpiar y mantener las tablas procesadas. [Aprende cómo formar parte](colab_data)
 
 ## Accediendo a tablas procesadas BD+
 
@@ -72,5 +72,5 @@ estándares y metodologías** para facilitar el proceso de análisis de datos.
 Hemos separado algunos materiales útiles para que entiendas mejor lo que hacemos
 y cómo sacar el mejor provecho de los datos:
 
-- [Cruzar datos de diferentes organizaciones de forma rápida](tutorial_join_tables.md)
-- [Entender patrones de tablas, conjuntos y variables](style_data.md)
+- [Cruzar datos de diferentes organizaciones de forma rápida](tutorial_join_tables)
+- [Entender patrones de tablas, conjuntos y variables](style_data)

--- a/next/content/docs/pt/access_data_bq.md
+++ b/next/content/docs/pt/access_data_bq.md
@@ -214,7 +214,7 @@ dados da [RAIS - Ministério da Economia](https://dev.to/basedosdados/bigquery-1
 O BigQuery possui um mecanismo de busca que permite buscar por nomes
 de *datasets* (conjuntos), *tables* (tabelas) ou *labels* (grupos).
 Construímos regras de nomeação simples e práticas para facilitar sua
-busca - [veja mais](style_data.md).
+busca - [veja mais](style_data).
 
 ### Entenda o uso gratuito do Big Query (BQ)
 

--- a/next/content/docs/pt/colab_data.md
+++ b/next/content/docs/pt/colab_data.md
@@ -114,19 +114,19 @@ As tabelas de arquitetura da RAIS [podem ser consultadas aqui](https://docs.goog
 
 #### Para o preenchimento de cada tabela do seu conjunto siga esse passo a passo:
 
-<Tip caption="A cada início e final de etapa consulte nosso [manual de estilo](style_data.md) para garantir que você está seguindo a padronização da BD"/>
+<Tip caption="A cada início e final de etapa consulte nosso [manual de estilo](style_data) para garantir que você está seguindo a padronização da BD"/>
 
 1. Listar todas as variáveis dos dados na coluna `original_name`
     - Obs: Caso a base mude o nome das variáveis ao longo dos anos (como a RAIS), é necessário fazer a compatibilização entre anos para todas as variáveis preenchendo a coluna de `original_name_YYYY` para cada ano ou mês disponível
-2. Renomear as variáveis conforme nosso [manual](style_data.md) na coluna `name`
+2. Renomear as variáveis conforme nosso [manual](style_data) na coluna `name`
 3. Entender o tipo da variável e preencher a coluna `bigquery_type`
-4. Preencher a descrição em `description` conforme o [manual](style_data.md)
+4. Preencher a descrição em `description` conforme o [manual](style_data)
 5. A partir da compatibilização entre anos e/ou consultas aos dados brutos, preencher a cobertura temporal em `temporal_coverage` de cada variável
     - Obs: Caso as variáveis tenham a mesma cobertura temporal da tabela preencher apenas com '(1)'
 6. Indicar com 'yes' ou 'no' se há dicionário para as variáveis em `covered_by_dictionary`
 7. Verificar se as variáveis representam alguma entidade presente nos [diretórios](https://basedosdados.org/dataset?q=diret%C3%B3rio&datasets_with=open_tables&organization=bd&page=1) para preencher o `directory_column`
 8. Para as variáveis do tipo `int64` ou `float64` verificar se é necessário incluir uma [unidade de medida](https://github.com/basedosdados/website/blob/master/ckanext-basedosdados/ckanext/basedosdados/validator/available_options/measurement_unit.py)
-9. Reordernar as variáveis conforme o [manual](style_data.md)
+9. Reordernar as variáveis conforme o [manual](style_data)
 
 <Tip caption="Quando terminar de preencher as tabelas de arquitetura, entre em contato com a equipe da Base dos Dados para validar tudo. É necessário que esteja claro o formato final que os dados devem ficar _antes_ de começar a escrever o código. Assim a gente evita o retrabalho."/>
 
@@ -153,7 +153,7 @@ A tabela `microdados_vinculos` da RAIS, por exemplo, é uma tabela muito grande 
 - Os caminhos de arquivos devem ser atalhos _relativos_ à pasta raíz
   (`<dataset_id>`), ou seja, não devem depender dos caminhos do seu
   computador.
-- A limpeza deve seguir nosso [manual de estilo](style_data.md) e as [melhores práticas de programação](https://en.wikipedia.org/wiki/Best_coding_practices).
+- A limpeza deve seguir nosso [manual de estilo](style_data) e as [melhores práticas de programação](https://en.wikipedia.org/wiki/Best_coding_practices).
 
 #### Exemplo: PNAD Contínua - Código de limpeza
 


### PR DESCRIPTION
O hyperlink para a documentação para contribuições leva para uma url inválida:

```
https://basedosdados.orghttps//basedosdados.org/docs/colab_data
```

<img width="1088" alt="image" src="https://github.com/user-attachments/assets/78353e7a-546e-47e6-a256-c478c5b0b530" />

Os hyperlinks para o manual de estilo contém a extensão `.md`, isso leva o usuário a uma página não existente

<img width="1088" alt="image" src="https://github.com/user-attachments/assets/8b1457b0-d8dd-4ca8-948f-9c5069f1ab42" />
