### PR TITLE
fix(chatbot): show the Data Basis (DB) logo on the English site

### DIFF
--- a/next/components/organisms/chatbot/BrandLogo.js
+++ b/next/components/organisms/chatbot/BrandLogo.js
@@ -1,0 +1,13 @@
+import { useRouter } from "next/router";
+
+import BDLogoImage from "../../../public/img/logos/bd_logo";
+import DBLogoImage from "../../../public/img/logos/db_logo";
+
+// Locale-aware wordmark: Data Basis (DB) on the English site, Base dos Dados (BD)
+// otherwise. Mirrors the rule used by the main site nav
+// (components/molecules/Menu.js), driven by router.locale so it is SSR-safe.
+export default function BrandLogo(props) {
+  const { locale } = useRouter();
+  const Logo = locale === "en" ? DBLogoImage : BDLogoImage;
+  return <Logo {...props} />;
+}

--- a/next/components/organisms/chatbot/Sidebar.js
+++ b/next/components/organisms/chatbot/Sidebar.js
@@ -9,7 +9,7 @@ import {
 } from '@chakra-ui/react'
 import cookies from 'js-cookie'
 import { useTranslation } from 'next-i18next'
-import BDLogoImage from '../../../public/img/logos/bd_logo'
+import BrandLogo from './BrandLogo'
 import SidebarIcon from '../../../public/img/icons/sidebarIcon'
 import CrossIcon from '../../../public/img/icons/crossIcon'
 import BodyText from '../../atoms/Text/BodyText'
@@ -120,11 +120,11 @@ function Sidebar({
             position="relative"
             left="-2px"
           >
-            <BDLogoImage widthImage="58px" heightImage="25px" />
+            <BrandLogo widthImage="58px" heightImage="25px" />
           </Box>
 
           {!isOpen && !isHovering && (
-            <BDLogoImage
+            <BrandLogo
               display={{ base: "none", md: "block" }}
               widthImage="34px"
               heightImage="34px"

--- a/next/pages/chatbot.js
+++ b/next/pages/chatbot.js
@@ -18,7 +18,7 @@ import OnboardingQuestions from "../components/organisms/chatbot/OnboardingQuest
 import Display from "../components/atoms/Text/Display";
 import SidebarIcon from "../public/img/icons/sidebarIcon";
 import CrossIcon from "../public/img/icons/crossIcon";
-import BDLogoImage from "../public/img/logos/bd_logo";
+import BrandLogo from "../components/organisms/chatbot/BrandLogo";
 import useChatbot from "../hooks/useChatbot";
 import { ChatbotProvider } from "../context/ChatbotContext";
 import { redirectToChatbotCheckout } from "../utils";
@@ -247,7 +247,7 @@ function ChatbotContent() {
         <SidebarIcon width="20px" height="20px" />
       </Box>
 
-      <BDLogoImage widthImage="48px" heightImage="21px" />
+      <BrandLogo widthImage="48px" heightImage="21px" />
 
       <Box
         as="button"


### PR DESCRIPTION
The chatbot's left sidebar and mobile header hardcoded the **Base dos Dados (BD)** wordmark, so `data-basis.org/chatbot` showed "BD" instead of the **Data Basis (DB)** logo.

## Fix
Add a small locale-aware `BrandLogo` (`components/organisms/chatbot/BrandLogo.js`): `DB` for `en`, `BD` otherwise — the same `router.locale === "en"` rule the main nav (`components/molecules/Menu.js`) already uses, driven by `router.locale` so it is SSR-safe. Wired into the three hardcoded spots: the sidebar logo (expanded + collapsed) and the mobile header.

## Notes
- Consistent with the rest of the site: **es keeps the BD logo** (the whole site does today — a separate, site-wide gap, not chatbot-specific).
- `bd_logo` and `db_logo` are drop-in (identical props/viewBox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
