### PR TITLE
feat(chatbot): localize chat UI (en/es) + keep Google login on the originating domain

### DIFF
--- a/next/components/organisms/chatbot/DownloadResults.js
+++ b/next/components/organisms/chatbot/DownloadResults.js
@@ -11,6 +11,7 @@ import {
   useToast,
 } from "@chakra-ui/react";
 import { Fragment, useState } from "react";
+import { useTranslation } from "next-i18next";
 
 import DownloadIcon from "../../../public/img/icons/downloadIcon";
 import TableChartViewIcon from "../../../public/img/icons/tableChartViewIcon";
@@ -67,7 +68,7 @@ const MenuItemProps = {
   _hover: { backgroundColor: "transparent", opacity: "0.7" },
 };
 
-function getExportErrorInfo(error) {
+function getExportErrorInfo(error, t) {
   const status = error?.response?.status;
   const data = error?.response?.data;
   const detail =
@@ -79,9 +80,8 @@ function getExportErrorInfo(error) {
 
   if (status === 410) {
     return {
-      title: "Resultado expirado",
-      description:
-        detail || "Estes resultados não estão mais disponíveis para download.",
+      title: t("ui.download.errors.expiredTitle"),
+      description: detail || t("ui.download.errors.expiredDescription"),
     };
   }
 
@@ -89,20 +89,21 @@ function getExportErrorInfo(error) {
     const isTooLarge =
       typeof detail === "string" && detail.toLowerCase().includes("grandes demais");
     return {
-      title: isTooLarge ? "Resultado muito grande" : "Formato não suportado",
+      title: isTooLarge
+        ? t("ui.download.errors.tooLargeTitle")
+        : t("ui.download.errors.unsupportedTitle"),
       description:
         detail ||
         (isTooLarge
-          ? "Estes resultados são grandes demais para baixar em um único arquivo."
-          : "O formato solicitado não está disponível para download."),
+          ? t("ui.download.errors.tooLargeDescription")
+          : t("ui.download.errors.unsupportedDescription")),
     };
   }
 
   if (status === 404) {
     return {
-      title: "Resultado não encontrado",
-      description:
-        "Não encontramos esse resultado. Ele pode ter expirado ou pertencer a outra conversa.",
+      title: t("ui.download.errors.notFoundTitle"),
+      description: t("ui.download.errors.notFoundDescription"),
     };
   }
 
@@ -110,8 +111,8 @@ function getExportErrorInfo(error) {
     typeof error?.message === "string" ? error.message.replace(/^\[Chatbot\]\s*/, "") : "";
 
   return {
-    title: "Falha ao baixar",
-    description: message || "Não foi possível baixar o resultado. Tente novamente.",
+    title: t("ui.download.errors.genericTitle"),
+    description: message || t("ui.download.errors.genericDescription"),
   };
 }
 
@@ -166,7 +167,7 @@ function DownloadToastContent({ status, title, description }) {
   );
 }
 
-async function downloadQueryResult({ toast, onExport, messageId, artifact }) {
+async function downloadQueryResult({ toast, onExport, messageId, artifact, t }) {
   if (!artifact?.query_ref) {
     console.error("downloadQueryResult: artifact sem query_ref", artifact);
     return false;
@@ -184,7 +185,10 @@ async function downloadQueryResult({ toast, onExport, messageId, artifact }) {
     duration: null,
     position: "bottom",
     render: () => (
-      <DownloadToastContent status="loading" title="Preparando o download..." />
+      <DownloadToastContent
+        status="loading"
+        title={t("ui.download.preparing")}
+      />
     ),
   });
 
@@ -201,13 +205,15 @@ async function downloadQueryResult({ toast, onExport, messageId, artifact }) {
 
     toast.update(toastId, {
       duration: 2500,
-      render: () => <DownloadToastContent status="success" title="Download iniciado" />,
+      render: () => (
+        <DownloadToastContent status="success" title={t("ui.download.started")} />
+      ),
     });
 
     return true;
   } catch (error) {
     console.error("Erro ao exportar resultado da consulta:", error);
-    const { title, description } = getExportErrorInfo(error);
+    const { title, description } = getExportErrorInfo(error, t);
 
     toast.update(toastId, {
       duration: 6000,
@@ -222,6 +228,7 @@ async function downloadQueryResult({ toast, onExport, messageId, artifact }) {
 }
 
 export function DownloadResultButton({ messageId, artifact, onExport, disabled }) {
+  const { t } = useTranslation("chatbot");
   const [status, setStatus] = useState("idle");
   const toast = useToast();
 
@@ -230,7 +237,7 @@ export function DownloadResultButton({ messageId, artifact, onExport, disabled }
     if (disabled || status === "loading" || !onExport || !messageId || !artifact) return;
 
     setStatus("loading");
-    const success = await downloadQueryResult({ toast, onExport, messageId, artifact });
+    const success = await downloadQueryResult({ toast, onExport, messageId, artifact, t });
     setStatus(success ? "idle" : "error");
     if (!success) {
       setTimeout(() => setStatus("idle"), 2000);
@@ -238,10 +245,10 @@ export function DownloadResultButton({ messageId, artifact, onExport, disabled }
   };
 
   const label = disabled
-    ? "Disponível assim que a resposta terminar"
+    ? t("ui.download.availableWhenDone")
     : status === "error"
-    ? "Falha ao baixar. Tente novamente."
-    : "Baixar CSV";
+    ? t("ui.download.retry")
+    : t("ui.download.csv");
 
   return (
     <Tooltip {...ActionTooltipProps} label={label}>
@@ -268,6 +275,7 @@ export function DownloadResultButton({ messageId, artifact, onExport, disabled }
 }
 
 export function DownloadResultsButton({ messageId, downloads, onExport }) {
+  const { t } = useTranslation("chatbot");
   const [statusByRef, setStatusByRef] = useState({});
   const toast = useToast();
 
@@ -279,7 +287,7 @@ export function DownloadResultsButton({ messageId, downloads, onExport }) {
     }
 
     setStatusByRef((prev) => ({ ...prev, [artifact.query_ref]: "loading" }));
-    const success = await downloadQueryResult({ toast, onExport, messageId, artifact });
+    const success = await downloadQueryResult({ toast, onExport, messageId, artifact, t });
     setStatusByRef((prev) => ({ ...prev, [artifact.query_ref]: success ? null : "error" }));
     if (!success) {
       setTimeout(() => {
@@ -294,7 +302,7 @@ export function DownloadResultsButton({ messageId, downloads, onExport }) {
         <>
           <Tooltip
             {...ActionTooltipProps}
-            label="Baixar resultados"
+            label={t("ui.download.label")}
             isDisabled={isOpen}
           >
             <MenuButton
@@ -346,7 +354,7 @@ export function DownloadResultsButton({ messageId, downloads, onExport }) {
                       )}
                       {status === "error" && (
                         <Box as="span" color="#E53E3E">
-                          Erro
+                          {t("ui.error")}
                         </Box>
                       )}
                     </Flex>

--- a/next/components/organisms/chatbot/FeedbackModal.js
+++ b/next/components/organisms/chatbot/FeedbackModal.js
@@ -4,6 +4,7 @@ import {
   Stack,
   Textarea,
 } from "@chakra-ui/react";
+import { useTranslation } from "next-i18next";
 import TitleText from "../../atoms/Text/TitleText";
 import {
   ModalGeneral,
@@ -18,6 +19,7 @@ export default function FeedbackModal({
   onSubmit,
   isSubmitting,
 }) {
+  const { t } = useTranslation("chatbot");
   const [feedbackText, setFeedbackText] = useState("");
   const isPositive = rating === 1;
 
@@ -41,7 +43,7 @@ export default function FeedbackModal({
       }}
     >
       <Stack spacing={0} marginBottom="16px">
-        <TitleText marginRight="24px">Feedback</TitleText>
+        <TitleText marginRight="24px">{t("ui.feedback.title")}</TitleText>
         <ModalCloseButton
           fontSize="14px"
           top="34px"
@@ -53,7 +55,7 @@ export default function FeedbackModal({
 
       <Stack spacing="16px" marginBottom="24px">
         <ExtraInfoTextForm marginBottom="0">
-          Dê os detalhes: (opcional)
+          {t("ui.feedback.detailsLabel")}
         </ExtraInfoTextForm>
 
         <Textarea
@@ -61,8 +63,8 @@ export default function FeedbackModal({
           onChange={(e) => setFeedbackText(e.target.value)}
           placeholder={
             isPositive
-              ? "O que foi satisfatório na resposta?"
-              : "O que foi insatisfatório na resposta?"
+              ? t("ui.feedback.positivePlaceholder")
+              : t("ui.feedback.negativePlaceholder")
           }
           minHeight="120px"
           resize="vertical"
@@ -100,7 +102,7 @@ export default function FeedbackModal({
           minWidth="120px"
           onClick={onClose}
         >
-          Cancelar
+          {t("ui.cancel")}
         </Button>
 
         <Button
@@ -109,7 +111,7 @@ export default function FeedbackModal({
           onClick={handleSubmit}
           isLoading={isSubmitting}
         >
-          Enviar
+          {t("ui.send")}
         </Button>
       </Stack>
     </ModalGeneral>

--- a/next/components/organisms/chatbot/Message.js
+++ b/next/components/organisms/chatbot/Message.js
@@ -7,6 +7,7 @@ import {
 } from "@chakra-ui/react";
 import { keyframes } from "@emotion/react";
 import React, { useMemo, useState } from "react";
+import { useTranslation } from "next-i18next";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm-v3";
 
@@ -66,6 +67,7 @@ const ActionButtonProps = {
 };
 
 function Message({ message, onFeedback, onExport, showFollowUpQuestions = false, onFollowUpClick }) {
+  const { t } = useTranslation("chatbot");
   const isUser = message.role === "user";
   const [feedback, setFeedback] = useState(message.rating ?? null);
   const [isFeedbackModalOpen, setIsFeedbackModalOpen] = useState(false);
@@ -129,7 +131,7 @@ function Message({ message, onFeedback, onExport, showFollowUpQuestions = false,
           fontSize="14px"
           lineHeight="20px"
         >
-          Obrigado pelo seu feedback!
+          {t("ui.feedback.thanks")}
         </Box>
       ),
     });
@@ -268,7 +270,7 @@ function Message({ message, onFeedback, onExport, showFollowUpQuestions = false,
                 <Flex gap="8px" alignItems="center">
                   <Tooltip
                     {...ActionTooltipProps}
-                    label={isCopied ? "Copiado!" : "Copiar resposta"}
+                    label={isCopied ? t("ui.copied") : t("ui.copyResponse")}
                   >
                     <Box
                       {...ActionButtonProps}
@@ -295,7 +297,7 @@ function Message({ message, onFeedback, onExport, showFollowUpQuestions = false,
                 </Flex>
 
                 <Flex gap="8px">
-                  <Tooltip {...ActionTooltipProps} label="Boa resposta">
+                  <Tooltip {...ActionTooltipProps} label={t("ui.goodResponse")}>
                     <Box
                       {...ActionButtonProps}
                       cursor={feedback != null ? "default" : "pointer"}
@@ -309,7 +311,7 @@ function Message({ message, onFeedback, onExport, showFollowUpQuestions = false,
                       <ThumbUpIcon width="18px" height="18px" />
                     </Box>
                   </Tooltip>
-                  <Tooltip {...ActionTooltipProps} label="Resposta ruim">
+                  <Tooltip {...ActionTooltipProps} label={t("ui.badResponse")}>
                     <Box
                       {...ActionButtonProps}
                       cursor={feedback != null ? "default" : "pointer"}

--- a/next/components/organisms/chatbot/OnboardingQuestions.js
+++ b/next/components/organisms/chatbot/OnboardingQuestions.js
@@ -1,5 +1,6 @@
 import { Box, Text } from "@chakra-ui/react";
 import { keyframes } from "@emotion/react";
+import { useTranslation } from "next-i18next";
 import DataStructureIcon from "../../../public/img/icons/dataStructureIcon";
 import TableChartViewIcon from "../../../public/img/icons/tableChartViewIcon";
 import DocIcon from "../../../public/img/icons/docIcon";
@@ -9,26 +10,7 @@ const fadeInUp = keyframes`
   to   { opacity: 1; transform: translateY(0); }
 `;
 
-export const OnboardingSuggestedQuestions = [
-  {
-    eyebrow: "Dados",
-    Icon: DataStructureIcon,
-    question:
-      "Qual foi a evolução do número de prefeituras conquistadas por cada partido no Brasil entre 2012 e 2020, destacando os 5 partidos que mais cresceram nesse período?",
-  },
-  {
-    eyebrow: "Análises",
-    Icon: TableChartViewIcon,
-    question:
-      "Qual é a diferença salarial média entre homens e mulheres no estado de São Paulo ao longo dos últimos cinco anos?",
-  },
-  {
-    eyebrow: "Documentos",
-    Icon: DocIcon,
-    question:
-      "Preciso de um csv que cruze os dados de preço médio da gasolina comum com o PIB dos 10 municípios com o maior PIB do Brasil",
-  },
-];
+const OnboardingIcons = [DataStructureIcon, TableChartViewIcon, DocIcon];
 
 const QuestionChipProps = {
   as: "button",
@@ -71,11 +53,15 @@ const QuestionChipProps = {
 };
 
 export default function OnboardingQuestions({ onQuestionClick, isDisabled }) {
-  const items = Array.isArray(OnboardingSuggestedQuestions)
-    ? OnboardingSuggestedQuestions.filter((item) =>
-        String(item?.question || "").trim()
-      )
-    : [];
+  const { t } = useTranslation("chatbot");
+  const rawItems = t("ui.onboarding.items", { returnObjects: true });
+  const items = (Array.isArray(rawItems) ? rawItems : [])
+    .map((item, index) => ({
+      eyebrow: item?.eyebrow,
+      question: item?.question,
+      Icon: OnboardingIcons[index] ?? DocIcon,
+    }))
+    .filter((item) => String(item?.question || "").trim());
 
   if (items.length === 0) return null;
 

--- a/next/components/organisms/chatbot/PulseDotLoader.js
+++ b/next/components/organisms/chatbot/PulseDotLoader.js
@@ -1,5 +1,6 @@
 import { Box } from "@chakra-ui/react";
 import { keyframes } from "@emotion/react";
+import { useTranslation } from "next-i18next";
 
 const dotSize = 8;
 const dotColor = "#2B8C4D";
@@ -10,12 +11,13 @@ const breathe = keyframes`
 `;
 
 export default function PulseDotLoader({ ...props }) {
+  const { t } = useTranslation("chatbot");
   return (
     <Box
       width={`${dotSize}px`}
       height={`${dotSize}px`}
       role="status"
-      aria-label="Pensando"
+      aria-label={t("ui.thinkingAria")}
       {...props}
     >
       <Box

--- a/next/components/organisms/chatbot/Search.js
+++ b/next/components/organisms/chatbot/Search.js
@@ -13,6 +13,7 @@ import {
   Box,
   Textarea,
 } from "@chakra-ui/react";
+import { useTranslation } from "next-i18next";
 import BodyText from "../../atoms/Text/BodyText";
 import SendIcon from "../../../public/img/icons/sendIcon";
 
@@ -30,6 +31,7 @@ const Search = forwardRef(function Search({
   isGenerating,
   showDisclaimer = true,
 }, ref) {
+  const { t } = useTranslation("chatbot");
   const textareaRef = useRef(null);
   const [isMultiLine, setIsMultiLine] = useState(false);
   const [value, setValue] = useState("");
@@ -173,10 +175,10 @@ const Search = forwardRef(function Search({
             transition="opacity 0.2s ease"
             placeholder={
               isBusy
-                ? "Faça uma pergunta..."
+                ? t("ui.search.placeholder")
                 : !showDisclaimer
-                  ? "Como posso ajudar você hoje?"
-                  : "Faça uma pergunta..."
+                  ? t("ui.helpQuestion")
+                  : t("ui.search.placeholder")
             }
             variant="unstyled"
             minHeight="38px"
@@ -250,12 +252,10 @@ const Search = forwardRef(function Search({
           textAlign="center"
         >
           <BodyText typography="small" color="#ACAEB1">
-            O chatbot pode cometer erros. Considere verificar informações
-            importantes.
+            {t("ui.search.disclaimer")}
           </BodyText>
           <BodyText typography="small" color="#ACAEB1">
-            Todas as informações aqui enviadas são registradas para análise e
-            melhoria do produto.
+            {t("ui.search.disclaimerPrivacy")}
           </BodyText>
         </VStack>
       )}

--- a/next/components/organisms/chatbot/Sidebar.js
+++ b/next/components/organisms/chatbot/Sidebar.js
@@ -8,6 +8,7 @@ import {
   useMediaQuery,
 } from '@chakra-ui/react'
 import cookies from 'js-cookie'
+import { useTranslation } from 'next-i18next'
 import BDLogoImage from '../../../public/img/logos/bd_logo'
 import SidebarIcon from '../../../public/img/icons/sidebarIcon'
 import CrossIcon from '../../../public/img/icons/crossIcon'
@@ -22,6 +23,7 @@ function Sidebar({
   isMobileOpen = false,
   onMobileClose,
 }) {
+  const { t } = useTranslation('chatbot')
   const [isExpanded, setIsExpanded] = useState(true)
   const [isHovering, setIsHovering] = useState(false)
   const [isMobile] = useMediaQuery("(max-width: 767px)")
@@ -148,7 +150,7 @@ function Sidebar({
               backgroundColor: "#EEEEEE",
             }}
             onClick={handleToggle}
-            aria-label={isMobile ? "Fechar menu" : isExpanded ? "Recolher menu" : "Expandir menu"}
+            aria-label={isMobile ? t("ui.sidebar.closeMenu") : isExpanded ? t("ui.sidebar.collapseMenu") : t("ui.sidebar.expandMenu")}
           >
             <SidebarIcon
               width="18px"
@@ -220,7 +222,7 @@ function Sidebar({
               transition="opacity 0.2s ease, transform 0.2s ease, width 0.2s ease"
               transform={isOpen ? "translateX(0)" : "translateX(4px)"}
             >
-              Nova conversa
+              {t("ui.newChat")}
             </BodyText>
           </Box>
           <Box
@@ -279,7 +281,7 @@ function Sidebar({
               whiteSpace="nowrap"
               transition="opacity 0.2s ease, width 0.2s ease"
             >
-              Sair
+              {t("ui.signOut")}
             </BodyText>
           </HStack>
         </Box>

--- a/next/components/organisms/chatbot/StructuredResponse.js
+++ b/next/components/organisms/chatbot/StructuredResponse.js
@@ -5,6 +5,7 @@ import {
 } from "@chakra-ui/react";
 import { ArrowForwardIcon } from "@chakra-ui/icons";
 import React from "react";
+import { useTranslation } from "next-i18next";
 
 import BodyText from "../../atoms/Text/BodyText";
 import Link from "../../atoms/Link";
@@ -35,12 +36,13 @@ export function StructuredSectionHeader({ title }) {
 }
 
 export const DataSourcesList = React.memo(function DataSourcesList({ dataSources }) {
+  const { t } = useTranslation("chatbot");
   if (!Array.isArray(dataSources) || dataSources.length === 0) return null;
 
   return (
     <Box marginTop="8px">
       <Box paddingX="16px">
-        <StructuredSectionHeader title="Fontes dos Dados" />
+        <StructuredSectionHeader title={t("ui.sources.title")} />
       </Box>
       <VStack align="stretch" spacing={0} marginTop="4px" width="100%">
         {dataSources.map((source, index) => {
@@ -130,12 +132,13 @@ export const DataSourcesList = React.memo(function DataSourcesList({ dataSources
 });
 
 export const FollowUpQuestionsList = React.memo(function FollowUpQuestionsList({ followUpQuestions, onQuestionClick }) {
+  const { t } = useTranslation("chatbot");
   if (!Array.isArray(followUpQuestions) || followUpQuestions.length === 0) return null;
 
   return (
     <Box marginTop="24px">
       <Box paddingX="16px">
-        <StructuredSectionHeader title="Perguntas Sugeridas" />
+        <StructuredSectionHeader title={t("ui.suggestedQuestions")} />
       </Box>
       <VStack
         align="stretch"

--- a/next/components/organisms/chatbot/ThinkingSection.js
+++ b/next/components/organisms/chatbot/ThinkingSection.js
@@ -8,6 +8,7 @@ import {
 } from "@chakra-ui/react";
 import { ChevronDownIcon } from "@chakra-ui/icons";
 import React, { useState } from "react";
+import { useTranslation } from "next-i18next";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm-v3";
 
@@ -27,43 +28,20 @@ import {
 } from "./markdown";
 import { pensandoTextShimmer } from "./shimmer";
 
-const ToolPhrases = {
-  search_datasets: {
-    running: "Buscando conjuntos de dados",
-    done: "Conjuntos de dados encontrados",
-    Icon: SearchIcon,
-  },
-  get_dataset_details: {
-    running: "Explorando conjunto de dados",
-    done: "Conjunto de dados explorado",
-    Icon: DataBaseIcon,
-  },
-  get_table_details: {
-    running: "Explorando estrutura da tabela",
-    done: "Estrutura da tabela explorada",
-    Icon: DataStructureIcon,
-  },
-  execute_bigquery_sql: {
-    running: "Consultando o BigQuery",
-    done: "Consulta ao BigQuery concluída",
-    Icon: CodeIcon,
-  },
-  decode_table_values: {
-    running: "Decodificando valores da tabela",
-    done: "Valores da tabela decodificados",
-    Icon: DataStructureIcon,
-  },
+const ToolIcons = {
+  search_datasets: SearchIcon,
+  get_dataset_details: DataBaseIcon,
+  get_table_details: DataStructureIcon,
+  execute_bigquery_sql: CodeIcon,
+  decode_table_values: DataStructureIcon,
 };
 
-const FallbackToolPhrases = {
-  running: "Executando ferramenta",
-  done: "Ferramenta executada",
-  Icon: CodeIcon,
-};
-
-function getToolStepMeta(name, { done = false } = {}) {
-  const phrases = ToolPhrases[name] ?? FallbackToolPhrases;
-  return { label: done ? phrases.done : phrases.running, Icon: phrases.Icon };
+function getToolStepMeta(name, { done = false, t } = {}) {
+  const Icon = ToolIcons[name] ?? CodeIcon;
+  const keyBase = ToolIcons[name]
+    ? `ui.thinking.tools.${name}`
+    : "ui.thinking.tools.fallback";
+  return { label: t(`${keyBase}.${done ? "done" : "running"}`), Icon };
 }
 
 function isPlainObject(value) {
@@ -208,13 +186,14 @@ function ToolStepItem({
   messageLoading,
   onExport,
 }) {
+  const { t } = useTranslation("chatbot");
   const [isOpen, setIsOpen] = useState(false);
   const isOrphan = step.kind === "orphan_output";
   const call = isOrphan ? null : step.call;
   const status = isLoadingStep ? "loading" : "done";
   const { label, Icon } = isOrphan
-    ? { label: "Resultado adicional", Icon: CodeIcon }
-    : getToolStepMeta(call?.name, { done: status === "done" });
+    ? { label: t("ui.thinking.additionalResult"), Icon: CodeIcon }
+    : getToolStepMeta(call?.name, { done: status === "done", t });
   const hasOutput = Boolean(formatToolOutputText(step.output));
   const downloadProps =
     step.output?.artifact?.type === "query_result"
@@ -330,7 +309,7 @@ function ToolStepItem({
                   textTransform="uppercase"
                   letterSpacing="5%"
                 >
-                  Solicitação
+                  {t("ui.thinking.request")}
                 </BodyText>
                 <SolicitationArgsBlocks call={call} downloadProps={downloadProps} />
               </VStack>
@@ -354,7 +333,7 @@ function ToolStepItem({
                   textTransform="uppercase"
                   letterSpacing="5%"
                 >
-                  Resultado
+                  {t("ui.thinking.result")}
                 </BodyText>
                 <ToolResultView output={step.output} />
               </VStack>

--- a/next/components/organisms/chatbot/ThreadList.js
+++ b/next/components/organisms/chatbot/ThreadList.js
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import { useRouter } from 'next/router';
+import { useTranslation } from 'next-i18next';
 import {
   VStack,
   Box,
@@ -25,6 +26,7 @@ import TrashIcon from '../../../public/img/icons/trashIcon';
 import ReloadIcon from '../../../public/img/icons/reloadIcon';
 
 export default function ThreadList({ onSelectThread, currentThreadId, isSidebarOpen, onNewChat }) {
+  const { t } = useTranslation('chatbot');
   const router = useRouter();
   const { threads, isLoading, error, refetch, deleteThread, isDeleting } = useChatbotContext();
   const deleteModal = useDisclosure();
@@ -114,7 +116,7 @@ export default function ThreadList({ onSelectThread, currentThreadId, isSidebarO
       >
         <Stack spacing={0} marginBottom="16px">
           <TitleText marginRight="20px">
-            Confirmar exclusão de conversa
+            {t('ui.thread.deleteTitle')}
           </TitleText>
           <ModalCloseButton
             fontSize="14px"
@@ -127,8 +129,7 @@ export default function ThreadList({ onSelectThread, currentThreadId, isSidebarO
 
         <Stack spacing="24px" marginBottom="16px">
           <ExtraInfoTextForm>
-            Tem certeza que deseja excluir esta conversa? Esta ação não pode ser
-            desfeita.
+            {t('ui.thread.deleteConfirm')}
           </ExtraInfoTextForm>
         </Stack>
 
@@ -149,7 +150,7 @@ export default function ThreadList({ onSelectThread, currentThreadId, isSidebarO
             }}
             onClick={() => deleteModal.onClose()}
           >
-            Cancelar
+            {t('ui.cancel')}
           </Button>
 
           <Button
@@ -161,7 +162,7 @@ export default function ThreadList({ onSelectThread, currentThreadId, isSidebarO
             onClick={() => confirmDelete()}
             isLoading={isDeleting}
           >
-            Excluir
+            {t('ui.delete')}
           </Button>
         </Stack>
       </ModalGeneral>
@@ -197,7 +198,7 @@ export default function ThreadList({ onSelectThread, currentThreadId, isSidebarO
                 transition="opacity 0.2s ease, transform 0.2s ease"
                 transform={isSidebarOpen ? "translateX(0)" : "translateX(4px)"}
               >
-                Conversas
+                {t('ui.thread.historyTitle')}
               </BodyText>
               {isSidebarOpen && <AccordionIcon color="#252A32" />}
             </AccordionButton>
@@ -223,8 +224,8 @@ export default function ThreadList({ onSelectThread, currentThreadId, isSidebarO
                       isSidebarOpen ? "translateX(0)" : "translateX(4px)"
                     }
                   >
-                    <span>Erro ao carregar histórico.</span>
-                    <span>Tente novamente.</span>
+                    <span>{t('ui.thread.loadError')}</span>
+                    <span>{t('ui.thread.tryAgain')}</span>
                   </BodyText>
                   <ReloadIcon
                     cursor="pointer"

--- a/next/components/organisms/chatbot/markdown.js
+++ b/next/components/organisms/chatbot/markdown.js
@@ -16,6 +16,7 @@ import {
   Tooltip,
 } from "@chakra-ui/react";
 import React, { useMemo, useState } from "react";
+import { useTranslation } from "next-i18next";
 
 import "highlight.js/styles/github.css";
 import hljs from "highlight.js/lib/core";
@@ -54,6 +55,7 @@ export function CodeBlock({
   downloadProps = null,
   title = null,
 }) {
+  const { t } = useTranslation("chatbot");
   const code = String(children).replace(/\n$/, "");
   const { hasCopied, onCopy } = useClipboard(code);
   const hasHeader = title != null;
@@ -83,7 +85,7 @@ export function CodeBlock({
     <Flex alignItems="center" gap="8px" flexShrink={0}>
       <Tooltip
         {...ActionTooltipProps}
-        label={hasCopied ? "Copiado!" : "Copiar"}
+        label={hasCopied ? t("ui.copied") : t("ui.copy")}
       >
         <Box
           cursor="pointer"
@@ -375,6 +377,7 @@ function orderColumnsWithIdLast(columns, moveIdToEnd) {
 }
 
 function TruncatableCellContent({ text, maxChars }) {
+  const { t } = useTranslation("chatbot");
   const [expanded, setExpanded] = useState(false);
 
   if (!maxChars || text.length <= maxChars) {
@@ -401,7 +404,7 @@ function TruncatableCellContent({ text, maxChars }) {
           _hover={{ textDecoration: "underline" }}
           onClick={() => setExpanded(false)}
         >
-          ver menos
+          {t("ui.table.seeLess")}
         </Text>
       </>
     );
@@ -426,7 +429,7 @@ function TruncatableCellContent({ text, maxChars }) {
         _hover={{ textDecoration: "underline" }}
         onClick={() => setExpanded(true)}
       >
-        ver mais
+        {t("ui.table.seeMore")}
       </Text>
     </>
   );
@@ -546,6 +549,7 @@ function RecordsTable({
   moveIdToEnd = false,
   truncateCellMaxChars,
 }) {
+  const { t } = useTranslation("chatbot");
   const columns = [];
   const seen = new Set();
   for (const row of records) {
@@ -612,7 +616,7 @@ function RecordsTable({
       </ToolResultTableContainer>
       {records.length > MaxTableRows && (
         <Text fontSize="12px" color="#71757A" marginTop="4px">
-          Mostrando {MaxTableRows} de {records.length} resultados
+          {t("ui.table.showingRows", { shown: MaxTableRows, total: records.length })}
         </Text>
       )}
     </Box>

--- a/next/pages/chatbot.js
+++ b/next/pages/chatbot.js
@@ -8,6 +8,8 @@ import {
 import { useState, useEffect, useRef, useCallback } from "react";
 import Head from "next/head";
 import { useRouter } from "next/router";
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import cookies from "js-cookie";
 import Sidebar from "../components/organisms/chatbot/Sidebar";
 import Search from "../components/organisms/chatbot/Search";
@@ -102,6 +104,7 @@ function ChatbotAccessGate({ children }) {
 
 function ChatbotContent() {
   const router = useRouter();
+  const { t } = useTranslation("chatbot");
   const { t: threadIdFromUrl } = router.query;
   const normalizedThreadId = Array.isArray(threadIdFromUrl)
     ? threadIdFromUrl[0]
@@ -229,7 +232,7 @@ function ChatbotContent() {
       <Box
         as="button"
         type="button"
-        aria-label="Abrir menu"
+        aria-label={t("ui.openMenu")}
         display="flex"
         alignItems="center"
         justifyContent="center"
@@ -249,7 +252,7 @@ function ChatbotContent() {
       <Box
         as="button"
         type="button"
-        aria-label="Nova conversa"
+        aria-label={t("ui.newChat")}
         display="flex"
         alignItems="center"
         justifyContent="center"
@@ -355,7 +358,7 @@ function ChatbotContent() {
                   lineHeight={{ base: "36px", md: "48px" }}
                   paddingX={{ base: "8px", md: 0 }}
                 >
-                  Olá,
+                  {t("ui.greetingPrefix")}
                   <Text
                     as="span"
                     textTransform="capitalize"
@@ -363,7 +366,7 @@ function ChatbotContent() {
                   >
                     {greetingFirstName
                       ? greetingFirstName
-                      : "Como posso ajudar você hoje?"}
+                      : t("ui.helpQuestion")}
                   </Text>
                 </Display>
                 <Box width="100%" flexShrink={0}>
@@ -406,6 +409,14 @@ function ChatbotContent() {
       </HStack>
     </HStack>
   );
+}
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ["common", "menu", "chatbot"])),
+    },
+  };
 }
 
 export default function Chatbot() {

--- a/next/pages/user/login.js
+++ b/next/pages/user/login.js
@@ -90,7 +90,12 @@ export default function Login() {
   }
 
   const handleGoogleLogin = () => {
-    window.location.href = `${process.env.NEXT_PUBLIC_API_URL}/account/google/login/`;
+    // Tell the backend which domain to return to after Google OAuth, so a login
+    // started on data-basis.org (en) or basedelosdatos.org (es) comes back to
+    // the same domain instead of the pt default. The backend allowlists it.
+    const redirectOrigin =
+      typeof window !== "undefined" ? window.location.origin : "";
+    window.location.href = `${process.env.NEXT_PUBLIC_API_URL}/account/google/login/?redirect_origin=${encodeURIComponent(redirectOrigin)}`;
   };
 
   async function handleSubmit(event) {

--- a/next/pages/user/register.js
+++ b/next/pages/user/register.js
@@ -68,7 +68,12 @@ export default function Register() {
   const [isLoading, setIsLoading] = useState(false)
 
   const handleGoogleLogin = () => {
-    window.location.href = `${process.env.NEXT_PUBLIC_API_URL}/account/google/login/`;
+    // Tell the backend which domain to return to after Google OAuth, so a login
+    // started on data-basis.org (en) or basedelosdatos.org (es) comes back to
+    // the same domain instead of the pt default. The backend allowlists it.
+    const redirectOrigin =
+      typeof window !== "undefined" ? window.location.origin : "";
+    window.location.href = `${process.env.NEXT_PUBLIC_API_URL}/account/google/login/?redirect_origin=${encodeURIComponent(redirectOrigin)}`;
   };
 
   const handleInputChange = (e, field) => {

--- a/next/public/locales/en/chatbot.json
+++ b/next/public/locales/en/chatbot.json
@@ -41,5 +41,95 @@
   "banner": {
     "title": "Create analyses in seconds with the power of AI and Base dos Dados' Datalake",
     "button": "Try the DB chatbot now"
+  },
+  "ui": {
+    "newChat": "New chat",
+    "openMenu": "Open menu",
+    "signOut": "Sign out",
+    "greetingPrefix": "Hello,",
+    "helpQuestion": "How can I help you today?",
+    "copy": "Copy",
+    "copied": "Copied!",
+    "copyResponse": "Copy response",
+    "goodResponse": "Good response",
+    "badResponse": "Bad response",
+    "cancel": "Cancel",
+    "send": "Send",
+    "delete": "Delete",
+    "error": "Error",
+    "thinkingAria": "Thinking",
+    "suggestedQuestions": "Suggested Questions",
+    "search": {
+      "placeholder": "Ask a question...",
+      "disclaimer": "The chatbot can make mistakes. Consider verifying important information.",
+      "disclaimerPrivacy": "All information submitted here is recorded for analysis and product improvement."
+    },
+    "sidebar": {
+      "closeMenu": "Close menu",
+      "collapseMenu": "Collapse menu",
+      "expandMenu": "Expand menu"
+    },
+    "sources": {
+      "title": "Data Sources"
+    },
+    "feedback": {
+      "title": "Feedback",
+      "thanks": "Thank you for your feedback!",
+      "detailsLabel": "Add details: (optional)",
+      "positivePlaceholder": "What was satisfactory about the response?",
+      "negativePlaceholder": "What was unsatisfactory about the response?"
+    },
+    "download": {
+      "label": "Download results",
+      "csv": "Download CSV",
+      "preparing": "Preparing download...",
+      "started": "Download started",
+      "availableWhenDone": "Available once the response finishes",
+      "retry": "Download failed. Please try again.",
+      "errors": {
+        "expiredTitle": "Result expired",
+        "expiredDescription": "These results are no longer available for download.",
+        "tooLargeTitle": "Result too large",
+        "tooLargeDescription": "These results are too large to download in a single file.",
+        "unsupportedTitle": "Unsupported format",
+        "unsupportedDescription": "The requested format is not available for download.",
+        "notFoundTitle": "Result not found",
+        "notFoundDescription": "We couldn't find that result. It may have expired or belong to another conversation.",
+        "genericTitle": "Download failed",
+        "genericDescription": "The result could not be downloaded. Please try again."
+      }
+    },
+    "thinking": {
+      "request": "Request",
+      "result": "Result",
+      "additionalResult": "Additional result",
+      "tools": {
+        "search_datasets": { "running": "Searching datasets", "done": "Datasets found" },
+        "get_dataset_details": { "running": "Exploring dataset", "done": "Dataset explored" },
+        "get_table_details": { "running": "Exploring table structure", "done": "Table structure explored" },
+        "execute_bigquery_sql": { "running": "Querying BigQuery", "done": "BigQuery query completed" },
+        "decode_table_values": { "running": "Decoding table values", "done": "Table values decoded" },
+        "fallback": { "running": "Running tool", "done": "Tool executed" }
+      }
+    },
+    "thread": {
+      "historyTitle": "Conversations",
+      "deleteTitle": "Confirm conversation deletion",
+      "deleteConfirm": "Are you sure you want to delete this conversation? This action cannot be undone.",
+      "loadError": "Error loading history.",
+      "tryAgain": "Please try again."
+    },
+    "table": {
+      "seeMore": "see more",
+      "seeLess": "see less",
+      "showingRows": "Showing {{shown}} of {{total}} results"
+    },
+    "onboarding": {
+      "items": [
+        { "eyebrow": "Data", "question": "What was the evolution of the number of city halls won by each party in Brazil between 2012 and 2020, highlighting the 5 parties that grew the most in that period?" },
+        { "eyebrow": "Analyses", "question": "What is the average wage gap between men and women in the state of São Paulo over the last five years?" },
+        { "eyebrow": "Documents", "question": "I need a CSV that cross-references the average price of regular gasoline with the GDP of the 10 municipalities with the highest GDP in Brazil" }
+      ]
+    }
   }
 }

--- a/next/public/locales/es/chatbot.json
+++ b/next/public/locales/es/chatbot.json
@@ -41,5 +41,95 @@
   "banner": {
     "title": "Crea análisis en segundos con el poder de la IA y el Datalake de Base de los Datos",
     "button": "Prueba ya el chatbot de BD"
+  },
+  "ui": {
+    "newChat": "Nueva conversación",
+    "openMenu": "Abrir menú",
+    "signOut": "Cerrar sesión",
+    "greetingPrefix": "Hola,",
+    "helpQuestion": "¿Cómo puedo ayudarte hoy?",
+    "copy": "Copiar",
+    "copied": "¡Copiado!",
+    "copyResponse": "Copiar respuesta",
+    "goodResponse": "Buena respuesta",
+    "badResponse": "Mala respuesta",
+    "cancel": "Cancelar",
+    "send": "Enviar",
+    "delete": "Eliminar",
+    "error": "Error",
+    "thinkingAria": "Pensando",
+    "suggestedQuestions": "Preguntas Sugeridas",
+    "search": {
+      "placeholder": "Haz una pregunta...",
+      "disclaimer": "El chatbot puede cometer errores. Considera verificar la información importante.",
+      "disclaimerPrivacy": "Toda la información enviada aquí se registra para análisis y mejora del producto."
+    },
+    "sidebar": {
+      "closeMenu": "Cerrar menú",
+      "collapseMenu": "Contraer menú",
+      "expandMenu": "Expandir menú"
+    },
+    "sources": {
+      "title": "Fuentes de Datos"
+    },
+    "feedback": {
+      "title": "Comentarios",
+      "thanks": "¡Gracias por tu comentario!",
+      "detailsLabel": "Añade detalles: (opcional)",
+      "positivePlaceholder": "¿Qué te resultó satisfactorio de la respuesta?",
+      "negativePlaceholder": "¿Qué te resultó insatisfactorio de la respuesta?"
+    },
+    "download": {
+      "label": "Descargar resultados",
+      "csv": "Descargar CSV",
+      "preparing": "Preparando la descarga...",
+      "started": "Descarga iniciada",
+      "availableWhenDone": "Disponible cuando termine la respuesta",
+      "retry": "Error al descargar. Inténtalo de nuevo.",
+      "errors": {
+        "expiredTitle": "Resultado caducado",
+        "expiredDescription": "Estos resultados ya no están disponibles para descargar.",
+        "tooLargeTitle": "Resultado demasiado grande",
+        "tooLargeDescription": "Estos resultados son demasiado grandes para descargarlos en un solo archivo.",
+        "unsupportedTitle": "Formato no compatible",
+        "unsupportedDescription": "El formato solicitado no está disponible para descargar.",
+        "notFoundTitle": "Resultado no encontrado",
+        "notFoundDescription": "No encontramos ese resultado. Puede haber caducado o pertenecer a otra conversación.",
+        "genericTitle": "Error al descargar",
+        "genericDescription": "No se pudo descargar el resultado. Inténtalo de nuevo."
+      }
+    },
+    "thinking": {
+      "request": "Solicitud",
+      "result": "Resultado",
+      "additionalResult": "Resultado adicional",
+      "tools": {
+        "search_datasets": { "running": "Buscando conjuntos de datos", "done": "Conjuntos de datos encontrados" },
+        "get_dataset_details": { "running": "Explorando conjunto de datos", "done": "Conjunto de datos explorado" },
+        "get_table_details": { "running": "Explorando la estructura de la tabla", "done": "Estructura de la tabla explorada" },
+        "execute_bigquery_sql": { "running": "Consultando BigQuery", "done": "Consulta a BigQuery completada" },
+        "decode_table_values": { "running": "Decodificando valores de la tabla", "done": "Valores de la tabla decodificados" },
+        "fallback": { "running": "Ejecutando herramienta", "done": "Herramienta ejecutada" }
+      }
+    },
+    "thread": {
+      "historyTitle": "Conversaciones",
+      "deleteTitle": "Confirmar eliminación de la conversación",
+      "deleteConfirm": "¿Seguro que deseas eliminar esta conversación? Esta acción no se puede deshacer.",
+      "loadError": "Error al cargar el historial.",
+      "tryAgain": "Inténtalo de nuevo."
+    },
+    "table": {
+      "seeMore": "ver más",
+      "seeLess": "ver menos",
+      "showingRows": "Mostrando {{shown}} de {{total}} resultados"
+    },
+    "onboarding": {
+      "items": [
+        { "eyebrow": "Datos", "question": "¿Cuál fue la evolución del número de alcaldías conquistadas por cada partido en Brasil entre 2012 y 2020, destacando los 5 partidos que más crecieron en ese período?" },
+        { "eyebrow": "Análisis", "question": "¿Cuál es la diferencia salarial media entre hombres y mujeres en el estado de São Paulo a lo largo de los últimos cinco años?" },
+        { "eyebrow": "Documentos", "question": "Necesito un csv que cruce los datos del precio medio de la gasolina común con el PIB de los 10 municipios con el mayor PIB de Brasil" }
+      ]
+    }
   }
 }

--- a/next/public/locales/pt/chatbot.json
+++ b/next/public/locales/pt/chatbot.json
@@ -41,5 +41,95 @@
   "banner": {
     "title": "Crie análises em segundos com o poder da IA e o Datalake da Base dos Dados",
     "button": "Teste já o chatbot da BD"
+  },
+  "ui": {
+    "newChat": "Nova conversa",
+    "openMenu": "Abrir menu",
+    "signOut": "Sair",
+    "greetingPrefix": "Olá,",
+    "helpQuestion": "Como posso ajudar você hoje?",
+    "copy": "Copiar",
+    "copied": "Copiado!",
+    "copyResponse": "Copiar resposta",
+    "goodResponse": "Boa resposta",
+    "badResponse": "Resposta ruim",
+    "cancel": "Cancelar",
+    "send": "Enviar",
+    "delete": "Excluir",
+    "error": "Erro",
+    "thinkingAria": "Pensando",
+    "suggestedQuestions": "Perguntas Sugeridas",
+    "search": {
+      "placeholder": "Faça uma pergunta...",
+      "disclaimer": "O chatbot pode cometer erros. Considere verificar informações importantes.",
+      "disclaimerPrivacy": "Todas as informações aqui enviadas são registradas para análise e melhoria do produto."
+    },
+    "sidebar": {
+      "closeMenu": "Fechar menu",
+      "collapseMenu": "Recolher menu",
+      "expandMenu": "Expandir menu"
+    },
+    "sources": {
+      "title": "Fontes dos Dados"
+    },
+    "feedback": {
+      "title": "Feedback",
+      "thanks": "Obrigado pelo seu feedback!",
+      "detailsLabel": "Dê os detalhes: (opcional)",
+      "positivePlaceholder": "O que foi satisfatório na resposta?",
+      "negativePlaceholder": "O que foi insatisfatório na resposta?"
+    },
+    "download": {
+      "label": "Baixar resultados",
+      "csv": "Baixar CSV",
+      "preparing": "Preparando o download...",
+      "started": "Download iniciado",
+      "availableWhenDone": "Disponível assim que a resposta terminar",
+      "retry": "Falha ao baixar. Tente novamente.",
+      "errors": {
+        "expiredTitle": "Resultado expirado",
+        "expiredDescription": "Estes resultados não estão mais disponíveis para download.",
+        "tooLargeTitle": "Resultado muito grande",
+        "tooLargeDescription": "Estes resultados são grandes demais para baixar em um único arquivo.",
+        "unsupportedTitle": "Formato não suportado",
+        "unsupportedDescription": "O formato solicitado não está disponível para download.",
+        "notFoundTitle": "Resultado não encontrado",
+        "notFoundDescription": "Não encontramos esse resultado. Ele pode ter expirado ou pertencer a outra conversa.",
+        "genericTitle": "Falha ao baixar",
+        "genericDescription": "Não foi possível baixar o resultado. Tente novamente."
+      }
+    },
+    "thinking": {
+      "request": "Solicitação",
+      "result": "Resultado",
+      "additionalResult": "Resultado adicional",
+      "tools": {
+        "search_datasets": { "running": "Buscando conjuntos de dados", "done": "Conjuntos de dados encontrados" },
+        "get_dataset_details": { "running": "Explorando conjunto de dados", "done": "Conjunto de dados explorado" },
+        "get_table_details": { "running": "Explorando estrutura da tabela", "done": "Estrutura da tabela explorada" },
+        "execute_bigquery_sql": { "running": "Consultando o BigQuery", "done": "Consulta ao BigQuery concluída" },
+        "decode_table_values": { "running": "Decodificando valores da tabela", "done": "Valores da tabela decodificados" },
+        "fallback": { "running": "Executando ferramenta", "done": "Ferramenta executada" }
+      }
+    },
+    "thread": {
+      "historyTitle": "Conversas",
+      "deleteTitle": "Confirmar exclusão de conversa",
+      "deleteConfirm": "Tem certeza que deseja excluir esta conversa? Esta ação não pode ser desfeita.",
+      "loadError": "Erro ao carregar histórico.",
+      "tryAgain": "Tente novamente."
+    },
+    "table": {
+      "seeMore": "ver mais",
+      "seeLess": "ver menos",
+      "showingRows": "Mostrando {{shown}} de {{total}} resultados"
+    },
+    "onboarding": {
+      "items": [
+        { "eyebrow": "Dados", "question": "Qual foi a evolução do número de prefeituras conquistadas por cada partido no Brasil entre 2012 e 2020, destacando os 5 partidos que mais cresceram nesse período?" },
+        { "eyebrow": "Análises", "question": "Qual é a diferença salarial média entre homens e mulheres no estado de São Paulo ao longo dos últimos cinco anos?" },
+        { "eyebrow": "Documentos", "question": "Preciso de um csv que cruze os dados de preço médio da gasolina comum com o PIB dos 10 municípios com o maior PIB do Brasil" }
+      ]
+    }
   }
 }


### PR DESCRIPTION
Two changes for the multi-domain chatbot experience (pt/en/es by domain).

## 1. Localize the chat interface
`pages/chatbot.js` and `components/organisms/chatbot/*` were built with hardcoded Portuguese and **no i18n wiring** (no `getStaticProps`, no `useTranslation`), so the chat UI stayed Portuguese on `data-basis.org` and `basedelosdatos.org` ("Olá", "Nova conversa", the disclaimer, "Fontes dos Dados", download/feedback/thread strings).

- Added `getStaticProps` (loads `common`, `menu`, `chatbot`) to `pages/chatbot.js`.
- Added a `ui` object to the existing `chatbot` namespace in `public/locales/{pt,en,es}/chatbot.json` (68 leaf keys, identical set across locales; pt values byte-identical to the old literals). Existing landing-page keys untouched.
- Routed every user-facing string through `t('ui.…')` across 10 components + the page. Internal-only strings (`console.*`, thrown Error messages, download **filenames**, brand `<title>`) intentionally left.

## 2. Keep Google login on the originating domain
`handleGoogleLogin` (login + register) now appends `?redirect_origin=${window.location.origin}` so the backend OAuth callback returns to the same domain (paired backend PR consumes and allowlists it).

## Validation
JSON parses in all three locales; `ui` key sets identical; all 14 changed JS files parse as JSX (module+jsx). A full `next build` was not run in the worktree (no `node_modules`) — CI is the build gate.

### For reviewers
- es `feedback.title` is rendered "Comentarios" (pt/en keep "Feedback") — swap to "Feedback" if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
