### PR TITLE
feat(about-us): show only active team roles, hide inactive members

### DIFF
--- a/next/pages/about-us.js
+++ b/next/pages/about-us.js
@@ -165,6 +165,27 @@ function getTeamScore(slug) {
   }
 }
 
+// A career is "active" while it has no end date. A person is shown only if
+// they hold at least one active role, and only their active roles are listed.
+function isActiveCareer(careerNode) {
+  return !careerNode.endAt
+}
+
+function hasActiveRole(node) {
+  const careers = node?.careers?.edges || []
+  return careers.some((edge) => edge.node.role && isActiveCareer(edge.node))
+}
+
+// True when the person holds an active (not ended) career in the given team.
+// Used by the team filter so a person whose only tie to a team is an ended
+// role is not listed under that team.
+function hasActiveRoleInTeam(node, teamSlug) {
+  const careers = node?.careers?.edges || []
+  return careers.some(
+    (edge) => isActiveCareer(edge.node) && edge.node.team?.slug === teamSlug
+  )
+}
+
 const TeamBox = ({
   index,
   name,
@@ -183,6 +204,7 @@ const TeamBox = ({
   const role = () => {
     const roles = []
     careers.map((elm) => {
+      if (!isActiveCareer(elm.node)) return
       const roleData = elm.node.role
       if (!roleData) return
       const roleName = roleData[`name${capitalize(locale)}`]
@@ -365,13 +387,13 @@ export default function AboutUs() {
     const sortPeopleArray = array
 
     function compareByRole(a, b) {
-      const rolesA = a.node.careers.edges.map(edge => {
+      const rolesA = a.node.careers.edges.filter(edge => isActiveCareer(edge.node)).map(edge => {
         const roleData = edge.node.role
         if (!roleData) return ''
         return roleData.slug || ''
       }).filter(Boolean)
 
-      const rolesB = b.node.careers.edges.map(edge => {
+      const rolesB = b.node.careers.edges.filter(edge => isActiveCareer(edge.node)).map(edge => {
         const roleData = edge.node.role
         if (!roleData) return ''
         return roleData.slug || ''
@@ -406,7 +428,9 @@ export default function AboutUs() {
       })
     }
 
-    return removeDuplicates(data).filter(obj => obj.node.firstName !== "API User" && obj.node.firstName !== "Staging")
+    return removeDuplicates(data)
+      .filter(obj => obj.node.firstName !== "API User" && obj.node.firstName !== "Staging")
+      .filter(obj => hasActiveRole(obj.node))
   }
 
   const keyIcon = (url) => {
@@ -440,7 +464,8 @@ export default function AboutUs() {
         return setPeople(allPeople)
       }
       setIsLoading(true)
-      setPeople(sortPeople(result))
+      const activeInTeam = result.filter((obj) => hasActiveRoleInTeam(obj.node, elm))
+      setPeople(sortPeople(activeInTeam))
     }
   }
 


### PR DESCRIPTION
## What

On `/about-us`, only **active** team roles are shown. A career counts as active only when it has no end date (`endAt`).

- Role display lists only active roles (ended roles are hidden).
- People with no active role are removed from the team list.
- Sorting ranks people by their active roles only.
- Clicking a team filter lists only people with an **active** career in that team.

## Why

The page showed outdated roles from ended careers — e.g. Ricardo Dahis displayed as "Líder de Plataforma" although that career ended 2025-03-12.

## Verification (against the production backend)

- **Ricardo Dahis**: ended "Líder de Plataforma" hidden; still shown with his active roles (Associado, Presidente do Conselho Administrativo, Co-fundador).
- **Gabriel Pisa**: dropped (his only roles are ended).
- **Team roster**: 25 of 27 accounts shown (the other is the API/Staging service account).
- **"Plataforma" filter**: Ricardo and Gabriel Pisa (ended platform careers) excluded; the 7 active members kept — including Laura Amaral, the current active Platform Leader.

Single-file change in `next/pages/about-us.js`; production build compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
