### PR TITLE
feat(prices): pin exact price ids per region, drop metadata-based selection

### DIFF
--- a/next/components/organisms/componentsUserPage/PlansAndPayment.js
+++ b/next/components/organisms/componentsUserPage/PlansAndPayment.js
@@ -659,9 +659,9 @@ export default function PlansAndPayment ({ userData }) {
   }
 
   function formatCheckoutAmount(amount) {
-    // Currency follows the selected plan's region (br → BRL, latam/intl → USD),
-    // matching what the storefront showed and what the backend webhook charges.
-    return formatCurrency(amount, checkoutInfos?.region)
+    // Currency follows the domain (br → BRL, latam/intl → USD), matching the region whose price
+    // ids the storefront selected and what the backend webhook charges.
+    return formatCurrency(amount, localeToRegion(router.locale))
   }
 
   const TotalToPayDisplay = () => {

--- a/next/constants/stripePlans.js
+++ b/next/constants/stripePlans.js
@@ -1,17 +1,20 @@
-// The exact Stripe prices the site sells, selected by their stable Stripe price id ("price_…",
-// verifiable in the Stripe dashboard). Selecting by id is robust to other active prices existing
-// on the same product — legacy tiers, gift prices, and the per-currency prices added for the
-// international rollout.
+// The exact Stripe prices the site sells, pinned by their stable Stripe price id ("price_…",
+// verifiable in the Stripe dashboard) for each plan AND region. Selecting by id is deterministic:
+// a new, edited, or mis-tagged price in Stripe is simply ignored until its id is added here and the
+// site is redeployed. Nothing is inferred from price metadata, amounts, or intervals.
 //
-// The ids below anchor each plan to its consumer (BRL) price. On the international domains the
-// site shows the same plan in the visitor's currency by swapping to the price that carries the
-// matching `region` tag (same product and interval) — see selectPlans. This mirrors the backend
-// checkout webhook, which charges the region-correct price from the card's country, so what the
-// visitor sees is what they are charged.
+// Only the *selection* is pinned. The amount shown for each plan still comes live from the getPlans
+// GraphQL query, so a price change in Stripe reflects on the site automatically; only adding or
+// swapping which price is sold requires updating this map and redeploying.
+//
+// Currency follows the domain (see localeToRegion / regionCurrency): basedosdados.org bills BRL,
+// data-basis.org and basedelosdatos.org bill USD. The backend checkout webhook independently
+// enforces the region-correct price from the card's country (arbitrage guard), so what the visitor
+// sees here is what they are charged.
 //
 // The ids below are the production Stripe account's (staging shares the same account). Any
 // environment on a different Stripe account can override them via NEXT_PUBLIC_STRIPE_PRICE_IDS,
-// a JSON object keyed by the same plan keys.
+// a JSON object shaped like DEFAULT_PRICE_IDS below (keyed by region, then plan key).
 
 export const PLAN_KEYS = [
   "bd_pro_month",
@@ -20,17 +23,30 @@ export const PLAN_KEYS = [
   "bd_chatbot_year",
 ]
 
-// The three pricing regions, tagged on each Stripe price via its `region` metadata:
-//   br    — Brazil, in BRL (the anchor prices below)
-//   latam — Spanish-speaking Latin America, in USD
-//   intl  — the rest of the world, in USD
+// The three pricing regions the site sells in.
 const DEFAULT_REGION = "br"
 
+// Exact price id per region and plan. Amounts in the comments are for human reference only —
+// the live amount is read from getPlans, never from here.
 const DEFAULT_PRICE_IDS = {
-  bd_pro_month: "price_1OcrtHCKkCLMrYWYcxJtHMMa", // BD Pro — R$47/month
-  bd_pro_year: "price_1PWlKQCKkCLMrYWYxV3xodMC", // BD Pro — R$444/year
-  bd_chatbot_month: "price_1TCkdbCKkCLMrYWYFgOfi2cc", // Chatbot — R$30/month
-  bd_chatbot_year: "price_1TCkdwCKkCLMrYWYXQlflpIn", // Chatbot — R$326/year
+  br: {
+    bd_pro_month: "price_1OcrtHCKkCLMrYWYcxJtHMMa", // BD Pro — R$47/month
+    bd_pro_year: "price_1PWlKQCKkCLMrYWYxV3xodMC", // BD Pro — R$444/year
+    bd_chatbot_month: "price_1TCkdbCKkCLMrYWYFgOfi2cc", // Chatbot — R$30/month
+    bd_chatbot_year: "price_1TCkdwCKkCLMrYWYXQlflpIn", // Chatbot — R$326/year
+  },
+  latam: {
+    bd_pro_month: "price_1U0yCrCKkCLMrYWY2piPpKCg", // BD Pro — US$12/month
+    bd_pro_year: "price_1U0yE4CKkCLMrYWYsVrOB3i5", // BD Pro — US$115/year
+    bd_chatbot_month: "price_1U0yJSCKkCLMrYWYj2DSeGa8", // Chatbot — US$8/month
+    bd_chatbot_year: "price_1U0yJtCKkCLMrYWYOs7xvfpL", // Chatbot — US$77/year
+  },
+  intl: {
+    bd_pro_month: "price_1U0dw1CKkCLMrYWYUkFlGyHA", // BD Pro — US$19/month
+    bd_pro_year: "price_1U0yBTCKkCLMrYWYDXo7NRwV", // BD Pro — US$180/year
+    bd_chatbot_month: "price_1U0yHZCKkCLMrYWYR4KtKTSQ", // Chatbot — US$15/month
+    bd_chatbot_year: "price_1U0yIGCKkCLMrYWYrE2FzOLt", // Chatbot — US$144/year
+  },
 }
 
 /**
@@ -58,8 +74,8 @@ export function localeToRegion(locale) {
 /**
  * Currency presentation for a pricing region.
  *
- * br bills in BRL; latam and intl bill in USD. USD is formatted en-US ("$19.00")
- * and BRL pt-BR ("R$ 47,00").
+ * br bills in BRL; latam and intl bill in USD. USD is formatted en-US ("$19.00") and BRL pt-BR
+ * ("R$ 47,00").
  *
  * @param {"br"|"latam"|"intl"} region
  * @returns {{code: string, locale: string, symbol: string}}
@@ -78,8 +94,8 @@ export function regionCurrency(region) {
 /**
  * Format a numeric amount in the currency of a pricing region.
  *
- * Returns undefined for a nullish amount, preserving the `amount?.toLocaleString(...)`
- * semantics of the call sites this replaces (which render nothing until the amount loads).
+ * Returns undefined for a nullish amount, preserving the `amount?.toLocaleString(...)` semantics of
+ * the call sites this replaces (which render nothing until the amount loads).
  *
  * @param {number|undefined|null} amount
  * @param {"br"|"latam"|"intl"} region
@@ -96,68 +112,54 @@ export function formatCurrency(amount, region, { minimumFractionDigits = 2 } = {
   })
 }
 
-function priceIds() {
+/**
+ * Resolve the pinned price ids for a region, applying any environment override.
+ *
+ * NEXT_PUBLIC_STRIPE_PRICE_IDS, when set, is a JSON object shaped like DEFAULT_PRICE_IDS
+ * (region → plan key → id). Only the given region's entries override; the rest fall back to the
+ * defaults above.
+ *
+ * @param {"br"|"latam"|"intl"} region
+ * @returns {Record<string, string>} plan key → Stripe price id for this region.
+ */
+function priceIds(region) {
   let overrides = {}
   try {
     overrides = JSON.parse(process.env.NEXT_PUBLIC_STRIPE_PRICE_IDS || "{}")
   } catch (e) {
     console.error("Invalid NEXT_PUBLIC_STRIPE_PRICE_IDS JSON; ignoring it.", e)
   }
-  return { ...DEFAULT_PRICE_IDS, ...overrides }
+  return { ...DEFAULT_PRICE_IDS[region], ...(overrides[region] || {}) }
 }
 
 /**
- * Resolve the plan nodes the site sells from the getPlans edges.
+ * Resolve the plan nodes the site sells from the getPlans edges, by exact Stripe price id.
  *
- * Each plan is anchored to its BRL price by exact Stripe price id. For a non-BR region, the
- * anchor is swapped for the sibling price that carries the matching `region` tag and the same
- * product (`productSlug`) and `interval`. When no such sibling exists (or the region is br), the
- * BRL anchor is shown. This keeps id-based selection as the source of truth while adding the
- * currency dimension, and never shows a price for the wrong product or interval.
+ * Each plan is matched to the pinned id for the given region. No inference from amount, product, or
+ * interval, and no cross-region fallback: if a region's id is not among the active prices returned
+ * by getPlans, that plan resolves to undefined (and a warning is logged).
  *
  * @param {Array<{node: object}>} edges - getPlans result data (array of { node }).
  * @param {"br"|"latam"|"intl"} [region="br"] - pricing region for the current domain.
- * @returns {Record<string, object|undefined>} plan-key -> price node (undefined if the
- *   configured id isn't among the active prices returned by getPlans).
+ * @returns {Record<string, object|undefined>} plan key → price node (undefined if the pinned id
+ *   isn't among the active prices returned by getPlans).
  */
 export function selectPlans(edges = [], region = DEFAULT_REGION) {
-  const ids = priceIds()
+  const ids = priceIds(region)
   const plans = {}
 
   for (const key of PLAN_KEYS) {
     const wantedId = ids[key]
-    const anchor = edges.find(({ node }) => node.stripePriceId === wantedId)
+    const match = edges.find(({ node }) => node.stripePriceId === wantedId)
 
-    if (!anchor) {
+    if (!match) {
       console.warn(
-        `Stripe price "${key}" (${wantedId}) not found among active prices from getPlans — ` +
-          "check the id and that the price is active."
-      )
-      plans[key] = undefined
-      continue
-    }
-
-    if (region === DEFAULT_REGION) {
-      plans[key] = anchor.node
-      continue
-    }
-
-    // Swap to the regional sibling: same product and interval, tagged for this region.
-    const sibling = edges.find(
-      ({ node }) =>
-        node.region === region &&
-        node.productSlug === anchor.node.productSlug &&
-        node.interval === anchor.node.interval
-    )
-
-    if (!sibling) {
-      console.warn(
-        `No "${region}" price for plan "${key}" (${anchor.node.productSlug}/${anchor.node.interval}); ` +
-          "showing the BRL price. Add the regional price in Stripe with the matching `region` tag."
+        `Stripe price "${key}" for region "${region}" (${wantedId}) not found among active prices ` +
+          "from getPlans — check the id and that the price is active."
       )
     }
 
-    plans[key] = (sibling ?? anchor).node
+    plans[key] = match?.node
   }
 
   return plans

--- a/next/pages/api/stripe/getPlans.js
+++ b/next/pages/api/stripe/getPlans.js
@@ -19,7 +19,6 @@ async function getPlans() {
                 productName
                 productSlug
                 interval
-                region
                 isActive
               }
             }

--- a/next/pages/prices.js
+++ b/next/pages/prices.js
@@ -599,7 +599,7 @@ export function SectionPrice({
                 plans?.[`bd_chatbot_${toggleAnual ? "year" : "month"}`]?.amount ??
                 (toggleAnual ? 326 : 30)
               }
-              region={plans?.[`bd_chatbot_${toggleAnual ? "year" : "month"}`]?.region}
+              region={plans?.[`bd_chatbot_${toggleAnual ? "year" : "month"}`] ? localeToRegion(locale) : "br"}
               anualPlan={toggleAnual}
               textResource={t("allFeaturesPlus", { plan: t("plans.free.title") })}
               resources={t("plans.chatbot.features", { returnObjects: true }).map(
@@ -638,7 +638,7 @@ export function SectionPrice({
             price={
               plans?.[`bd_pro_${toggleAnual ? "year" : "month"}`]?.amount || 444
             }
-            region={plans?.[`bd_pro_${toggleAnual ? "year" : "month"}`]?.region}
+            region={plans?.[`bd_pro_${toggleAnual ? "year" : "month"}`] ? localeToRegion(locale) : "br"}
             anualPlan={toggleAnual}
             textResource={t("allFeaturesPlus", { plan: t("plans.free.title") })}
             resources={t("plans.pro.features", { returnObjects: true }).map(


### PR DESCRIPTION
## What

Replaces the region-metadata price selection (merged earlier) with an explicit, pinned map of all 12 Stripe price ids — 4 plans × `br`/`latam`/`intl`. Selection is now purely **id-based and deterministic**: a new, edited, or mis-tagged price in Stripe is ignored until its id is added here and the site is redeployed. Nothing is inferred from `region`, `productSlug`, `interval`, or amount.

This removes the drift risk raised in review: BD Pro has extra active seat-tier prices (R$300–500/mo) on the same product, and metadata matching could have surfaced the wrong one. Id-based selection can't.

## Only the selection is pinned

The displayed **amount still comes live from the `getPlans` GraphQL query** — a price change in Stripe reflects on the site automatically. Only *adding or swapping which price is sold* needs a code change + deploy. That's the intended trade.

## Changes

- **`stripePlans.js`**: `DEFAULT_PRICE_IDS` is now `region → plan → id` (all 12 ids); `selectPlans(edges, region)` matches by exact `stripePriceId` only — no cross-region fallback; `NEXT_PUBLIC_STRIPE_PRICE_IDS` override is region-keyed to match.
- **`getPlans` API**: drop the now-unused `region` field from the query.
- **`prices.js` / `PlansAndPayment.js`**: currency follows the domain locale (`localeToRegion`) rather than a node's `region` tag; cards fall back to BRL formatting while the real price is loading or if a pinned id is missing.

## Backend is intentionally left as-is

The backend arbitrage webhook stays metadata-based. It **fails safe** — never blocks checkout, and at worst skips the currency re-correction on a domain switch — so it needs no hardcoded ids and no second copy of the map to maintain.

## Tests

Standalone harness, 15/15: exact-id selection per region, **stray seat-tier and mis-tagged prices ignored**, missing-id → undefined (no fallback), region-keyed env override, BRL/USD currency formatting. (No jest in the repo.)

## The 12-id map (for review)

| plan | br | latam (US$) | intl (US$) |
|---|---|---|---|
| bd_pro month | R$47 `…cxJtHMMa` | $12 `…2piPpKCg` | $19 `…UkFlGyHA` |
| bd_pro year | R$444 `…xV3xodMC` | $115 `…sVrOB3i5` | $180 `…DXo7NRwV` |
| chatbot month | R$30 `…FgOfi2cc` | $8 `…j2DSeGa8` | $15 `…R4KtKTSQ` |
| chatbot year | R$326 `…XQlflpIn` | $77 `…Os7xvfpL` | $144 `…rE2FzOLt` |
