### PR TITLE
fix: localize column descriptions and DB brand (en/es)

### DIFF
--- a/next/components/organisms/componentsUserPage/PlansAndPayment.js
+++ b/next/components/organisms/componentsUserPage/PlansAndPayment.js
@@ -332,6 +332,13 @@ export default function PlansAndPayment ({ userData }) {
   const isChatbotCheckout = checkoutInfos?.productName?.toLowerCase().includes("chatbot") || checkoutInfos?.productSlug?.toLowerCase().includes("chatbot")
   const hasSubscribed = isChatbotCheckout ? hasSubscribedChatbot : hasSubscribedBDPro
 
+  // Stripe product names are stored with the Portuguese brand ("BD Pro"). The English
+  // brand is "DB", so swap the brand token when rendering the product name in English.
+  const localizedProductName = (name) =>
+    router.locale === "en" && typeof name === "string"
+      ? name.replace(/\bBD\b/g, "DB")
+      : name
+
   function getCheckoutStepLabel() {
     if (checkoutStep === "plan") {
       return isChatbotCheckout ? t("username.step1of2") : t("username.step2of3")
@@ -828,7 +835,7 @@ export default function PlansAndPayment ({ userData }) {
               <Stack flexDirection="column" spacing={0} gap="16px">
                 <Box display="flex" flexDirection="row" gap="8px" width="100%">
                   <LabelText textTransform="capitalize">
-                    {checkoutInfos?.productName}
+                    {localizedProductName(checkoutInfos?.productName)}
                   </LabelText>
                   {!isChatbotCheckout && (
                     <BodyText
@@ -1067,7 +1074,7 @@ export default function PlansAndPayment ({ userData }) {
                     gap="16px"
                   >
                     <LabelText textTransform="capitalize">
-                      {checkoutInfos?.productName}
+                      {localizedProductName(checkoutInfos?.productName)}
                     </LabelText>
                     <BodyText typography="small" color="#71757A">
                       {formattedPlanInterval(checkoutInfos?.interval)}

--- a/next/pages/api/tables/getTableColumns.js
+++ b/next/pages/api/tables/getTableColumns.js
@@ -1,20 +1,48 @@
 import axios from "axios";
 import { validate as isUuid } from "uuid";
 
+const GRAPHQL_URL = `${process.env.NEXT_PUBLIC_API_URL}/api/v1/graphql`;
+
 async function getTableColumns(id) {
   const API_URL = `${process.env.NEXT_PUBLIC_API_URL}/tables/${id}/columns/`;
 
-  try {
-    const res = await axios({
-      url: API_URL,
-      method: "GET",
-    });
-    const data = res?.data;
-    return data;
-  } catch (error) {
-    console.error(error);
-    return "err";
-  }
+  const res = await axios({
+    url: API_URL,
+    method: "GET",
+  });
+  return res?.data;
+}
+
+// The REST endpoint above only exposes the Portuguese `description`/`observations`.
+// Fetch the localized fields from GraphQL so the columns table can render English and
+// Spanish descriptions on data-basis.org / basedelosdatos.org (the frontend reads
+// `description${Locale}` with a fallback to `description`).
+async function getLocalizedColumns(id) {
+  const res = await axios({
+    url: GRAPHQL_URL,
+    method: "POST",
+    data: {
+      query: `
+      query {
+        allColumn(table_Id: "${id}", first: 1000) {
+          edges {
+            node {
+              _id
+              name
+              descriptionPt
+              descriptionEn
+              descriptionEs
+              observationsPt
+              observationsEn
+              observationsEs
+            }
+          }
+        }
+      }
+      `,
+    },
+  });
+  return res?.data?.data?.allColumn?.edges?.map((edge) => edge.node) || [];
 }
 
 export default async function handler(req, res) {
@@ -24,9 +52,45 @@ export default async function handler(req, res) {
     return res.status(400).json({ error: "Invalid or missing ID", success: false });
   }
 
-  const result = await getTableColumns(id);
+  const [columnsResult, localizedResult] = await Promise.allSettled([
+    getTableColumns(id),
+    getLocalizedColumns(id),
+  ]);
 
-  if (result === "err") return res.status(500).json({ error: "err", success: false });
+  if (columnsResult.status !== "fulfilled" || !columnsResult.value) {
+    console.error(columnsResult.reason);
+    return res.status(500).json({ error: "err", success: false });
+  }
 
-  return res.status(200).json({ resource: result, success: true });
+  let resource = columnsResult.value;
+
+  // Enrich with localized descriptions/observations. If the GraphQL call fails, fall
+  // back to the REST payload (Portuguese only) rather than breaking the columns table.
+  if (localizedResult.status === "fulfilled" && Array.isArray(resource)) {
+    const localizedById = {};
+    const localizedByName = {};
+    localizedResult.value.forEach((node) => {
+      if (node?._id) localizedById[node._id] = node;
+      if (node?.name) localizedByName[node.name] = node;
+    });
+
+    resource = resource.map((column) => {
+      const localized = localizedById[column.id] || localizedByName[column.name];
+      if (!localized) return column;
+
+      return {
+        ...column,
+        descriptionPt: localized.descriptionPt ?? column.description,
+        descriptionEn: localized.descriptionEn,
+        descriptionEs: localized.descriptionEs,
+        observationsPt: localized.observationsPt ?? column.observations,
+        observationsEn: localized.observationsEn,
+        observationsEs: localized.observationsEs,
+      };
+    });
+  } else if (localizedResult.status === "rejected") {
+    console.error("Failed to fetch localized column fields:", localizedResult.reason);
+  }
+
+  return res.status(200).json({ resource, success: true });
 }

--- a/next/public/locales/en/user.json
+++ b/next/public/locales/en/user.json
@@ -35,7 +35,7 @@
             "termsLink": "Terms of Service",
             "part2": " and ",
             "privacyLink": "Privacy Policy",
-            "part3": " of Base dos Dados."
+            "part3": " of Data Basis."
         },
         "placeholders": {
             "firstName": "Enter your first name",


### PR DESCRIPTION
Follow-up localization polish for data-basis.org (en) and basedelosdatos.org (es), on top of the previously merged #1594. Three commits:

### 1. Localize dataset column descriptions (en/es) — `056290e4`
The columns table sourced descriptions from the REST endpoint `/tables/{id}/columns/`, which only exposes the Portuguese `description`/`observations`. The frontend already reads `description${Locale}` with a fallback, but those keys were never present, so en/es pages always showed Portuguese.

The endpoint now enriches the REST payload with `descriptionPt/En/Es` + `observationsPt/En/Es` from GraphQL (`allColumn`), merged by column id. ~92% of columns (50,301 / 54,727) have English/Spanish descriptions in the backend, which now surface; columns lacking a translation fall back to Portuguese, and GraphQL failures degrade gracefully to the REST payload.

Verified live on `pnad_covid`: en → "Year", "Interview Order"; es → "Año", "Sigla de la Unidad de la Federación"; pt unchanged.

### 2. en signup terms brand → "Data Basis" — `4a636874`
The English signup consent line read "…of Base dos Dados." Now "…of Data Basis.", consistent with the rest of the en locale.

### 3. Checkout shows "DB Pro" in en — `26abe175`
The checkout modal rendered the raw Stripe product name (`checkoutInfos.productName`, e.g. "BD Pro") on every locale. A locale-aware helper now swaps the "BD" brand token to "DB" for English at both display sites. es/pt keep "BD"; non-branded names (Chatbot products) pass through untouched.

### Notes
- `es` intentionally keeps "BD" (Base de los Datos). Backend `productName` lookup keys and subscription slugs stay "BD Pro" to match backend data.
- Chatbot strings left to the parallel session localizing that experience.
- `cypress/e2e/payment.cy.js` asserts `'BD Pro'` — fine in the default pt locale, would need updating only if run against en.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
