### PR TITLE
feat: align en/es sites and recover spatial coverage

### DIFF
--- a/next/components/molecules/DataInformationQuery.js
+++ b/next/components/molecules/DataInformationQuery.js
@@ -29,7 +29,7 @@ import GreenTab from "../atoms/GreenTab";
 import Toggle from "../atoms/Toggle";
 import TableColumns from "./TableColumns";
 import { AlertDiscalimerBox} from "./DisclaimerBox";
-import { triggerGAEvent, triggerGAEventWithData, formatBytes, hasBDProSubscription } from "../../utils";
+import { triggerGAEvent, triggerGAEventWithData, formatBytes, hasBDProSubscription, localizeQueryTableAlias } from "../../utils";
 
 import {
   getBigTableQuery
@@ -233,14 +233,14 @@ const DataInformationQuery = memo(({ resource, datasetName, changeTab }) => {
   const SqlCodeString = useCallback(async () => {
     const result = await getBigTableQuery(resource?._id, checkedColumns, includeTranslation);
     if(result === null) return;
-    setSqlCode(result.trim());
+    setSqlCode(localizeQueryTableAlias(result.trim(), locale));
     setIsLoadingCode(false);
     setIsLoadingSpin(false);
     const tourBD = getTourBD();
     if(tourBD && tourBD.state === 'begin') {
       cookies.set('tourBD', '{"state":"table"}', { expires: 360 });
     }
-  }, [resource?._id, checkedColumns, includeTranslation, getTourBD]);
+  }, [resource?._id, checkedColumns, includeTranslation, getTourBD, locale]);
 
   const handleAccessIndexes = useCallback((index) => {
     const categoryValues = [t('table.bigQueryAndPackages'), t('table.download')];

--- a/next/components/organisms/DatasetSearchCard.js
+++ b/next/components/organisms/DatasetSearchCard.js
@@ -38,6 +38,7 @@ const DatasetSearchCard= ({
   name,
   organizations,
   temporalCoverageText,
+  spatialCoverage,
   tables,
   rawDataSources,
   informationRequests,
@@ -257,11 +258,11 @@ const DatasetSearchCard= ({
                 {temporalCoverageText || t('notProvided')}
               </MetadataRow>
 
-              {/* {locale !== 'pt' && (
+              {locale !== 'pt' && (
                 <MetadataRow label={t('spatialCoverage')}>
                   {spatialCoverage || t('notProvided')}
                 </MetadataRow>
-              )} */}
+              )}
 
               <MetadataRow label={t('resources')}>
                 {resourcesText}

--- a/next/pages/api/datasets/getDataset.js
+++ b/next/pages/api/datasets/getDataset.js
@@ -27,6 +27,7 @@ export default async function getDataset(id, locale = 'pt') {
                 description
                 description${capitalize(locale)}
                 temporalCoverage
+                spatialCoverageName${capitalize(locale)}
                 status {
                   slug
                 }

--- a/next/pages/dataset/[dataset].js
+++ b/next/pages/dataset/[dataset].js
@@ -33,6 +33,7 @@ import {
   hasBDProSubscription,
   hasChatbotSubscription,
   trackNavigateToChatbotLp,
+  isBasedosdadosDomain,
 } from "../../utils";
 
 import { DataBaseIcon } from "../../public/img/icons/databaseIcon";
@@ -479,7 +480,7 @@ export default function DatasetPage ({ dataset, userGuide, hiddenDataset }) {
                 </BodyText>
               </GridItem>
 
-              {/* {locale !== 'pt' ?
+              {locale !== 'pt' &&
                 <GridItem colSpan={{ base: 5, lg: 3 }} marginBottom="8px">
                   <LabelText
                     typography="large"
@@ -498,9 +499,7 @@ export default function DatasetPage ({ dataset, userGuide, hiddenDataset }) {
                       : t('notProvided')}
                   </BodyText>
                 </GridItem>
-                :
-                <></>
-              } */}
+              }
             </Grid>
           </GridItem>
         </Grid>
@@ -535,7 +534,7 @@ export default function DatasetPage ({ dataset, userGuide, hiddenDataset }) {
             }}
           />
         )}
-        {!showSubscriptionBanner && abVariant && (
+        {isBasedosdadosDomain() && !showSubscriptionBanner && abVariant && (
           <ServiceHighlightABTest {...abTestContent[abVariant]} />
         )}
 

--- a/next/pages/search.js
+++ b/next/pages/search.js
@@ -154,6 +154,11 @@ function DatasetCard({ data, locale, index, page }) {
         themes={data?.themes}
         name={data?.name || t('noName')}
         temporalCoverageText={(data?.temporal_coverage && data.temporal_coverage[0]) || ""}
+        spatialCoverage={(data?.spatial_coverage || [])
+          .map(coverage => coverage.name)
+          .filter(Boolean)
+          .sort((a, b) => a.localeCompare(b, locale))
+          .join(', ')}
         organizations={data.organizations}
         tables={{
           id: data?.first_table_id,
@@ -237,6 +242,7 @@ export default function SearchDatasetPage() {
     return {
       themes: aggregations?.themes || [],
       organizations: aggregations?.organizations || [],
+      spatialCoverages: aggregations?.spatial_coverages || [],
       tags: aggregations?.tags || [],
       observationLevels: aggregations?.observation_levels || []
     }
@@ -697,6 +703,24 @@ export default function SearchDatasetPage() {
           />
 
           <Divider marginY="16px !important" borderColor="#DEDFE0"/>
+
+          {locale !== 'pt' && (
+            <>
+              <CheckboxFilterAccordion
+                isActive={validateActiveFilterAccordin("spatial_coverage")}
+                choices={memoizedFilters.spatialCoverages}
+                valueField="key"
+                displayField="name"
+                fieldName={t('spatialCoverage')}
+                valuesChecked={valuesCheckedFilter("spatial_coverage")}
+                onChange={(value) => handleSelectFilter(["spatial_coverage",`${value}`])}
+                isLoading={!isLoading}
+                facet="spatial_coverage"
+              />
+
+              <Divider marginY="16px !important" borderColor="#DEDFE0"/>
+            </>
+          )}
 
           <CheckboxFilterAccordion
             isActive={validateActiveFilterAccordin("organization")}

--- a/next/public/locales/en/home.json
+++ b/next/public/locales/en/home.json
@@ -1,10 +1,10 @@
 {
   "organized_data": "Organized data.",
   "reliable_analysis": "Reliable analysis.",
-  "description_organized_data": "Data Basis is an NGO that maintains the largest public data platform in Brazil and offers specialized services in data engineering, analysis, and training.",
+  "description_organized_data": "Data Basis is an NGO that maintains a large public data platform and offers specialized services in data engineering, analysis, and training.",
   "organized_data_first_button": "Access the data platform",
   "organized_data_second_button": "Learn about consulting services",
-  "socioeconomic_data": "The main socioeconomic data from Brazil, in one place.",
+  "socioeconomic_data": "The main socioeconomic data, in one place.",
   "productivity_data_analysis": {
     "title": "Gain productivity in your data analysis",
     "subtitle": "Treated tables and standardized variables to easily cross datasets"
@@ -46,7 +46,7 @@
     },
     {
       "title": "Automate the translation of institutional codes",
-      "content": "Save time with automated code translation, such as the 7-digit IBGE identifiers for Brazilian municipalities."
+      "content": "Save time with automated code translation, such as standardized geographic identifiers for municipalities and regions."
     },
     {
       "title": "Build analyses with the support of user guides",

--- a/next/public/locales/es/home.json
+++ b/next/public/locales/es/home.json
@@ -1,10 +1,10 @@
 {
   "organized_data": "Datos organizados.",
   "reliable_analysis": "Análisis confiables.",
-  "description_organized_data": "Base de los Datos es una ONG que mantiene la mayor plataforma de datos públicos de Brasil y ofrece servicios especializados en ingeniería, análisis y capacitación de datos.",
+  "description_organized_data": "Base de los Datos es una ONG que mantiene una gran plataforma de datos públicos y ofrece servicios especializados en ingeniería, análisis y capacitación de datos.",
   "organized_data_first_button": "Accede a la plataforma de datos",
   "organized_data_second_button": "Conoce los servicios de consultoría",
-  "socioeconomic_data": "Los principales datos socioeconómicos de Brasil, en un solo lugar.",
+  "socioeconomic_data": "Los principales datos socioeconómicos, en un solo lugar.",
   "productivity_data_analysis": {
     "title": "Gana productividad en tu análisis de datos",
     "subtitle": "Tablas tratadas y variables estandarizadas para cruzar conjuntos de datos con facilidad"
@@ -46,7 +46,7 @@
     },
     {
       "title": "Automatiza la traducción de códigos institucionales",
-      "content": "Ahorra tiempo con la traducción automatizada de códigos, como los identificadores de 7 dígitos del IBGE para los municipios brasileños."
+      "content": "Ahorra tiempo con la traducción automatizada de códigos, como identificadores geográficos estandarizados para municipios y regiones."
     },
     {
       "title": "Construye análisis con el apoyo de las guías de uso",

--- a/next/utils.js
+++ b/next/utils.js
@@ -1,5 +1,36 @@
 import cookies from 'js-cookie';
 
+// Returns the brand domain this build is serving. Prefers the build-time
+// NEXT_PUBLIC_DOMAIN (baked per Docker image: basedosdados.org, data-basis.org,
+// basedelosdatos.org) so it is correct on the server and under Docker, where the
+// browser hostname is localhost. Falls back to the hostname for local npm dev.
+export function getDomain() {
+  if (process.env.NEXT_PUBLIC_DOMAIN) return process.env.NEXT_PUBLIC_DOMAIN.replace(/^www\./, "");
+  if (typeof window !== "undefined") return window.location.hostname.replace(/^www\./, "");
+  return "";
+}
+
+// True only on the Brazilian branch (basedosdados.org), which is the only one
+// that offers consulting services and Brazil-specific content.
+export function isBasedosdadosDomain() {
+  return getDomain() === "basedosdados.org";
+}
+
+// The backend query generator (getTableOneBigTableQuery) always aliases the
+// table as `dados`. Rename that alias to match the interface language so the
+// generated SQL reads naturally per site: pt -> dados, en -> data, es -> datos.
+// The replace is targeted at the alias declaration (`AS dados`) and the column
+// prefixes (`dados.`); word boundaries keep it from touching the project path
+// `basedosdados.<dataset>.<table>` or any other identifier.
+export function localizeQueryTableAlias(query, locale) {
+  const aliasByLocale = { pt: "dados", en: "data", es: "datos" };
+  const alias = aliasByLocale[locale] || "dados";
+  if (alias === "dados" || typeof query !== "string") return query;
+  return query
+    .replace(/\bAS dados\b/g, `AS ${alias}`)
+    .replace(/\bdados\./g, `${alias}.`);
+}
+
 export function filterOnlyValidValues(obj, validValues = null) {
   return Object.entries(obj).filter(
     ([k, v]) =>


### PR DESCRIPTION
## Summary

Same changeset as basedosdados/website#1594 (open against `staging`), targeted at `main`.

Makes the English (data-basis.org) and Spanish (basedelosdatos.org) sites consistent by removing Portuguese/Brazil-specific elements, and restores the previously-hidden **spatial coverage** feature.

- **Consulting banner** — dataset-page `ServiceHighlightABTest` renders only on `basedosdados.org`, gated on `NEXT_PUBLIC_DOMAIN` (new `getDomain()`/`isBasedosdadosDomain()` helpers; build-time domain, correct under Docker).
- **Generated query alias** — `localizeQueryTableAlias()` rewrites the backend's `dados` table alias per locale (pt→`dados`, en→`data`, es→`datos`) across SQL/Python/R; the `basedosdados.<dataset>.<table>` path is left untouched.
- **Spatial coverage** (recovered, gated to non-`pt`) — dataset page (beside temporal), result cards, and the search left-column filter box placed **above** Organization; hidden on `pt`.
- **Homepage** — Brazil-specific phrasing removed in `en`/`es`; testimonials left intact.

> Depends on the backend `spatial_coverages` aggregation: basedosdados/backend#1039 (main) / #1038 (merged to staging).

## Test plan

- Verified locally (npm dev) against production and a local Docker backend: banner gating (hidden on data-basis.org, shown on basedosdados.org), localized query alias, spatial coverage on dataset/cards/search filter (en/es shown, pt hidden), reorder above Organization, homepage free of Brazil mentions.
- `next build` passes (1292 pages, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)