### PR TITLE
fix(chatbot): localize chatbot tab title per domain, drop "LP" prefix

### DIFF
--- a/next/pages/chatbot.js
+++ b/next/pages/chatbot.js
@@ -283,15 +283,15 @@ function ChatbotContent() {
   return (
     <HStack width="100%" minHeight="100dvh" spacing={0} align="stretch">
       <Head>
-        <title>Chatbot - Basedosdados</title>
+        <title>{t("head.pageTitle")}</title>
         <meta
           property="og:title"
-          content="Chatbot - Basedosdados"
+          content={t("head.pageTitle")}
           key="ogtitle"
         />
         <meta
           property="og:description"
-          content="Chatbot - Basedosdados"
+          content={t("head.pageTitle")}
           key="ogdesc"
         />
       </Head>

--- a/next/public/locales/en/chatbot.json
+++ b/next/public/locales/en/chatbot.json
@@ -1,7 +1,7 @@
 {
   "head": {
-    "pageTitle": "Chatbot LP - Data Basis",
-    "metaTitle": "Chatbot LP - Data Basis"
+    "pageTitle": "Chatbot - Data Basis",
+    "metaTitle": "Chatbot - Data Basis"
   },
   "hero": {
     "title": "Talk to a large collection of public data",

--- a/next/public/locales/es/chatbot.json
+++ b/next/public/locales/es/chatbot.json
@@ -1,7 +1,7 @@
 {
   "head": {
-    "pageTitle": "Chatbot LP - Base de los Datos",
-    "metaTitle": "Chatbot LP - Base de los Datos"
+    "pageTitle": "Chatbot - Base de los Datos",
+    "metaTitle": "Chatbot - Base de los Datos"
   },
   "hero": {
     "title": "Conversa con un gran acervo de datos públicos",

--- a/next/public/locales/pt/chatbot.json
+++ b/next/public/locales/pt/chatbot.json
@@ -1,7 +1,7 @@
 {
   "head": {
-    "pageTitle": "Chatbot LP - Base dos Dados",
-    "metaTitle": "Chatbot LP - Base dos Dados"
+    "pageTitle": "Chatbot - Base dos Dados",
+    "metaTitle": "Chatbot - Base dos Dados"
   },
   "hero": {
     "title": "Converse com o maior acervo de dados públicos do Brasil",


### PR DESCRIPTION
## What

Fixes the chatbot tab title, which was hardcoded and non-localized.

- The app page (`pages/chatbot.js`) showed `Chatbot - Basedosdados` on every domain.
- The landing page (`pages/chatbot-lp.js`) showed `Chatbot LP - <brand>`.

Both now render **`Chatbot - <brand>`**, localized per domain:

| locale | title |
|---|---|
| en (data-basis.org) | Chatbot - Data Basis |
| pt (basedosdados.org) | Chatbot - Base dos Dados |
| es (basedelosdatos.org) | Chatbot - Base de los Datos |

## Changes

- `public/locales/{en,pt,es}/chatbot.json`: `head.pageTitle` / `head.metaTitle` change from `Chatbot LP - <brand>` to `Chatbot - <brand>`.
- `pages/chatbot.js`: render `t("head.pageTitle")` in the `<Head>` (title + og:title + og:description) instead of the literal `Chatbot - Basedosdados`.
- `pages/chatbot-lp.js`: no code change — it already reads `head.pageTitle` / `head.metaTitle`, so its title and og:title pick up the new value.
