### PR TITLE
docs: correct CLAUDE.md Git Flow model (branch from main, same commits)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,33 +6,34 @@
 Canonical reference: https://github.com/basedosdados/backend/wiki/Boas-Pr%C3%A1ticas#segue-o-fluxo
 
 ### The environment branches — never commit or push directly
-- `main` — production (basedosdados.org).
+- `main` — production (basedosdados.org). Source of truth: resets flow *from* `main`.
 - `staging` — pre-production / QA.
-- `development` — integration / testing. First target for new work.
-
-These three are **parallel, independently maintained** branches, not a linear chain.
-Their histories have diverged, so you never merge one environment branch into another to
-move a feature — that would drag the whole environment forward. Each feature is promoted
-into each environment **selectively**, via its own PR carrying only that feature.
+- `development` — integration / testing.
 
 Note: the integration branch here is named `development` (full word), not `dev`.
 
-### Feature workflow — promote the feature, not the environment
-1. Cut your feature branch off `development` (the branch you integrate and test in first).
-   Name it by intent: `feat/…`, `fix/…`, `chore/…`, `docs/…`, `refactor/…`.
-   Keep one logical change per branch, with tidy commits — you will cherry-pick them.
-2. Open a PR from that branch into `development`.
-3. To promote the same feature to `staging`, cut a new branch off `staging` and
-   cherry-pick only this feature's commit(s) onto it, then open a PR into `staging`.
-4. To promote to `main`, repeat: cut a branch off `main`, cherry-pick the same commit(s),
-   open a PR into `main`.
-5. Result: one clean PR per environment, each carrying only this feature.
+### How work flows
+Cut every feature off `main`, then merge the **same commits** into `development`, `staging`,
+and `main` — one PR per target. The three branches are meant to hold identical history for
+each feature. They drift apart as changes land at different times, so the team periodically
+**resets `staging` and `development` back to `main`** to re-align them. Because resets flow
+from `main`, a change must reach `main` to survive — anything living only on `staging` or
+`development` is discarded at the next reset.
+
+### Feature workflow — same commits into every branch
+1. Cut your feature branch off `main` (ideally just after a reset, when the branches are aligned).
+   Name it by intent: `feat/…`, `fix/…`, `chore/…`, `docs/…`, `refactor/…`. One logical change per branch.
+2. Open a PR from that branch into each target branch: `development`, `staging`, and `main`.
+3. Merge with a **merge commit or fast-forward — never squash, never cherry-pick** — so the
+   identical commit SHA lands on all three branches.
+4. If a target has drifted far from `main`, realign it via the periodic reset rather than
+   forcing a noisy cross-branch merge.
 
 ### Rules for agents working in this repo
-- Never commit or push to `main`, `staging`, or `development` directly.
-- Move a feature between environments by cherry-picking it onto a branch cut off the
-  target — never by merging `development → staging` or `staging → main`.
-- Each promotion branch is cut off its own target, so the PR diff is only this feature.
-- One logical change per branch; one PR at a time per target; keep commits clean for cherry-picking.
+- Never commit or push to `main`, `staging`, or `development` directly — always a feature branch + PR.
+- Cut features off `main` so the same commit can enter every environment.
+- Merge as merge-commit/FF, **never squash** (squash mints a new SHA per branch) and
+  **never cherry-pick** (also a new SHA) — both break the "same commits everywhere" rule.
+- Never merge one environment branch into another to promote a feature.
 - Before committing, verify you are on a feature branch: `git branch --show-current`.
 - Do not push without explicit permission.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,30 +10,36 @@ Canonical reference: https://github.com/basedosdados/backend/wiki/Boas-Pr%C3%A1t
 - `staging` — pre-production / QA.
 - `development` — integration / testing.
 
-Note: the integration branch here is named `development` (full word), not `dev`.
-
 ### How work flows
-Cut every feature off `main`, then merge the **same commits** into `development`, `staging`,
-and `main` — one PR per target. The three branches are meant to hold identical history for
-each feature. They drift apart as changes land at different times, so the team periodically
-**resets `staging` and `development` back to `main`** to re-align them. Because resets flow
-from `main`, a change must reach `main` to survive — anything living only on `staging` or
-`development` is discarded at the next reset.
+Every feature starts from `main` and is promoted back into the other environments using
+**one branch and three PRs** — the same head branch is PR'd into `development`, `staging`, and
+`main`. Merging the same branch into each target puts the *same commit objects* into all
+three, so the feature's own commits share SHAs everywhere. Only the merge commits differ,
+which is expected and fine.
 
-### Feature workflow — same commits into every branch
-1. Cut your feature branch off `main` (ideally just after a reset, when the branches are aligned).
-   Name it by intent: `feat/…`, `fix/…`, `chore/…`, `docs/…`, `refactor/…`. One logical change per branch.
-2. Open a PR from that branch into each target branch: `development`, `staging`, and `main`.
-3. Merge with a **merge commit or fast-forward — never squash, never cherry-pick** — so the
-   identical commit SHA lands on all three branches.
-4. If a target has drifted far from `main`, realign it via the periodic reset rather than
-   forcing a noisy cross-branch merge.
+The environments still drift apart as those merge commits accumulate at different times, so
+the team **resets `staging` and `development` back to `main` roughly every two weeks**. Because
+resets flow *from* `main`, a change must reach `main` to survive — anything living only on
+`staging` or `development` is discarded at the next reset.
+
+### Feature workflow — one branch, three PRs
+1. Cut your feature branch off `main` — never off `staging` or `development`.
+   Name it by intent: `feat/…`, `fix/…`, `chore/…`, `docs/…`, `refactor/…`.
+   One logical change per branch.
+2. From that **same branch**, open three PRs: one into `development`, one into `staging`, one
+   into `main`. Do not cut a separate branch per target, and do not cherry-pick.
+3. Merge with a **merge commit or fast-forward — never squash**. A squash mints a new,
+   unrelated commit on each branch and breaks the shared history the resets rely on.
+4. Timing: a `main`-based branch merges cleanly into `development`/`staging` when those are
+   aligned with `main` — in practice, shortly after a reset. The longer since the last
+   reset, the more of `main`'s accumulated commits the PR will drag along. If a target has
+   drifted far, wait for the reset rather than forcing a noisy merge.
 
 ### Rules for agents working in this repo
 - Never commit or push to `main`, `staging`, or `development` directly — always a feature branch + PR.
-- Cut features off `main` so the same commit can enter every environment.
-- Merge as merge-commit/FF, **never squash** (squash mints a new SHA per branch) and
-  **never cherry-pick** (also a new SHA) — both break the "same commits everywhere" rule.
+- Always cut features off `main`, never off `staging` or `development`.
+- Use **one branch for all three PRs**. Never a branch-per-target, never cherry-pick.
+- **Never squash-merge.** Merge commit or fast-forward only.
 - Never merge one environment branch into another to promote a feature.
 - Before committing, verify you are on a feature branch: `git branch --show-current`.
 - Do not push without explicit permission.


### PR DESCRIPTION
Corrects the CLAUDE.md merged earlier, which described a cherry-pick / per-target-branch flow. That is **not** the team convention.

Corrected model: cut features off `main` and merge the **same commits** into \`development\`/\`staging\`/\`main\` — never squash, never cherry-pick — so identical commit SHAs land on every branch. The branches are kept aligned by the team's periodic reset of staging/development back to `main`.

Targets `main` (the source of truth); staging/development inherit the corrected file at the next reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)