### PR TITLE
fix(prices): select Stripe prices by explicit id, not by amount

### DIFF
--- a/next/components/organisms/componentsUserPage/PlansAndPayment.js
+++ b/next/components/organisms/componentsUserPage/PlansAndPayment.js
@@ -24,6 +24,7 @@ import Toggle from "../../atoms/Toggle";
 import { SectionPrice } from "../../../pages/prices";
 import PaymentSystem from "../../organisms/PaymentSystem";
 import { triggerGAEvent, triggerGAEventWithData, hasBDProSubscription, hasChatbotSubscription, getChatbotStreamlitAppUrl, getSubscriptionStatusKey, isSubscriptionTrialing } from "../../../utils";
+import { selectPlans } from "../../../constants/stripePlans";
 
 const SubscriptionBadgeStyles = {
   active: { backgroundColor: "#D5E8DB", color: "#2B8C4D" },
@@ -198,39 +199,7 @@ export default function PlansAndPayment ({ userData }) {
           .then(res => res.json())
 
         if(result.success === true) {
-          function filterData(productName, interval, isActive, amount) {
-            let array = result.data
-
-            return array.filter(item => 
-              (productName ? item.node.productName === productName : true) &&
-              (interval ? item.node.interval === interval : true) &&
-              (amount ? item.node.amount === amount : true) &&
-              (isActive !== undefined ? item.node.isActive === isActive : true)
-            )
-          }
-
-          function filterChatbot(interval, amount) {
-            return result.data.filter((item) => {
-              const name = item.node.productName?.toLowerCase() || ""
-              const slug = item.node.productSlug?.toLowerCase() || ""
-              const isConsumerChatbot =
-                (name.includes("chatbot") || slug.includes("chatbot")) &&
-                !name.includes("empresas")
-              return isConsumerChatbot &&
-                item.node.interval === interval &&
-                item.node.amount === amount &&
-                item.node.isActive === true
-            })
-          }
-
-          const filteredPlans = {
-            bd_pro_month : filterData("BD Pro", "month", true, 47)[0].node,
-            bd_pro_year : filterData("BD Pro", "year", true, 444)[0].node,
-            bd_chatbot_month : filterChatbot("month", 30)[0]?.node,
-            bd_chatbot_year : filterChatbot("year", 326)[0]?.node,
-          }
-
-          setPlans(filteredPlans)
+          setPlans(selectPlans(result.data))
         }
       } catch (error) {
         console.error(error)

--- a/next/constants/stripePlans.js
+++ b/next/constants/stripePlans.js
@@ -1,0 +1,63 @@
+// The exact Stripe prices the site sells, selected by their stable Stripe price id ("price_…",
+// verifiable in the Stripe dashboard). Selecting by id is robust to other active prices existing
+// on the same product — legacy tiers, gift prices, and the per-currency prices being added for
+// the international rollout.
+//
+// These are the current consumer (BRL) prices. The international/USD prices are selected by the
+// upcoming currency logic, not here.
+//
+// The ids below are the production Stripe account's (staging shares the same account). Any
+// environment on a different Stripe account can override them via NEXT_PUBLIC_STRIPE_PRICE_IDS,
+// a JSON object keyed by the same plan keys.
+
+export const PLAN_KEYS = [
+  "bd_pro_month",
+  "bd_pro_year",
+  "bd_chatbot_month",
+  "bd_chatbot_year",
+]
+
+const DEFAULT_PRICE_IDS = {
+  bd_pro_month: "price_1OcrtHCKkCLMrYWYcxJtHMMa", // BD Pro — R$47/month
+  bd_pro_year: "price_1PWlKQCKkCLMrYWYxV3xodMC", // BD Pro — R$444/year
+  bd_chatbot_month: "price_1TCkdbCKkCLMrYWYFgOfi2cc", // Chatbot — R$30/month
+  bd_chatbot_year: "price_1TCkdwCKkCLMrYWYXQlflpIn", // Chatbot — R$326/year
+}
+
+function priceIds() {
+  let overrides = {}
+  try {
+    overrides = JSON.parse(process.env.NEXT_PUBLIC_STRIPE_PRICE_IDS || "{}")
+  } catch (e) {
+    console.error("Invalid NEXT_PUBLIC_STRIPE_PRICE_IDS JSON; ignoring it.", e)
+  }
+  return { ...DEFAULT_PRICE_IDS, ...overrides }
+}
+
+/**
+ * Resolve the plan nodes the site sells from the getPlans edges, by exact Stripe price id.
+ *
+ * @param {Array<{node: object}>} edges - getPlans result data (array of { node }).
+ * @returns {Record<string, object|undefined>} plan-key -> price node (undefined if the
+ *   configured id isn't among the active prices returned by getPlans).
+ */
+export function selectPlans(edges = []) {
+  const ids = priceIds()
+  const plans = {}
+
+  for (const key of PLAN_KEYS) {
+    const wantedId = ids[key]
+    const match = edges.find(({ node }) => node.stripePriceId === wantedId)
+
+    if (!match) {
+      console.warn(
+        `Stripe price "${key}" (${wantedId}) not found among active prices from getPlans — ` +
+          "check the id and that the price is active."
+      )
+    }
+
+    plans[key] = match?.node
+  }
+
+  return plans
+}

--- a/next/pages/api/stripe/getPlans.js
+++ b/next/pages/api/stripe/getPlans.js
@@ -14,6 +14,7 @@ async function getPlans() {
             edges {
               node {
                 _id
+                stripePriceId
                 amount
                 productName
                 productSlug

--- a/next/pages/prices.js
+++ b/next/pages/prices.js
@@ -24,6 +24,7 @@ import BodyText from "../components/atoms/Text/BodyText";
 import CheckIcon from "../public/img/icons/checkIcon";
 import InfoIcon from '../public/img/icons/infoIcon';
 import { triggerGAEvent, triggerGAEventWithData } from "../utils";
+import { selectPlans } from "../constants/stripePlans";
 
 export async function getStaticProps({ locale }) {
   const pagesProps = await withPages();
@@ -365,39 +366,7 @@ export function SectionPrice({
         .then(res => res.json())
 
       if(result.success === true) {
-        function filterData(productName, interval, isActive, amount) {
-          let array = result.data
-
-          return array.filter(item => 
-            (productName ? item.node.productName === productName : true) &&
-            (interval ? item.node.interval === interval : true) &&
-            (amount ? item.node.amount === amount : true) &&
-            (isActive !== undefined ? item.node.isActive === isActive : true)
-          )
-        }
-
-        function filterChatbot(interval, amount) {
-          return result.data.filter((item) => {
-            const name = item.node.productName?.toLowerCase() || ""
-            const slug = item.node.productSlug?.toLowerCase() || ""
-            const isConsumerChatbot =
-              (name.includes("chatbot") || slug.includes("chatbot")) &&
-              !name.includes("empresas")
-            return isConsumerChatbot &&
-              item.node.interval === interval &&
-              item.node.amount === amount &&
-              item.node.isActive === true
-          })
-        }
-
-        const filteredPlans = {
-          bd_pro_month : filterData("BD Pro", "month", true, 47)[0].node,
-          bd_pro_year : filterData("BD Pro", "year", true, 444)[0].node,
-          bd_chatbot_month : filterChatbot("month", 30)[0]?.node,
-          bd_chatbot_year : filterChatbot("year", 326)[0]?.node,
-        }
-
-        setPlans(filteredPlans)
+        setPlans(selectPlans(result.data))
       }
     } catch (error) {
       console.error(error)


### PR DESCRIPTION
## What
Selects the Stripe prices the site sells by their **exact Stripe price id** instead of by amount — in both `/prices` and the account **Plans & Payment** tab.

## Why
`filterData("BD Pro", "month", true, 47)` (and the chatbot equivalents) disambiguate among a product's many active prices by **amount**. That breaks if two active prices share the amount, if an amount changes, or — imminently — as we add per-currency (BRL/USD) prices for the international rollout. Selecting by the exact, dashboard-verifiable price id is robust to any other active prices existing.

## How
- **`next/constants/stripePlans.js`** (new): the four consumer price ids the site sells, and a shared `selectPlans(edges)` that matches each plan by `stripePriceId`. Ids are overridable per environment via **`NEXT_PUBLIC_STRIPE_PRICE_IDS`** (JSON) for any environment on a different Stripe account. **No amount fallback** — a missing/renamed id logs a warning and yields no plan (fail-loud), rather than silently selling the wrong price.
- **`getPlans.js`**: request the new `stripePriceId` field.
- **`prices.js`** and **`PlansAndPayment.js`**: use `selectPlans`, dropping the duplicated amount-based filters.

The international/USD prices are selected by the upcoming currency logic, not here.

## Dependency / deploy order
Requires the backend `stripePriceId` field (basedosdados/backend#1044) deployed to the environment this site queries (`NEXT_PUBLIC_API_URL`). #1044 is on **staging** now; it must reach **main** before this ships to production — otherwise `getPlans` errors on the unknown field.

## Test plan
- [ ] On staging, `/prices` and Plans & Payment show exactly the four configured prices, regardless of other active prices on the product (e.g. after the USD prices are created).
- [ ] Checkout still works (still uses `node._id`).
- [ ] A wrong/inactive id logs a console warning and that plan is absent (no silent wrong-price).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
