### PR TITLE
feat(prices): show region-appropriate currency by domain

### DIFF
--- a/next/components/organisms/componentsUserPage/PlansAndPayment.js
+++ b/next/components/organisms/componentsUserPage/PlansAndPayment.js
@@ -24,7 +24,7 @@ import Toggle from "../../atoms/Toggle";
 import { SectionPrice } from "../../../pages/prices";
 import PaymentSystem from "../../organisms/PaymentSystem";
 import { triggerGAEvent, triggerGAEventWithData, hasBDProSubscription, hasChatbotSubscription, getChatbotStreamlitAppUrl, getSubscriptionStatusKey, isSubscriptionTrialing } from "../../../utils";
-import { selectPlans } from "../../../constants/stripePlans";
+import { selectPlans, localeToRegion, formatCurrency } from "../../../constants/stripePlans";
 
 const SubscriptionBadgeStyles = {
   active: { backgroundColor: "#D5E8DB", color: "#2B8C4D" },
@@ -199,7 +199,7 @@ export default function PlansAndPayment ({ userData }) {
           .then(res => res.json())
 
         if(result.success === true) {
-          setPlans(selectPlans(result.data))
+          setPlans(selectPlans(result.data, localeToRegion(router.locale)))
         }
       } catch (error) {
         console.error(error)
@@ -645,7 +645,7 @@ export default function PlansAndPayment ({ userData }) {
           <Text>{t('username.coupon')} {coupon.toUpperCase()} {limitText}</Text>
         </GridItem>
         <GridItem textAlign="end">
-          <Text>- {couponInfos?.discountAmount?.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL', minimumFractionDigits: 2 })}/{formattedPlanInterval(checkoutInfos?.interval, true)}</Text>
+          <Text>- {formatCheckoutAmount(couponInfos?.discountAmount)}/{formattedPlanInterval(checkoutInfos?.interval, true)}</Text>
         </GridItem>
       </>
     )
@@ -659,11 +659,9 @@ export default function PlansAndPayment ({ userData }) {
   }
 
   function formatCheckoutAmount(amount) {
-    return amount?.toLocaleString("pt-BR", {
-      style: "currency",
-      currency: "BRL",
-      minimumFractionDigits: 2,
-    })
+    // Currency follows the selected plan's region (br → BRL, latam/intl → USD),
+    // matching what the storefront showed and what the backend webhook charges.
+    return formatCurrency(amount, checkoutInfos?.region)
   }
 
   const TotalToPayDisplay = () => {
@@ -964,11 +962,7 @@ export default function PlansAndPayment ({ userData }) {
                 </GridItem>
                 <GridItem textAlign="end">
                   <Text>
-                    {checkoutInfos?.amount?.toLocaleString("pt-BR", {
-                      style: "currency",
-                      currency: "BRL",
-                      minimumFractionDigits: 2,
-                    })}
+                    {formatCheckoutAmount(checkoutInfos?.amount)}
                     /{formattedPlanInterval(checkoutInfos?.interval, true)}
                   </Text>
                 </GridItem>
@@ -987,11 +981,7 @@ export default function PlansAndPayment ({ userData }) {
                   º {formattedPlanInterval(checkoutInfos?.interval, true)}{" "}
                   {!hasSubscribed && "e 7º dia"}
                   {t("username.couponDuration", { returnObjects: true })[1]}
-                  {checkoutInfos?.amount?.toLocaleString("pt-BR", {
-                    style: "currency",
-                    currency: "BRL",
-                    minimumFractionDigits: 2,
-                  })}
+                  {formatCheckoutAmount(checkoutInfos?.amount)}
                   /{formattedPlanInterval(checkoutInfos?.interval, true)}.
                 </BodyText>
               )}

--- a/next/constants/stripePlans.js
+++ b/next/constants/stripePlans.js
@@ -1,10 +1,13 @@
 // The exact Stripe prices the site sells, selected by their stable Stripe price id ("price_…",
 // verifiable in the Stripe dashboard). Selecting by id is robust to other active prices existing
-// on the same product — legacy tiers, gift prices, and the per-currency prices being added for
-// the international rollout.
+// on the same product — legacy tiers, gift prices, and the per-currency prices added for the
+// international rollout.
 //
-// These are the current consumer (BRL) prices. The international/USD prices are selected by the
-// upcoming currency logic, not here.
+// The ids below anchor each plan to its consumer (BRL) price. On the international domains the
+// site shows the same plan in the visitor's currency by swapping to the price that carries the
+// matching `region` tag (same product and interval) — see selectPlans. This mirrors the backend
+// checkout webhook, which charges the region-correct price from the card's country, so what the
+// visitor sees is what they are charged.
 //
 // The ids below are the production Stripe account's (staging shares the same account). Any
 // environment on a different Stripe account can override them via NEXT_PUBLIC_STRIPE_PRICE_IDS,
@@ -17,11 +20,80 @@ export const PLAN_KEYS = [
   "bd_chatbot_year",
 ]
 
+// The three pricing regions, tagged on each Stripe price via its `region` metadata:
+//   br    — Brazil, in BRL (the anchor prices below)
+//   latam — Spanish-speaking Latin America, in USD
+//   intl  — the rest of the world, in USD
+const DEFAULT_REGION = "br"
+
 const DEFAULT_PRICE_IDS = {
   bd_pro_month: "price_1OcrtHCKkCLMrYWYcxJtHMMa", // BD Pro — R$47/month
   bd_pro_year: "price_1PWlKQCKkCLMrYWYxV3xodMC", // BD Pro — R$444/year
   bd_chatbot_month: "price_1TCkdbCKkCLMrYWYFgOfi2cc", // Chatbot — R$30/month
   bd_chatbot_year: "price_1TCkdwCKkCLMrYWYXQlflpIn", // Chatbot — R$326/year
+}
+
+/**
+ * Map the site locale (domain) to a pricing region.
+ *
+ * basedosdados.org (pt) → br, basedelosdatos.org (es) → latam, data-basis.org (en) → intl.
+ * Anything unknown falls back to the BRL region, the site's historical behavior.
+ *
+ * @param {string|undefined} locale - next-i18next locale for the current domain.
+ * @returns {"br"|"latam"|"intl"} the pricing region.
+ */
+export function localeToRegion(locale) {
+  switch (locale) {
+    case "en":
+      return "intl"
+    case "es":
+      return "latam"
+    case "pt":
+      return "br"
+    default:
+      return DEFAULT_REGION
+  }
+}
+
+/**
+ * Currency presentation for a pricing region.
+ *
+ * br bills in BRL; latam and intl bill in USD. USD is formatted en-US ("$19.00")
+ * and BRL pt-BR ("R$ 47,00").
+ *
+ * @param {"br"|"latam"|"intl"} region
+ * @returns {{code: string, locale: string, symbol: string}}
+ */
+export function regionCurrency(region) {
+  switch (region) {
+    case "intl":
+    case "latam":
+      return { code: "USD", locale: "en-US", symbol: "$" }
+    case "br":
+    default:
+      return { code: "BRL", locale: "pt-BR", symbol: "R$" }
+  }
+}
+
+/**
+ * Format a numeric amount in the currency of a pricing region.
+ *
+ * Returns undefined for a nullish amount, preserving the `amount?.toLocaleString(...)`
+ * semantics of the call sites this replaces (which render nothing until the amount loads).
+ *
+ * @param {number|undefined|null} amount
+ * @param {"br"|"latam"|"intl"} region
+ * @param {{minimumFractionDigits?: number}} [opts]
+ * @returns {string|undefined}
+ */
+export function formatCurrency(amount, region, { minimumFractionDigits = 2 } = {}) {
+  if (amount === null || amount === undefined) return undefined
+  const { code, locale } = regionCurrency(region)
+  return amount.toLocaleString(locale, {
+    style: "currency",
+    currency: code,
+    minimumFractionDigits,
+  })
 }
 
 function priceIds() {
@@ -35,28 +107,57 @@ function priceIds() {
 }
 
 /**
- * Resolve the plan nodes the site sells from the getPlans edges, by exact Stripe price id.
+ * Resolve the plan nodes the site sells from the getPlans edges.
+ *
+ * Each plan is anchored to its BRL price by exact Stripe price id. For a non-BR region, the
+ * anchor is swapped for the sibling price that carries the matching `region` tag and the same
+ * product (`productSlug`) and `interval`. When no such sibling exists (or the region is br), the
+ * BRL anchor is shown. This keeps id-based selection as the source of truth while adding the
+ * currency dimension, and never shows a price for the wrong product or interval.
  *
  * @param {Array<{node: object}>} edges - getPlans result data (array of { node }).
+ * @param {"br"|"latam"|"intl"} [region="br"] - pricing region for the current domain.
  * @returns {Record<string, object|undefined>} plan-key -> price node (undefined if the
  *   configured id isn't among the active prices returned by getPlans).
  */
-export function selectPlans(edges = []) {
+export function selectPlans(edges = [], region = DEFAULT_REGION) {
   const ids = priceIds()
   const plans = {}
 
   for (const key of PLAN_KEYS) {
     const wantedId = ids[key]
-    const match = edges.find(({ node }) => node.stripePriceId === wantedId)
+    const anchor = edges.find(({ node }) => node.stripePriceId === wantedId)
 
-    if (!match) {
+    if (!anchor) {
       console.warn(
         `Stripe price "${key}" (${wantedId}) not found among active prices from getPlans — ` +
           "check the id and that the price is active."
       )
+      plans[key] = undefined
+      continue
     }
 
-    plans[key] = match?.node
+    if (region === DEFAULT_REGION) {
+      plans[key] = anchor.node
+      continue
+    }
+
+    // Swap to the regional sibling: same product and interval, tagged for this region.
+    const sibling = edges.find(
+      ({ node }) =>
+        node.region === region &&
+        node.productSlug === anchor.node.productSlug &&
+        node.interval === anchor.node.interval
+    )
+
+    if (!sibling) {
+      console.warn(
+        `No "${region}" price for plan "${key}" (${anchor.node.productSlug}/${anchor.node.interval}); ` +
+          "showing the BRL price. Add the regional price in Stripe with the matching `region` tag."
+      )
+    }
+
+    plans[key] = (sibling ?? anchor).node
   }
 
   return plans

--- a/next/pages/api/stripe/getPlans.js
+++ b/next/pages/api/stripe/getPlans.js
@@ -19,6 +19,7 @@ async function getPlans() {
                 productName
                 productSlug
                 interval
+                region
                 isActive
               }
             }

--- a/next/pages/prices.js
+++ b/next/pages/prices.js
@@ -24,7 +24,7 @@ import BodyText from "../components/atoms/Text/BodyText";
 import CheckIcon from "../public/img/icons/checkIcon";
 import InfoIcon from '../public/img/icons/infoIcon';
 import { triggerGAEvent, triggerGAEventWithData } from "../utils";
-import { selectPlans } from "../constants/stripePlans";
+import { selectPlans, localeToRegion, regionCurrency, formatCurrency } from "../constants/stripePlans";
 
 export async function getStaticProps({ locale }) {
   const pagesProps = await withPages();
@@ -40,6 +40,7 @@ export const CardPrice = ({
   title,
   subTitle,
   price,
+  region,
   anualPlan = false,
   hidePrice = false,
   textResource,
@@ -48,6 +49,7 @@ export const CardPrice = ({
   locale,
   isBeta = false,
 }) => {
+  const { symbol: currencySymbol } = regionCurrency(region);
   const { t } = useTranslation('prices');
   const router = useRouter();
 
@@ -149,7 +151,7 @@ export const CardPrice = ({
                 alignItems="center"
               >
                 <Display textAlign="center">
-                  R$ {anualPlan ? Math.ceil(price / 12) : price}
+                  {currencySymbol} {anualPlan ? Math.ceil(price / 12) : price}
                 </Display>
                 <TitleText
                   typography="small"
@@ -170,9 +172,7 @@ export const CardPrice = ({
               >
                 {anualPlan &&
                   t("annualBillingMessage", {
-                    price: price.toLocaleString("pt-BR", {
-                      style: "currency",
-                      currency: "BRL",
+                    price: formatCurrency(price, region, {
                       minimumFractionDigits: 0,
                     }),
                   })}
@@ -366,7 +366,7 @@ export function SectionPrice({
         .then(res => res.json())
 
       if(result.success === true) {
-        setPlans(selectPlans(result.data))
+        setPlans(selectPlans(result.data, localeToRegion(locale)))
       }
     } catch (error) {
       console.error(error)
@@ -569,6 +569,7 @@ export function SectionPrice({
             title={t("plans.free.title")}
             subTitle={t("plans.free.subtitle")}
             price="0"
+            region={localeToRegion(locale)}
             textResource={t("features")}
             resources={t("plans.free.features", { returnObjects: true }).map(
               (feature, index) => ({
@@ -598,6 +599,7 @@ export function SectionPrice({
                 plans?.[`bd_chatbot_${toggleAnual ? "year" : "month"}`]?.amount ??
                 (toggleAnual ? 326 : 30)
               }
+              region={plans?.[`bd_chatbot_${toggleAnual ? "year" : "month"}`]?.region}
               anualPlan={toggleAnual}
               textResource={t("allFeaturesPlus", { plan: t("plans.free.title") })}
               resources={t("plans.chatbot.features", { returnObjects: true }).map(
@@ -636,6 +638,7 @@ export function SectionPrice({
             price={
               plans?.[`bd_pro_${toggleAnual ? "year" : "month"}`]?.amount || 444
             }
+            region={plans?.[`bd_pro_${toggleAnual ? "year" : "month"}`]?.region}
             anualPlan={toggleAnual}
             textResource={t("allFeaturesPlus", { plan: t("plans.free.title") })}
             resources={t("plans.pro.features", { returnObjects: true }).map(


### PR DESCRIPTION
## What

Extends the id-based price selection from #1620 with a currency dimension. Each plan is still anchored to its BRL price by exact Stripe price id; on the international domains it is swapped for the sibling price carrying the matching `region` tag (same product and interval). Currency formatting follows the shown price's region — BRL on basedosdados.org (pt), USD on data-basis.org (en) and basedelosdatos.org (es).

This mirrors the backend checkout webhook (`feat/regional-pricing`), which charges the region-correct price from the card's country, so **what the visitor sees is what they are charged.**

## Changes

- **`stripePlans.js`** — `localeToRegion(locale)` (pt→br, es→latam, en→intl); `selectPlans(edges, region)` swaps each anchor to its regional sibling, falling back to the BRL anchor when no sibling exists (or region is br); `regionCurrency` / `formatCurrency` centralize BRL/USD presentation.
- **`getPlans` API** — requests the new `region` field on each price node.
- **`prices.js`** — `CardPrice` takes the selected price's region and renders its currency symbol; plan cards pass region from the selected node (free card from the locale).
- **`PlansAndPayment.js` checkout** — `formatCheckoutAmount` formats in the selected plan's currency; every BRL-hardcoded amount display now routes through it (subtotal, coupon, total, confirmation).

## Tests

Verified with a standalone Node harness (22/22): region selection, regional swap, BR fallback, missing-anchor handling, `region`-field-absent degradation, env override, and BRL/USD currency formatting. (No jest in the repo.)

## Degrades safely

If the backend `region` field is absent, or a price has no regional sibling, every plan shows the BRL price — today's behavior. So this is safe to ship first or simultaneously with the backend.

## Deploy note

Ships as a pair with the backend `feat/regional-pricing`. Deploy the backend **enforcement** no earlier than this display change, so the site never shows R$ while charging US$.
