### PR TITLE
Fix: Chatbot auth httpOnly - Staging

### DIFF
--- a/next/hooks/useChatbot.js
+++ b/next/hooks/useChatbot.js
@@ -14,6 +14,14 @@ const TOOL_STREAM_FRAME_INTERVAL_MS = 1000 / 24
 const TOOL_STREAM_MIN_CHARS_PER_FRAME = 20
 const TOOL_STREAM_DECAY_DIVISOR = 20
 
+function isAuthFailure(errorOrStatus) {
+  const status =
+    typeof errorOrStatus === 'number'
+      ? errorOrStatus
+      : errorOrStatus?.response?.status
+  return status === 401 || status === 403
+}
+
 function messageSortTime(createdAt) {
   if (createdAt == null) return null
   const t = new Date(createdAt).getTime()
@@ -149,10 +157,14 @@ export default function useChatbot(initialThreadId = null, options = {}) {
   const pendingStreamsRef = useRef([])
   const newChatSendingRef = useRef(false)
 
+  const { getAccessToken, invalidateSessionCache } = useChatbotAuth()
+  const { refetch: refetchThreads } = useChatbotContext()
+
   const handleAuthError = useCallback(async () => {
+    invalidateSessionCache()
     await clearClientSession()
     router.push('/user/login')
-  }, [router])
+  }, [invalidateSessionCache, router])
 
   useEffect(() => {
     if (initialThreadId === undefined) return
@@ -193,9 +205,6 @@ export default function useChatbot(initialThreadId = null, options = {}) {
   const toolStreamRafRef = useRef(null)
   const toolStreamPumpRef = useRef(null)
   const toolStreamLastFlushRef = useRef(0)
-
-  const { getAccessToken } = useChatbotAuth()
-  const { refetch: refetchThreads } = useChatbotContext()
 
   const cancelToolStream = useCallback(targetThreadId => {
     const q = toolStreamQueueRef.current
@@ -303,6 +312,9 @@ export default function useChatbot(initialThreadId = null, options = {}) {
         lastFetchedThreadIdRef.current = id
       } catch (err) {
         console.error('Failed to fetch messages:', err)
+        if (isAuthFailure(err)) {
+          handleAuthError()
+        }
       } finally {
         if (!silent) {
           pendingHistoryLoadsRef.current = Math.max(0, pendingHistoryLoadsRef.current - 1)
@@ -395,6 +407,9 @@ export default function useChatbot(initialThreadId = null, options = {}) {
         return newThreadId
       } catch (err) {
         console.error('Failed to create thread:', err)
+        if (isAuthFailure(err)) {
+          handleAuthError()
+        }
         throw err
       }
     },
@@ -435,6 +450,9 @@ export default function useChatbot(initialThreadId = null, options = {}) {
         return true
       } catch (err) {
         console.error('Failed to send feedback:', err)
+        if (isAuthFailure(err)) {
+          handleAuthError()
+        }
         return false
       }
     },
@@ -451,11 +469,17 @@ export default function useChatbot(initialThreadId = null, options = {}) {
         )
       }
 
-      const response = await axios.post('/api/chatbot/exports', null, {
-        params: { messageId, queryRef, format }
-      })
-
-      return response.data?.url ?? null
+      try {
+        const response = await axios.post('/api/chatbot/exports', null, {
+          params: { messageId, queryRef, format }
+        })
+        return response.data?.url ?? null
+      } catch (err) {
+        if (isAuthFailure(err)) {
+          handleAuthError()
+        }
+        throw err
+      }
     },
     [getAccessToken, handleAuthError]
   )
@@ -769,6 +793,10 @@ export default function useChatbot(initialThreadId = null, options = {}) {
         })
 
         if (!response.ok) {
+          if (isAuthFailure(response.status)) {
+            handleAuthError()
+            return
+          }
           let errorBody = null
           try {
             errorBody = await response.clone().json()

--- a/next/hooks/useChatbotAuth.js
+++ b/next/hooks/useChatbotAuth.js
@@ -2,6 +2,8 @@ import { useCallback } from 'react';
 import axios from 'axios';
 import { useQueryClient } from '@tanstack/react-query';
 
+const ValidateTokenStaleTimeMs = 60 * 1000;
+
 export default function useChatbotAuth() {
   const queryClient = useQueryClient();
 
@@ -13,7 +15,7 @@ export default function useChatbotAuth() {
           const response = await axios.get('/api/user/validateToken');
           return response.data.success;
         },
-        staleTime: 5 * 60 * 1000,
+        staleTime: ValidateTokenStaleTimeMs,
       });
       return data;
     } catch (e) {
@@ -32,23 +34,35 @@ export default function useChatbotAuth() {
     }
   }, []);
 
+  const invalidateSessionCache = useCallback(() => {
+    queryClient.removeQueries({ queryKey: ['validateToken'] });
+    queryClient.removeQueries({ queryKey: ['chatbotThreads'] });
+  }, [queryClient]);
+
   const ensureSession = useCallback(async () => {
     const isValid = await validateToken();
     if (isValid) return true;
 
     const refreshed = await refreshToken();
     if (refreshed) {
-      queryClient.removeQueries({ queryKey: ['validateToken'] });
+      invalidateSessionCache();
       return validateToken();
     }
 
+    invalidateSessionCache();
     return false;
-  }, [validateToken, refreshToken, queryClient]);
+  }, [validateToken, refreshToken, invalidateSessionCache]);
 
   const getAccessToken = useCallback(async () => {
     const ok = await ensureSession();
     return ok ? true : null;
   }, [ensureSession]);
 
-  return { getAccessToken, ensureSession, validateToken, refreshToken };
+  return {
+    getAccessToken,
+    ensureSession,
+    validateToken,
+    refreshToken,
+    invalidateSessionCache,
+  };
 }

--- a/next/hooks/useThreads.js
+++ b/next/hooks/useThreads.js
@@ -2,8 +2,13 @@ import axios from 'axios';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import useChatbotAuth from './useChatbotAuth';
 
+function isAuthFailure(error) {
+  const status = error?.response?.status;
+  return status === 401 || status === 403;
+}
+
 export default function useThreads() {
-  const { getAccessToken } = useChatbotAuth();
+  const { getAccessToken, invalidateSessionCache } = useChatbotAuth();
   const queryClient = useQueryClient();
 
   const {
@@ -16,10 +21,18 @@ export default function useThreads() {
     queryFn: async () => {
       const accessToken = await getAccessToken();
       if (!accessToken) {
+        invalidateSessionCache();
         throw new Error('Sessão não autorizada');
       }
-      const { data } = await axios.get('/api/chatbot/threads');
-      return data;
+      try {
+        const { data } = await axios.get('/api/chatbot/threads');
+        return data;
+      } catch (err) {
+        if (isAuthFailure(err)) {
+          invalidateSessionCache();
+        }
+        throw err;
+      }
     },
     staleTime: 1000 * 60 * 5,
   });
@@ -28,11 +41,19 @@ export default function useThreads() {
     mutationFn: async (threadId) => {
       const accessToken = await getAccessToken();
       if (!accessToken) {
+        invalidateSessionCache();
         throw new Error('Sessão não autorizada');
       }
-      await axios.delete(`/api/chatbot/threads`, {
-        params: { id: threadId },
-      });
+      try {
+        await axios.delete(`/api/chatbot/threads`, {
+          params: { id: threadId },
+        });
+      } catch (err) {
+        if (isAuthFailure(err)) {
+          invalidateSessionCache();
+        }
+        throw err;
+      }
     },
     onSuccess: () => {
       queryClient.invalidateQueries(['chatbotThreads']);

--- a/next/lib/requireChatbotAuth.js
+++ b/next/lib/requireChatbotAuth.js
@@ -1,0 +1,81 @@
+import { request, gql } from 'graphql-request'
+import { getTokenFromRequest } from './authCookie'
+
+const ApiUrl = `${process.env.NEXT_PUBLIC_API_URL}/api/v1/graphql`
+
+const VerifyTokenMutation = gql`
+  mutation verifyToken($token: String!) {
+    verifyToken(token: $token) {
+      payload
+    }
+  }
+`
+
+function parsePayload(raw) {
+  let payload = raw
+  if (typeof payload === 'string') {
+    try {
+      payload = JSON.parse(payload)
+    } catch {
+      payload = {}
+    }
+  }
+  return payload && typeof payload === 'object' ? payload : {}
+}
+
+export async function verifySessionToken(token) {
+  if (!token) {
+    return { valid: false, has_chatbot_access: false, payload: null }
+  }
+
+  try {
+    const result = await request(ApiUrl, VerifyTokenMutation, { token })
+    if (!result?.verifyToken) {
+      return { valid: false, has_chatbot_access: false, payload: null }
+    }
+
+    const payload = parsePayload(result.verifyToken.payload)
+    return {
+      valid: true,
+      has_chatbot_access: payload?.has_chatbot_access === true,
+      payload,
+    }
+  } catch (error) {
+    console.error('verifySessionToken error:', error)
+    return { valid: false, has_chatbot_access: false, payload: null }
+  }
+}
+
+export async function requireChatbotAuth(req) {
+  const token = getTokenFromRequest(req)
+  if (!token) {
+    return {
+      ok: false,
+      status: 401,
+      error: 'Missing authentication token',
+    }
+  }
+
+  const verified = await verifySessionToken(token)
+  if (!verified.valid) {
+    return {
+      ok: false,
+      status: 401,
+      error: 'Invalid or expired token',
+    }
+  }
+
+  if (!verified.has_chatbot_access) {
+    return {
+      ok: false,
+      status: 403,
+      error: 'Chatbot access required',
+    }
+  }
+
+  return {
+    ok: true,
+    authHeader: `Bearer ${token}`,
+    payload: verified.payload,
+  }
+}

--- a/next/pages/api/chatbot/exports.js
+++ b/next/pages/api/chatbot/exports.js
@@ -1,11 +1,11 @@
 import axios from 'axios'
-import { getAuthorizationHeader } from '../../../lib/authCookie'
+import { requireChatbotAuth } from '../../../lib/requireChatbotAuth'
 
 const API_URL = process.env.CHATBOT_URL
 
 export default async function handler(req, res) {
   const { method } = req
-  const authHeader = getAuthorizationHeader(req)
+  const auth = await requireChatbotAuth(req)
   const rawMessageId = req.query.messageId
   const messageId = Array.isArray(rawMessageId) ? rawMessageId[0] : rawMessageId
   const rawQueryRef = req.query.queryRef
@@ -17,8 +17,8 @@ export default async function handler(req, res) {
     return res.status(503).json({ error: 'Chatbot API URL is not configured' })
   }
 
-  if (!authHeader) {
-    return res.status(401).json({ error: 'Missing authentication token' })
+  if (!auth.ok) {
+    return res.status(auth.status).json({ error: auth.error })
   }
 
   if (!messageId || typeof messageId !== 'string') {
@@ -28,6 +28,8 @@ export default async function handler(req, res) {
   if (!queryRef || typeof queryRef !== 'string') {
     return res.status(400).json({ error: 'Missing queryRef parameter' })
   }
+
+  const authHeader = auth.authHeader
 
   try {
     if (method === 'POST') {

--- a/next/pages/api/chatbot/feedback.js
+++ b/next/pages/api/chatbot/feedback.js
@@ -1,11 +1,11 @@
 import axios from 'axios'
-import { getAuthorizationHeader } from '../../../lib/authCookie'
+import { requireChatbotAuth } from '../../../lib/requireChatbotAuth'
 
 const API_URL = process.env.CHATBOT_URL
 
 export default async function handler(req, res) {
   const { method } = req
-  const authHeader = getAuthorizationHeader(req)
+  const auth = await requireChatbotAuth(req)
   const rawMessageId = req.query.messageId
   const messageId = Array.isArray(rawMessageId) ? rawMessageId[0] : rawMessageId
 
@@ -13,13 +13,15 @@ export default async function handler(req, res) {
     return res.status(503).json({ error: 'Chatbot API URL is not configured' })
   }
 
-  if (!authHeader) {
-    return res.status(401).json({ error: 'Missing authentication token' })
+  if (!auth.ok) {
+    return res.status(auth.status).json({ error: auth.error })
   }
 
   if (!messageId || typeof messageId !== 'string') {
     return res.status(400).json({ error: 'Missing messageId parameter' })
   }
+
+  const authHeader = auth.authHeader
 
   try {
     if (method === 'PUT') {

--- a/next/pages/api/chatbot/messages.js
+++ b/next/pages/api/chatbot/messages.js
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import { getAuthorizationHeader } from '../../../lib/authCookie'
+import { requireChatbotAuth } from '../../../lib/requireChatbotAuth'
 
 const API_URL = process.env.CHATBOT_URL
 
@@ -14,12 +14,14 @@ function bufferStreamToString(stream) {
 
 export default async function handler(req, res) {
   const { method } = req
-  const authHeader = getAuthorizationHeader(req)
+  const auth = await requireChatbotAuth(req)
   const { threadId } = req.query
 
-  if (!authHeader) {
-    return res.status(401).json({ error: 'Missing authentication token' })
+  if (!auth.ok) {
+    return res.status(auth.status).json({ error: auth.error })
   }
+
+  const authHeader = auth.authHeader
 
   if (!threadId) {
     return res.status(400).json({ error: 'Missing threadId parameter' })

--- a/next/pages/api/chatbot/threads.js
+++ b/next/pages/api/chatbot/threads.js
@@ -1,15 +1,17 @@
 import axios from 'axios'
-import { getAuthorizationHeader } from '../../../lib/authCookie'
+import { requireChatbotAuth } from '../../../lib/requireChatbotAuth'
 
 const API_URL = process.env.CHATBOT_URL
 
 export default async function handler(req, res) {
   const { method } = req
-  const authHeader = getAuthorizationHeader(req)
+  const auth = await requireChatbotAuth(req)
 
-  if (!authHeader) {
-    return res.status(401).json({ error: 'Missing authentication token' })
+  if (!auth.ok) {
+    return res.status(auth.status).json({ error: auth.error })
   }
+
+  const authHeader = auth.authHeader
 
   try {
     if (method === 'GET') {

--- a/next/pages/api/user/validateToken.js
+++ b/next/pages/api/user/validateToken.js
@@ -1,25 +1,5 @@
-import { request, gql } from 'graphql-request'
 import { getTokenFromRequest } from '../../../lib/authCookie'
-
-const API_URL = `${process.env.NEXT_PUBLIC_API_URL}/api/v1/graphql`
-
-const VERIFY_TOKEN = gql`
-  mutation verifyToken($token: String!) {
-    verifyToken(token: $token) {
-      payload
-    }
-  }
-`
-
-async function validateToken(token) {
-  try {
-    const response = await request(API_URL, VERIFY_TOKEN, { token })
-    return response
-  } catch (error) {
-    console.error('validateToken error:', error)
-    return 'err'
-  }
-}
+import { verifySessionToken } from '../../../lib/requireChatbotAuth'
 
 export default async function handler(req, res) {
   if (req.method !== 'GET' && req.method !== 'POST') {
@@ -32,21 +12,13 @@ export default async function handler(req, res) {
     return res.status(401).json({ error: 'Missing authentication token', success: false })
   }
 
-  const result = await validateToken(token)
-
-  if (result.errors) return res.status(500).json({ error: result.errors, success: false })
-  if (result === 'err') return res.status(500).json({ error: 'err', success: false })
-  if (result.verifyToken === null) return res.status(500).json({ error: 'err', success: false })
-
-  let payload = result.verifyToken?.payload
-  if (typeof payload === 'string') {
-    try {
-      payload = JSON.parse(payload)
-    } catch {
-      payload = {}
-    }
+  const verified = await verifySessionToken(token)
+  if (!verified.valid) {
+    return res.status(401).json({ error: 'Invalid or expired token', success: false })
   }
-  const has_chatbot_access = payload?.has_chatbot_access === true
 
-  res.status(200).json({ success: true, has_chatbot_access })
+  res.status(200).json({
+    success: true,
+    has_chatbot_access: verified.has_chatbot_access,
+  })
 }


### PR DESCRIPTION
# Checklist de validação 
---

## Auth / sessão

- [x] Login e-mail/senha funciona
- [x] Cookie `token` está como **HttpOnly** (DevTools → Application → Cookies; não aparece em `document.cookie`)
- [x] Login Google funciona
- [x] Após login Google, `token` some da URL
- [x] Após login Google, cookie `token` está HttpOnly
- [x] Refresh da página mantém a sessão
- [x] Logout pelo Menu limpa a sessão
- [x] Logout pela Sidebar do chatbot limpa a sessão
- [x] Após logout, refresh não volta logado
- [x] Sessão inválida/expirada redireciona para login e limpa o cookie de verdade

---

## Chatbot

- [x] `/chatbot` sem login → redireciona para login
- [x] `/chatbot` logado sem acesso chatbot → vai para checkout/planos
- [x] `/chatbot` com acesso → entra normalmente
- [x] No Network, **não** há `validateToken?p=` / `btoa` / `Authorization: Bearer` saindo do browser
- [x] Listar threads funciona
- [x] Abrir conversa existente funciona
- [x] Enviar mensagem (stream) funciona
- [x] Enviar feedback funciona
- [x] Export CSV funciona
- [x] Novo chat funciona
- [x] Deletar thread funciona
- [x] `GET /api/chatbot/threads` sem cookie → **401**
- [x] Logado sem `has_chatbot_access`, `GET /api/chatbot/threads` → **403**

---

## Colaterais

- [x] Página `/user/[username]` carrega perfil logado
- [x] Upload de foto de perfil funciona
- [x] Dataset (fluxo admin/sudo, se aplicável) continua ok
- [x] `chatbot-lp` mostra estado de acesso coerente com a sessão

---

## Regressão rápida

- [x] Navegação geral logado (menu, preços, conta) ok
- [x] Após logout, APIs do chatbot continuam retornando 401

---

## Sinais de problema 

- [ ] Cookie `token` legível no console (`document.cookie`) → httpOnly falhou
- [ ] Requests com `validateToken?p=` ou `Bearer eyJ...` no browser → vazamento voltou
- [ ] Logout “não desloga” de verdade → clearSession/`path` quebrado
- [ ] Chatbot abre a UI mas APIs 401/403 → cookie não está indo (`SameSite`/`Secure`)

