### PR TITLE
fix(prices): use interval-aware fallback for the DB Pro card

### DIFF
--- a/next/pages/prices.js
+++ b/next/pages/prices.js
@@ -636,7 +636,8 @@ export function SectionPrice({
             title={t("plans.pro.title")}
             subTitle={t("plans.pro.subtitle")}
             price={
-              plans?.[`bd_pro_${toggleAnual ? "year" : "month"}`]?.amount || 444
+              plans?.[`bd_pro_${toggleAnual ? "year" : "month"}`]?.amount ||
+              (toggleAnual ? 444 : 47)
             }
             region={plans?.[`bd_pro_${toggleAnual ? "year" : "month"}`] ? localeToRegion(locale) : "br"}
             anualPlan={toggleAnual}


### PR DESCRIPTION
## What

The DB Pro pricing card fell back to a hardcoded `444` (the annual amount) for **both** the monthly and annual toggle. So whenever the plan doesn't resolve from `getPlans`, the monthly view showed **"R$ 444/month"** instead of **"R$ 47/month"**. The Chatbot card already handled this correctly (`toggleAnual ? 326 : 30`); DB Pro didn't.

```diff
- plans?.[`bd_pro_${toggleAnual ? "year" : "month"}`]?.amount || 444
+ plans?.[`bd_pro_${toggleAnual ? "year" : "month"}`]?.amount ||
+ (toggleAnual ? 444 : 47)
```

## When it shows

The fallback runs whenever a plan can't be resolved from `getPlans`:
- On the international domains against **staging's test-mode Stripe**, where the pinned USD price ids aren't present (so DB Pro falls back).
- Any time `getPlans` is unavailable — notably if the id-based site is deployed somewhere the backend doesn't yet expose `stripePriceId` (#1044).

Not a prod-data problem: when the pinned ids resolve, the real amount from `getPlans` is shown and no fallback runs. This just makes the degraded state correct.
