### PR TITLE
feat(chatbot): send the site locale when creating a chatbot thread

### DIFF
--- a/next/hooks/useChatbot.js
+++ b/next/hooks/useChatbot.js
@@ -378,7 +378,9 @@ export default function useChatbot(initialThreadId = null, options = {}) {
 
         const response = await axios.post(
           '/api/chatbot/threads',
-          { title },
+          // Send the site's active locale (pt/en/es, derived from the domain) so the
+          // chatbot backend persists the thread's language and answers accordingly.
+          { title, language: router.locale || 'pt' },
           {
             headers: { Authorization: `Bearer ${accessToken}` }
           }
@@ -396,7 +398,7 @@ export default function useChatbot(initialThreadId = null, options = {}) {
         throw err
       }
     },
-    [getAccessToken, handleAuthError, refetchThreads, onThreadCreated]
+    [getAccessToken, handleAuthError, refetchThreads, onThreadCreated, router]
   )
 
   const sendFeedback = useCallback(


### PR DESCRIPTION
## What
Sends the site's active locale (pt/en/es) when creating a chatbot thread, so the chatbot backend can persist the thread's language and answer in it.

## Why
The chatbot page is localized per domain (basedosdados.org → pt, data-basis.org → en, basedelosdatos.org → es), but the frontend never told the chatbot backend which language to use — the bot only inferred it from the user's text. This is the frontend half of basedosdados/chatbot#58 (`Thread.language`).

## How
`useChatbot.js` `createThread` now includes `language: router.locale` in the `POST /chatbot/threads` body (`router` added to the `useCallback` deps). The Next proxy (`pages/api/chatbot/threads.js`) already forwards the request body, so no proxy change is needed.

## Compatibility / deploy order
Backward-compatible and independent: the chatbot backend ignores the extra `language` field until basedosdados/chatbot#58 deploys, so this can ship in any order.

## Test plan
- [ ] On data-basis.org, creating a thread sends `language: "en"`; basedelosdatos.org → `"es"`; basedosdados.org → `"pt"`.
- [ ] After chatbot#58 deploys, the created thread's language matches the domain and the bot answers in it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
