### PR TITLE
Fix/chatbot auth http only

### DIFF
--- a/next/components/molecules/ImgCrop.js
+++ b/next/components/molecules/ImgCrop.js
@@ -19,9 +19,34 @@ import cookies from 'js-cookie';
 import { useTranslation } from "react-i18next";
 import { Button } from './uiUserPage';
 
-import updatePictureProfile from '../../pages/api/user/updatePictureProfile'
 import 'react-image-crop/dist/ReactCrop.css';
 import styles from "../../styles/imgCrop.module.css";
+
+async function fileToBase64(file) {
+  const buffer = await file.arrayBuffer()
+  const bytes = new Uint8Array(buffer)
+  let binary = ''
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i])
+  }
+  return btoa(binary)
+}
+
+async function updatePictureProfile(id, file) {
+  const fileBase64 = await fileToBase64(file)
+  const response = await fetch('/api/user/updatePictureProfile', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'same-origin',
+    body: JSON.stringify({
+      id,
+      fileBase64,
+      fileName: file.name,
+      contentType: file.type || 'image/jpeg',
+    }),
+  })
+  return { status: response.status, data: await response.json().catch(() => null) }
+}
 
 export default function CropImage ({
   isOpen,

--- a/next/components/molecules/Menu.js
+++ b/next/components/molecules/Menu.js
@@ -32,7 +32,7 @@ import { ControlledInputSimple } from "../atoms/ControlledInput";
 import Link from "../atoms/Link";
 import Button from "../atoms/Button";
 import HelpWidget from "../atoms/HelpWidget";
-import { triggerGAEvent, triggerGAEventWithData, hasBDProSubscription, hasChatbotSubscription, trackNavigateToChatbotLp } from "../../utils";
+import { triggerGAEvent, triggerGAEventWithData, hasBDProSubscription, hasChatbotSubscription, trackNavigateToChatbotLp, clearClientSession } from "../../utils";
 
 import LabelText from "../atoms/Text/LabelText";
 import BodyText from "../atoms/Text/BodyText";
@@ -471,9 +471,8 @@ function MenuDrawerUser({ userData, isOpen, onClose, isUserPro, haveInterprisePl
           _hover={{
             opacity: 0.7
           }}
-          onClick={() => {
-            cookies.remove('userBD', { path: '/' })
-            cookies.remove('token', { path: '/' })
+          onClick={async () => {
+            await clearClientSession()
             if(window.location.pathname.includes('/user/')) return window.location.href = "/"
             window.location.reload()
           }}
@@ -646,9 +645,8 @@ function MenuUser ({ userData, onOpen, onClose, isUserPro }) {
             gap="8px"
             padding="16px"
             _hover={{ backgroundColor: "transparent", opacity: "0.7" }}
-            onClick={() => {
-              cookies.remove('userBD', { path: '/' })
-              cookies.remove('token', { path: '/' })
+            onClick={async () => {
+              await clearClientSession()
               if(window.location.pathname.includes('/user/')) return window.location.href = "/"
               window.location.reload()
             }}

--- a/next/components/organisms/chatbot/Sidebar.js
+++ b/next/components/organisms/chatbot/Sidebar.js
@@ -7,8 +7,8 @@ import {
   HStack,
   useMediaQuery,
 } from '@chakra-ui/react'
-import cookies from 'js-cookie'
 import BDLogoImage from '../../../public/img/logos/bd_logo'
+import { clearClientSession } from '../../../utils'
 import SidebarIcon from '../../../public/img/icons/sidebarIcon'
 import CrossIcon from '../../../public/img/icons/crossIcon'
 import BodyText from '../../atoms/Text/BodyText'
@@ -28,9 +28,8 @@ function Sidebar({
 
   const isOpen = isMobile ? true : isExpanded
 
-  const handleLogout = useCallback(() => {
-    cookies.remove('userBD', { path: '/' })
-    cookies.remove('token', { path: '/' })
+  const handleLogout = useCallback(async () => {
+    await clearClientSession()
     if (typeof window === 'undefined') return
     if (window.location.pathname.includes('/user/')) {
       window.location.href = '/'

--- a/next/components/organisms/componentsUserPage/Account.js
+++ b/next/components/organisms/componentsUserPage/Account.js
@@ -14,7 +14,7 @@ import Link from "../../atoms/Link";
 import TitleText from "../../atoms/Text/TitleText";
 import CheckIcon from "../../../public/img/icons/checkIcon";
 import WarningIcon from "../../../public/img/icons/warningIcon";
-import { hasBDProSubscription } from "../../../utils";
+import { hasBDProSubscription, clearClientSession } from "../../../utils";
 
 import {
   LabelTextForm,
@@ -136,10 +136,9 @@ export default function Account({ userInfo }) {
     }
   }
 
-  function handleCloseSucessEraseAccount() {
+  async function handleCloseSucessEraseAccount() {
     setIsLoading(true)
-    cookies.remove('userBD', { path: '/' })
-    cookies.remove('token', { path: '/' })
+    await clearClientSession()
     sucessEraseModalAccount.onClose()
     return window.open("/", "_self")
   }

--- a/next/hooks/useChatbot.js
+++ b/next/hooks/useChatbot.js
@@ -14,6 +14,14 @@ const TOOL_STREAM_FRAME_INTERVAL_MS = 1000 / 24
 const TOOL_STREAM_MIN_CHARS_PER_FRAME = 20
 const TOOL_STREAM_DECAY_DIVISOR = 20
 
+function isAuthFailure(errorOrStatus) {
+  const status =
+    typeof errorOrStatus === 'number'
+      ? errorOrStatus
+      : errorOrStatus?.response?.status
+  return status === 401 || status === 403
+}
+
 function messageSortTime(createdAt) {
   if (createdAt == null) return null
   const t = new Date(createdAt).getTime()
@@ -149,10 +157,14 @@ export default function useChatbot(initialThreadId = null, options = {}) {
   const pendingStreamsRef = useRef([])
   const newChatSendingRef = useRef(false)
 
+  const { getAccessToken, invalidateSessionCache } = useChatbotAuth()
+  const { refetch: refetchThreads } = useChatbotContext()
+
   const handleAuthError = useCallback(async () => {
+    invalidateSessionCache()
     await clearClientSession()
     router.push('/user/login')
-  }, [router])
+  }, [invalidateSessionCache, router])
 
   useEffect(() => {
     if (initialThreadId === undefined) return
@@ -193,9 +205,6 @@ export default function useChatbot(initialThreadId = null, options = {}) {
   const toolStreamRafRef = useRef(null)
   const toolStreamPumpRef = useRef(null)
   const toolStreamLastFlushRef = useRef(0)
-
-  const { getAccessToken } = useChatbotAuth()
-  const { refetch: refetchThreads } = useChatbotContext()
 
   const cancelToolStream = useCallback(targetThreadId => {
     const q = toolStreamQueueRef.current
@@ -303,6 +312,9 @@ export default function useChatbot(initialThreadId = null, options = {}) {
         lastFetchedThreadIdRef.current = id
       } catch (err) {
         console.error('Failed to fetch messages:', err)
+        if (isAuthFailure(err)) {
+          handleAuthError()
+        }
       } finally {
         if (!silent) {
           pendingHistoryLoadsRef.current = Math.max(0, pendingHistoryLoadsRef.current - 1)
@@ -395,6 +407,9 @@ export default function useChatbot(initialThreadId = null, options = {}) {
         return newThreadId
       } catch (err) {
         console.error('Failed to create thread:', err)
+        if (isAuthFailure(err)) {
+          handleAuthError()
+        }
         throw err
       }
     },
@@ -435,6 +450,9 @@ export default function useChatbot(initialThreadId = null, options = {}) {
         return true
       } catch (err) {
         console.error('Failed to send feedback:', err)
+        if (isAuthFailure(err)) {
+          handleAuthError()
+        }
         return false
       }
     },
@@ -451,11 +469,17 @@ export default function useChatbot(initialThreadId = null, options = {}) {
         )
       }
 
-      const response = await axios.post('/api/chatbot/exports', null, {
-        params: { messageId, queryRef, format }
-      })
-
-      return response.data?.url ?? null
+      try {
+        const response = await axios.post('/api/chatbot/exports', null, {
+          params: { messageId, queryRef, format }
+        })
+        return response.data?.url ?? null
+      } catch (err) {
+        if (isAuthFailure(err)) {
+          handleAuthError()
+        }
+        throw err
+      }
     },
     [getAccessToken, handleAuthError]
   )
@@ -769,6 +793,10 @@ export default function useChatbot(initialThreadId = null, options = {}) {
         })
 
         if (!response.ok) {
+          if (isAuthFailure(response.status)) {
+            handleAuthError()
+            return
+          }
           let errorBody = null
           try {
             errorBody = await response.clone().json()

--- a/next/hooks/useChatbot.js
+++ b/next/hooks/useChatbot.js
@@ -1,9 +1,9 @@
 import axios from 'axios'
-import cookies from 'js-cookie'
 import { useRouter } from 'next/router'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { flushSync } from 'react-dom'
 import { useChatbotContext } from '../context/ChatbotContext'
+import { clearClientSession } from '../utils'
 import useChatbotAuth from './useChatbotAuth'
 
 const TYPEWRITER_FRAME_INTERVAL_MS = 1000 / 30
@@ -149,9 +149,8 @@ export default function useChatbot(initialThreadId = null, options = {}) {
   const pendingStreamsRef = useRef([])
   const newChatSendingRef = useRef(false)
 
-  const handleAuthError = useCallback(() => {
-    cookies.remove('token')
-    cookies.remove('userBD')
+  const handleAuthError = useCallback(async () => {
+    await clearClientSession()
     router.push('/user/login')
   }, [router])
 
@@ -250,10 +249,7 @@ export default function useChatbot(initialThreadId = null, options = {}) {
           return
         }
         const response = await axios.get('/api/chatbot/messages', {
-          params: { threadId: id, _ts: `${Date.now()}` },
-          headers: {
-            Authorization: `Bearer ${accessToken}`
-          }
+          params: { threadId: id, _ts: `${Date.now()}` }
         })
 
         if (navGen !== fetchSeqRef.current) {
@@ -387,10 +383,7 @@ export default function useChatbot(initialThreadId = null, options = {}) {
 
         const response = await axios.post(
           '/api/chatbot/threads',
-          { title },
-          {
-            headers: { Authorization: `Bearer ${accessToken}` }
-          }
+          { title }
         )
 
         const newThreadId = response.data.id
@@ -428,8 +421,7 @@ export default function useChatbot(initialThreadId = null, options = {}) {
             comments: normalizedComments,
           },
           {
-            params: { messageId: id },
-            headers: { Authorization: `Bearer ${accessToken}` }
+            params: { messageId: id }
           }
         )
 
@@ -460,8 +452,7 @@ export default function useChatbot(initialThreadId = null, options = {}) {
       }
 
       const response = await axios.post('/api/chatbot/exports', null, {
-        params: { messageId, queryRef, format },
-        headers: { Authorization: `Bearer ${accessToken}` }
+        params: { messageId, queryRef, format }
       })
 
       return response.data?.url ?? null
@@ -770,11 +761,11 @@ export default function useChatbot(initialThreadId = null, options = {}) {
         const response = await fetch(`/api/chatbot/messages?threadId=${streamThreadId}`, {
           method: 'POST',
           headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${accessToken}`
+            'Content-Type': 'application/json'
           },
           body: JSON.stringify({ content, stream: true }),
-          signal: controller.signal
+          signal: controller.signal,
+          credentials: 'same-origin'
         })
 
         if (!response.ok) {

--- a/next/hooks/useChatbotAuth.js
+++ b/next/hooks/useChatbotAuth.js
@@ -1,19 +1,16 @@
 import { useCallback } from 'react';
 import axios from 'axios';
-import cookies from 'js-cookie';
 import { useQueryClient } from '@tanstack/react-query';
 
 export default function useChatbotAuth() {
   const queryClient = useQueryClient();
 
-  const validateToken = useCallback(async (token) => {
+  const validateToken = useCallback(async () => {
     try {
       const data = await queryClient.fetchQuery({
-        queryKey: ['validateToken', token],
+        queryKey: ['validateToken'],
         queryFn: async () => {
-          const response = await axios.get('/api/user/validateToken', {
-            params: { p: btoa(token) }
-          });
+          const response = await axios.get('/api/user/validateToken');
           return response.data.success;
         },
         staleTime: 5 * 60 * 1000,
@@ -25,11 +22,9 @@ export default function useChatbotAuth() {
     }
   }, [queryClient]);
 
-  const refreshToken = useCallback(async (token) => {
+  const refreshToken = useCallback(async () => {
     try {
-      const response = await axios.get('/api/user/refreshToken', {
-        params: { p: btoa(token) }
-      });
+      const response = await axios.get('/api/user/refreshToken');
       return response.data.success;
     } catch (e) {
       console.error('Token refresh failed:', e);
@@ -37,21 +32,23 @@ export default function useChatbotAuth() {
     }
   }, []);
 
-  const getAccessToken = useCallback(async () => {
-    const token = cookies.get('token');
+  const ensureSession = useCallback(async () => {
+    const isValid = await validateToken();
+    if (isValid) return true;
 
-    if (!token) return null;
-
-    const isValid = await validateToken(token);
-    if (isValid) return token;
-
-    const refreshed = await refreshToken(token);
+    const refreshed = await refreshToken();
     if (refreshed) {
-      return cookies.get('token');
+      queryClient.removeQueries({ queryKey: ['validateToken'] });
+      return validateToken();
     }
 
-    return null;
-  }, [validateToken, refreshToken]);
+    return false;
+  }, [validateToken, refreshToken, queryClient]);
 
-  return { getAccessToken };
+  const getAccessToken = useCallback(async () => {
+    const ok = await ensureSession();
+    return ok ? true : null;
+  }, [ensureSession]);
+
+  return { getAccessToken, ensureSession, validateToken, refreshToken };
 }

--- a/next/hooks/useChatbotAuth.js
+++ b/next/hooks/useChatbotAuth.js
@@ -2,6 +2,8 @@ import { useCallback } from 'react';
 import axios from 'axios';
 import { useQueryClient } from '@tanstack/react-query';
 
+const ValidateTokenStaleTimeMs = 60 * 1000;
+
 export default function useChatbotAuth() {
   const queryClient = useQueryClient();
 
@@ -13,7 +15,7 @@ export default function useChatbotAuth() {
           const response = await axios.get('/api/user/validateToken');
           return response.data.success;
         },
-        staleTime: 5 * 60 * 1000,
+        staleTime: ValidateTokenStaleTimeMs,
       });
       return data;
     } catch (e) {
@@ -32,23 +34,35 @@ export default function useChatbotAuth() {
     }
   }, []);
 
+  const invalidateSessionCache = useCallback(() => {
+    queryClient.removeQueries({ queryKey: ['validateToken'] });
+    queryClient.removeQueries({ queryKey: ['chatbotThreads'] });
+  }, [queryClient]);
+
   const ensureSession = useCallback(async () => {
     const isValid = await validateToken();
     if (isValid) return true;
 
     const refreshed = await refreshToken();
     if (refreshed) {
-      queryClient.removeQueries({ queryKey: ['validateToken'] });
+      invalidateSessionCache();
       return validateToken();
     }
 
+    invalidateSessionCache();
     return false;
-  }, [validateToken, refreshToken, queryClient]);
+  }, [validateToken, refreshToken, invalidateSessionCache]);
 
   const getAccessToken = useCallback(async () => {
     const ok = await ensureSession();
     return ok ? true : null;
   }, [ensureSession]);
 
-  return { getAccessToken, ensureSession, validateToken, refreshToken };
+  return {
+    getAccessToken,
+    ensureSession,
+    validateToken,
+    refreshToken,
+    invalidateSessionCache,
+  };
 }

--- a/next/hooks/useThreads.js
+++ b/next/hooks/useThreads.js
@@ -15,11 +15,10 @@ export default function useThreads() {
     queryKey: ['chatbotThreads'],
     queryFn: async () => {
       const accessToken = await getAccessToken();
-      const { data } = await axios.get('/api/chatbot/threads', {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-      });
+      if (!accessToken) {
+        throw new Error('Sessão não autorizada');
+      }
+      const { data } = await axios.get('/api/chatbot/threads');
       return data;
     },
     staleTime: 1000 * 60 * 5,
@@ -28,11 +27,11 @@ export default function useThreads() {
   const deleteMutation = useMutation({
     mutationFn: async (threadId) => {
       const accessToken = await getAccessToken();
+      if (!accessToken) {
+        throw new Error('Sessão não autorizada');
+      }
       await axios.delete(`/api/chatbot/threads`, {
         params: { id: threadId },
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
       });
     },
     onSuccess: () => {

--- a/next/hooks/useThreads.js
+++ b/next/hooks/useThreads.js
@@ -2,8 +2,13 @@ import axios from 'axios';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import useChatbotAuth from './useChatbotAuth';
 
+function isAuthFailure(error) {
+  const status = error?.response?.status;
+  return status === 401 || status === 403;
+}
+
 export default function useThreads() {
-  const { getAccessToken } = useChatbotAuth();
+  const { getAccessToken, invalidateSessionCache } = useChatbotAuth();
   const queryClient = useQueryClient();
 
   const {
@@ -16,10 +21,18 @@ export default function useThreads() {
     queryFn: async () => {
       const accessToken = await getAccessToken();
       if (!accessToken) {
+        invalidateSessionCache();
         throw new Error('Sessão não autorizada');
       }
-      const { data } = await axios.get('/api/chatbot/threads');
-      return data;
+      try {
+        const { data } = await axios.get('/api/chatbot/threads');
+        return data;
+      } catch (err) {
+        if (isAuthFailure(err)) {
+          invalidateSessionCache();
+        }
+        throw err;
+      }
     },
     staleTime: 1000 * 60 * 5,
   });
@@ -28,11 +41,19 @@ export default function useThreads() {
     mutationFn: async (threadId) => {
       const accessToken = await getAccessToken();
       if (!accessToken) {
+        invalidateSessionCache();
         throw new Error('Sessão não autorizada');
       }
-      await axios.delete(`/api/chatbot/threads`, {
-        params: { id: threadId },
-      });
+      try {
+        await axios.delete(`/api/chatbot/threads`, {
+          params: { id: threadId },
+        });
+      } catch (err) {
+        if (isAuthFailure(err)) {
+          invalidateSessionCache();
+        }
+        throw err;
+      }
     },
     onSuccess: () => {
       queryClient.invalidateQueries(['chatbotThreads']);

--- a/next/lib/authCookie.js
+++ b/next/lib/authCookie.js
@@ -1,0 +1,46 @@
+import { serialize } from 'cookie'
+
+const TokenMaxAge = 60 * 60 * 24 * 7
+
+function cookieBaseOptions(extra = {}) {
+  return {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+    ...extra,
+  }
+}
+
+export function getTokenFromRequest(req) {
+  const authHeader = req.headers?.authorization
+  if (typeof authHeader === 'string' && authHeader.startsWith('Bearer ')) {
+    const bearer = authHeader.slice(7).trim()
+    if (bearer) return bearer
+  }
+
+  const cookieToken = req.cookies?.token
+  if (cookieToken && String(cookieToken).trim()) {
+    return String(cookieToken).trim()
+  }
+
+  const bodyToken = req.body?.token
+  if (bodyToken && String(bodyToken).trim()) {
+    return String(bodyToken).trim()
+  }
+
+  return null
+}
+
+export function getAuthorizationHeader(req) {
+  const token = getTokenFromRequest(req)
+  return token ? `Bearer ${token}` : null
+}
+
+export function serializeTokenCookie(token, { maxAge = TokenMaxAge } = {}) {
+  return serialize("token", token, cookieBaseOptions({ maxAge }));
+}
+
+export function serializeClearedTokenCookie() {
+  return serialize('token', '', cookieBaseOptions({ maxAge: -1 }))
+}

--- a/next/lib/requireChatbotAuth.js
+++ b/next/lib/requireChatbotAuth.js
@@ -1,0 +1,81 @@
+import { request, gql } from 'graphql-request'
+import { getTokenFromRequest } from './authCookie'
+
+const ApiUrl = `${process.env.NEXT_PUBLIC_API_URL}/api/v1/graphql`
+
+const VerifyTokenMutation = gql`
+  mutation verifyToken($token: String!) {
+    verifyToken(token: $token) {
+      payload
+    }
+  }
+`
+
+function parsePayload(raw) {
+  let payload = raw
+  if (typeof payload === 'string') {
+    try {
+      payload = JSON.parse(payload)
+    } catch {
+      payload = {}
+    }
+  }
+  return payload && typeof payload === 'object' ? payload : {}
+}
+
+export async function verifySessionToken(token) {
+  if (!token) {
+    return { valid: false, has_chatbot_access: false, payload: null }
+  }
+
+  try {
+    const result = await request(ApiUrl, VerifyTokenMutation, { token })
+    if (!result?.verifyToken) {
+      return { valid: false, has_chatbot_access: false, payload: null }
+    }
+
+    const payload = parsePayload(result.verifyToken.payload)
+    return {
+      valid: true,
+      has_chatbot_access: payload?.has_chatbot_access === true,
+      payload,
+    }
+  } catch (error) {
+    console.error('verifySessionToken error:', error)
+    return { valid: false, has_chatbot_access: false, payload: null }
+  }
+}
+
+export async function requireChatbotAuth(req) {
+  const token = getTokenFromRequest(req)
+  if (!token) {
+    return {
+      ok: false,
+      status: 401,
+      error: 'Missing authentication token',
+    }
+  }
+
+  const verified = await verifySessionToken(token)
+  if (!verified.valid) {
+    return {
+      ok: false,
+      status: 401,
+      error: 'Invalid or expired token',
+    }
+  }
+
+  if (!verified.has_chatbot_access) {
+    return {
+      ok: false,
+      status: 403,
+      error: 'Chatbot access required',
+    }
+  }
+
+  return {
+    ok: true,
+    authHeader: `Bearer ${token}`,
+    payload: verified.payload,
+  }
+}

--- a/next/middlewares/authUser.js
+++ b/next/middlewares/authUser.js
@@ -1,42 +1,39 @@
-import cookies from "js-cookie";
+import { serializeClearedTokenCookie } from "../lib/authCookie";
 
-async function isJWTInvalid() {
+async function isJWTInvalid(cookieHeader = "") {
   try {
-    const decoded = await fetch(`/api/user/validateToken`, {method: "GET"})
-      .then(res => res.json())
+    const decoded = await fetch(`/api/user/validateToken`, {
+      method: "GET",
+      headers: cookieHeader ? { Cookie: cookieHeader } : {},
+    }).then((res) => res.json());
 
-    return decoded.success
+    return !decoded.success;
   } catch (error) {
-    console.error(error)
-    return true
+    console.error(error);
+    return true;
   }
 }
 
-
 export default async function authUser(context, destiny) {
-  const { req, res } = context
+  const { req, res } = context;
 
-  const invalidToken = await isJWTInvalid()
+  const invalidToken = await isJWTInvalid(req.headers.cookie || "");
 
   if (invalidToken) {
-    cookies.remove('userBD', { path: '/' })
-    cookies.remove('token', { path: '/' })
-
-    res.setHeader('Set-Cookie', [
+    res.setHeader("Set-Cookie", [
+      serializeClearedTokenCookie(),
       `userBD=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT`,
-      `token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT`
-    ])
+    ]);
 
     return {
       redirect: {
         destination: destiny,
         permanent: false,
       },
-    }
+    };
   }
 
   return {
-    props: {
-    }
-  }
+    props: {},
+  };
 }

--- a/next/pages/api/chatbot/exports.js
+++ b/next/pages/api/chatbot/exports.js
@@ -1,10 +1,11 @@
 import axios from 'axios'
+import { getAuthorizationHeader } from '../../../lib/authCookie'
 
 const API_URL = process.env.CHATBOT_URL
 
 export default async function handler(req, res) {
   const { method } = req
-  const authHeader = req.headers.authorization
+  const authHeader = getAuthorizationHeader(req)
   const rawMessageId = req.query.messageId
   const messageId = Array.isArray(rawMessageId) ? rawMessageId[0] : rawMessageId
   const rawQueryRef = req.query.queryRef
@@ -17,7 +18,7 @@ export default async function handler(req, res) {
   }
 
   if (!authHeader) {
-    return res.status(401).json({ error: 'Missing authorization header' })
+    return res.status(401).json({ error: 'Missing authentication token' })
   }
 
   if (!messageId || typeof messageId !== 'string') {

--- a/next/pages/api/chatbot/exports.js
+++ b/next/pages/api/chatbot/exports.js
@@ -1,11 +1,11 @@
 import axios from 'axios'
-import { getAuthorizationHeader } from '../../../lib/authCookie'
+import { requireChatbotAuth } from '../../../lib/requireChatbotAuth'
 
 const API_URL = process.env.CHATBOT_URL
 
 export default async function handler(req, res) {
   const { method } = req
-  const authHeader = getAuthorizationHeader(req)
+  const auth = await requireChatbotAuth(req)
   const rawMessageId = req.query.messageId
   const messageId = Array.isArray(rawMessageId) ? rawMessageId[0] : rawMessageId
   const rawQueryRef = req.query.queryRef
@@ -17,8 +17,8 @@ export default async function handler(req, res) {
     return res.status(503).json({ error: 'Chatbot API URL is not configured' })
   }
 
-  if (!authHeader) {
-    return res.status(401).json({ error: 'Missing authentication token' })
+  if (!auth.ok) {
+    return res.status(auth.status).json({ error: auth.error })
   }
 
   if (!messageId || typeof messageId !== 'string') {
@@ -28,6 +28,8 @@ export default async function handler(req, res) {
   if (!queryRef || typeof queryRef !== 'string') {
     return res.status(400).json({ error: 'Missing queryRef parameter' })
   }
+
+  const authHeader = auth.authHeader
 
   try {
     if (method === 'POST') {

--- a/next/pages/api/chatbot/feedback.js
+++ b/next/pages/api/chatbot/feedback.js
@@ -1,11 +1,11 @@
 import axios from 'axios'
-import { getAuthorizationHeader } from '../../../lib/authCookie'
+import { requireChatbotAuth } from '../../../lib/requireChatbotAuth'
 
 const API_URL = process.env.CHATBOT_URL
 
 export default async function handler(req, res) {
   const { method } = req
-  const authHeader = getAuthorizationHeader(req)
+  const auth = await requireChatbotAuth(req)
   const rawMessageId = req.query.messageId
   const messageId = Array.isArray(rawMessageId) ? rawMessageId[0] : rawMessageId
 
@@ -13,13 +13,15 @@ export default async function handler(req, res) {
     return res.status(503).json({ error: 'Chatbot API URL is not configured' })
   }
 
-  if (!authHeader) {
-    return res.status(401).json({ error: 'Missing authentication token' })
+  if (!auth.ok) {
+    return res.status(auth.status).json({ error: auth.error })
   }
 
   if (!messageId || typeof messageId !== 'string') {
     return res.status(400).json({ error: 'Missing messageId parameter' })
   }
+
+  const authHeader = auth.authHeader
 
   try {
     if (method === 'PUT') {

--- a/next/pages/api/chatbot/feedback.js
+++ b/next/pages/api/chatbot/feedback.js
@@ -1,10 +1,11 @@
 import axios from 'axios'
+import { getAuthorizationHeader } from '../../../lib/authCookie'
 
 const API_URL = process.env.CHATBOT_URL
 
 export default async function handler(req, res) {
   const { method } = req
-  const authHeader = req.headers.authorization
+  const authHeader = getAuthorizationHeader(req)
   const rawMessageId = req.query.messageId
   const messageId = Array.isArray(rawMessageId) ? rawMessageId[0] : rawMessageId
 
@@ -13,7 +14,7 @@ export default async function handler(req, res) {
   }
 
   if (!authHeader) {
-    return res.status(401).json({ error: 'Missing authorization header' })
+    return res.status(401).json({ error: 'Missing authentication token' })
   }
 
   if (!messageId || typeof messageId !== 'string') {

--- a/next/pages/api/chatbot/messages.js
+++ b/next/pages/api/chatbot/messages.js
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import { getAuthorizationHeader } from '../../../lib/authCookie'
+import { requireChatbotAuth } from '../../../lib/requireChatbotAuth'
 
 const API_URL = process.env.CHATBOT_URL
 
@@ -14,12 +14,14 @@ function bufferStreamToString(stream) {
 
 export default async function handler(req, res) {
   const { method } = req
-  const authHeader = getAuthorizationHeader(req)
+  const auth = await requireChatbotAuth(req)
   const { threadId } = req.query
 
-  if (!authHeader) {
-    return res.status(401).json({ error: 'Missing authentication token' })
+  if (!auth.ok) {
+    return res.status(auth.status).json({ error: auth.error })
   }
+
+  const authHeader = auth.authHeader
 
   if (!threadId) {
     return res.status(400).json({ error: 'Missing threadId parameter' })

--- a/next/pages/api/chatbot/messages.js
+++ b/next/pages/api/chatbot/messages.js
@@ -1,4 +1,5 @@
 import axios from 'axios'
+import { getAuthorizationHeader } from '../../../lib/authCookie'
 
 const API_URL = process.env.CHATBOT_URL
 
@@ -13,11 +14,11 @@ function bufferStreamToString(stream) {
 
 export default async function handler(req, res) {
   const { method } = req
-  const authHeader = req.headers.authorization
+  const authHeader = getAuthorizationHeader(req)
   const { threadId } = req.query
 
   if (!authHeader) {
-    return res.status(401).json({ error: 'Missing authorization header' })
+    return res.status(401).json({ error: 'Missing authentication token' })
   }
 
   if (!threadId) {

--- a/next/pages/api/chatbot/threads.js
+++ b/next/pages/api/chatbot/threads.js
@@ -1,13 +1,14 @@
 import axios from 'axios'
+import { getAuthorizationHeader } from '../../../lib/authCookie'
 
 const API_URL = process.env.CHATBOT_URL
 
 export default async function handler(req, res) {
   const { method } = req
-  const authHeader = req.headers.authorization
+  const authHeader = getAuthorizationHeader(req)
 
   if (!authHeader) {
-    return res.status(401).json({ error: 'Missing authorization header' })
+    return res.status(401).json({ error: 'Missing authentication token' })
   }
 
   try {

--- a/next/pages/api/chatbot/threads.js
+++ b/next/pages/api/chatbot/threads.js
@@ -1,15 +1,17 @@
 import axios from 'axios'
-import { getAuthorizationHeader } from '../../../lib/authCookie'
+import { requireChatbotAuth } from '../../../lib/requireChatbotAuth'
 
 const API_URL = process.env.CHATBOT_URL
 
 export default async function handler(req, res) {
   const { method } = req
-  const authHeader = getAuthorizationHeader(req)
+  const auth = await requireChatbotAuth(req)
 
-  if (!authHeader) {
-    return res.status(401).json({ error: 'Missing authentication token' })
+  if (!auth.ok) {
+    return res.status(auth.status).json({ error: auth.error })
   }
+
+  const authHeader = auth.authHeader
 
   try {
     if (method === 'GET') {

--- a/next/pages/api/user/clearSession.js
+++ b/next/pages/api/user/clearSession.js
@@ -1,0 +1,11 @@
+import { serializeClearedTokenCookie } from '../../../lib/authCookie'
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST' && req.method !== 'GET') {
+    res.setHeader('Allow', ['GET', 'POST'])
+    return res.status(405).json({ error: 'Method not allowed', success: false })
+  }
+
+  res.setHeader('Set-Cookie', serializeClearedTokenCookie())
+  res.status(200).json({ success: true })
+}

--- a/next/pages/api/user/getToken.js
+++ b/next/pages/api/user/getToken.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { serialize } from 'cookie';
+import { serializeTokenCookie } from '../../../lib/authCookie';
 
 const API_URL= `${process.env.NEXT_PUBLIC_API_URL}/api/v1/graphql`
 
@@ -40,10 +40,7 @@ export default async function handler(req, res) {
   if(result.data.authToken === null) return res.status(500).json({error: "err"})
 
   if(simple === false) {
-    res.setHeader('Set-Cookie', serialize('token', result.data.authToken.token, {
-      maxAge: 60 * 60 * 24 * 7,
-      path: '/'
-    }))
+    res.setHeader('Set-Cookie', serializeTokenCookie(result.data.authToken.token))
   }
 
   res.status(200).json(result.data.authToken.user)

--- a/next/pages/api/user/getUser.js
+++ b/next/pages/api/user/getUser.js
@@ -75,12 +75,12 @@ async function getUser(id, token) {
 }
 
 export default async function handler(req, res) {
-  const token = () => {
-    if(req.query.q) return atob(req.query.q)
-    return req.cookies.token
+  const token = req.cookies.token
+  if (!token) {
+    return res.status(401).json({ error: 'Missing authentication token' })
   }
 
-  const result = await getUser(atob(req.query.p), token())
+  const result = await getUser(atob(req.query.p), token)
 
   if(result.errors) return res.status(500).json({error: result.errors})
   if(result === "err") return res.status(500).json({error: "err"})

--- a/next/pages/api/user/refreshToken.js
+++ b/next/pages/api/user/refreshToken.js
@@ -1,7 +1,7 @@
-import { request, gql } from 'graphql-request';
-import { serialize } from 'cookie';
+import { request, gql } from 'graphql-request'
+import { getTokenFromRequest, serializeTokenCookie } from '../../../lib/authCookie'
 
-const API_URL = `${process.env.NEXT_PUBLIC_API_URL}/api/v1/graphql`;
+const API_URL = `${process.env.NEXT_PUBLIC_API_URL}/api/v1/graphql`
 
 const REFRESH_TOKEN = gql`
   mutation refreshToken($token: String!) {
@@ -11,32 +11,35 @@ const REFRESH_TOKEN = gql`
       token
     }
   }
-`;
+`
 
 async function refreshToken(token) {
   try {
-    const response = await request(API_URL, REFRESH_TOKEN, { token });
-    return response;
+    const response = await request(API_URL, REFRESH_TOKEN, { token })
+    return response
   } catch (error) {
-    console.error('refreshToken error:', error);
-    return "err";
+    console.error('refreshToken error:', error)
+    return 'err'
   }
 }
 
 export default async function handler(req, res) {
-  if (!req.query.p) {
-    return res.status(400).json({ error: 'Missing token parameter', success: false });
+  if (req.method !== 'GET' && req.method !== 'POST') {
+    res.setHeader('Allow', ['GET', 'POST'])
+    return res.status(405).json({ error: 'Method not allowed', success: false })
   }
-  const result = await refreshToken(atob(req.query.p))
 
-  if(result.errors) return res.status(500).json({error: result.errors})
-  if(result === "err") return res.status(500).json({error: "err"})
-  if(result.refreshToken === null) return res.status(500).json({error: "err"})
+  const token = getTokenFromRequest(req)
+  if (!token) {
+    return res.status(401).json({ error: 'Missing authentication token', success: false })
+  }
 
-  res.setHeader('Set-Cookie', serialize('token', result.refreshToken.token, {
-    maxAge: 60 * 60 * 24 * 7,
-    path: '/'
-  }))
+  const result = await refreshToken(token)
 
+  if (result.errors) return res.status(500).json({ error: result.errors, success: false })
+  if (result === 'err') return res.status(500).json({ error: 'err', success: false })
+  if (result.refreshToken === null) return res.status(500).json({ error: 'err', success: false })
+
+  res.setHeader('Set-Cookie', serializeTokenCookie(result.refreshToken.token))
   res.status(200).json({ success: true })
 }

--- a/next/pages/api/user/setSession.js
+++ b/next/pages/api/user/setSession.js
@@ -1,0 +1,16 @@
+import { getTokenFromRequest, serializeTokenCookie } from '../../../lib/authCookie'
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST'])
+    return res.status(405).json({ error: 'Method not allowed', success: false })
+  }
+
+  const token = getTokenFromRequest(req)
+  if (!token) {
+    return res.status(400).json({ error: 'Missing authentication token', success: false })
+  }
+
+  res.setHeader('Set-Cookie', serializeTokenCookie(token))
+  res.status(200).json({ success: true })
+}

--- a/next/pages/api/user/updatePictureProfile.js
+++ b/next/pages/api/user/updatePictureProfile.js
@@ -1,18 +1,33 @@
-import axios from "axios";
-import cookies from "js-cookie";
+import axios from 'axios'
+import FormData from 'form-data'
+import { getAuthorizationHeader } from '../../../lib/authCookie'
 
-const API_URL= `${process.env.NEXT_PUBLIC_API_URL}/api/v1/graphql`
+const API_URL = `${process.env.NEXT_PUBLIC_API_URL}/api/v1/graphql`
 
-export default async function updatePictureProfile(
-  id,
-  file,
-) {
-  let token = cookies.get("token") || ""
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST'])
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
 
-  const formData = new FormData()
+  const authHeader = getAuthorizationHeader(req)
+  if (!authHeader) {
+    return res.status(401).json({ error: 'Missing authentication token' })
+  }
 
-  formData.append('operations', JSON.stringify({
-    query: `
+  const { id, fileBase64, fileName, contentType } = req.body || {}
+  if (!id || !fileBase64) {
+    return res.status(400).json({ error: 'Missing id or fileBase64' })
+  }
+
+  try {
+    const buffer = Buffer.from(fileBase64, 'base64')
+    const formData = new FormData()
+
+    formData.append(
+      'operations',
+      JSON.stringify({
+        query: `
     mutation ($file: Upload!) {
       CreateUpdateAccount(input: {id: ${id} , picture: $file}) {
         account {
@@ -21,28 +36,33 @@ export default async function updatePictureProfile(
       }
     }
     `,
-    variables: {
-      file: null,
-    },
-  }))
-  formData.append('map', JSON.stringify({
-    '0': ['variables.file'],
-  }))
-  formData.append('0', file);
-
-  try {
-    const res = await axios({
-      url: API_URL,
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'multipart/form-data'
-      },
-      data: formData
+        variables: {
+          file: null,
+        },
+      })
+    )
+    formData.append('map', JSON.stringify({ '0': ['variables.file'] }))
+    formData.append('0', buffer, {
+      filename: fileName || 'profile.jpeg',
+      contentType: contentType || 'image/jpeg',
     })
-    const data = res 
-    return data
+
+    const response = await axios({
+      url: API_URL,
+      method: 'POST',
+      headers: {
+        Authorization: authHeader,
+        ...formData.getHeaders(),
+      },
+      data: formData,
+      maxBodyLength: Infinity,
+    })
+
+    return res.status(200).json(response.data)
   } catch (error) {
-    return error
+    console.error('updatePictureProfile error:', error.response?.data || error.message)
+    return res
+      .status(error.response?.status || 500)
+      .json(error.response?.data || { error: 'Internal Server Error' })
   }
 }

--- a/next/pages/api/user/validateToken.js
+++ b/next/pages/api/user/validateToken.js
@@ -1,25 +1,5 @@
-import { request, gql } from 'graphql-request'
 import { getTokenFromRequest } from '../../../lib/authCookie'
-
-const API_URL = `${process.env.NEXT_PUBLIC_API_URL}/api/v1/graphql`
-
-const VERIFY_TOKEN = gql`
-  mutation verifyToken($token: String!) {
-    verifyToken(token: $token) {
-      payload
-    }
-  }
-`
-
-async function validateToken(token) {
-  try {
-    const response = await request(API_URL, VERIFY_TOKEN, { token })
-    return response
-  } catch (error) {
-    console.error('validateToken error:', error)
-    return 'err'
-  }
-}
+import { verifySessionToken } from '../../../lib/requireChatbotAuth'
 
 export default async function handler(req, res) {
   if (req.method !== 'GET' && req.method !== 'POST') {
@@ -32,21 +12,13 @@ export default async function handler(req, res) {
     return res.status(401).json({ error: 'Missing authentication token', success: false })
   }
 
-  const result = await validateToken(token)
-
-  if (result.errors) return res.status(500).json({ error: result.errors, success: false })
-  if (result === 'err') return res.status(500).json({ error: 'err', success: false })
-  if (result.verifyToken === null) return res.status(500).json({ error: 'err', success: false })
-
-  let payload = result.verifyToken?.payload
-  if (typeof payload === 'string') {
-    try {
-      payload = JSON.parse(payload)
-    } catch {
-      payload = {}
-    }
+  const verified = await verifySessionToken(token)
+  if (!verified.valid) {
+    return res.status(401).json({ error: 'Invalid or expired token', success: false })
   }
-  const has_chatbot_access = payload?.has_chatbot_access === true
 
-  res.status(200).json({ success: true, has_chatbot_access })
+  res.status(200).json({
+    success: true,
+    has_chatbot_access: verified.has_chatbot_access,
+  })
 }

--- a/next/pages/api/user/validateToken.js
+++ b/next/pages/api/user/validateToken.js
@@ -1,6 +1,7 @@
-import { request, gql } from 'graphql-request';
+import { request, gql } from 'graphql-request'
+import { getTokenFromRequest } from '../../../lib/authCookie'
 
-const API_URL = `${process.env.NEXT_PUBLIC_API_URL}/api/v1/graphql`;
+const API_URL = `${process.env.NEXT_PUBLIC_API_URL}/api/v1/graphql`
 
 const VERIFY_TOKEN = gql`
   mutation verifyToken($token: String!) {
@@ -8,37 +9,44 @@ const VERIFY_TOKEN = gql`
       payload
     }
   }
-`;
+`
 
 async function validateToken(token) {
   try {
-    const response = await request(API_URL, VERIFY_TOKEN, { token });
-    return response;
+    const response = await request(API_URL, VERIFY_TOKEN, { token })
+    return response
   } catch (error) {
-    console.error('validateToken error:', error);
-    return "err";
+    console.error('validateToken error:', error)
+    return 'err'
   }
 }
 
 export default async function handler(req, res) {
-  if (!req.query.p) {
-    return res.status(400).json({ error: 'Missing token parameter', success: false });
+  if (req.method !== 'GET' && req.method !== 'POST') {
+    res.setHeader('Allow', ['GET', 'POST'])
+    return res.status(405).json({ error: 'Method not allowed', success: false })
   }
-  const result = await validateToken(atob(req.query.p))
 
-  if(result.errors) return res.status(500).json({error: result.errors, success: false })
-  if(result === "err") return res.status(500).json({error: "err", success: false })
-  if(result.verifyToken === null) return res.status(500).json({error: "err", success: false})
+  const token = getTokenFromRequest(req)
+  if (!token) {
+    return res.status(401).json({ error: 'Missing authentication token', success: false })
+  }
 
-  let payload = result.verifyToken?.payload;
+  const result = await validateToken(token)
+
+  if (result.errors) return res.status(500).json({ error: result.errors, success: false })
+  if (result === 'err') return res.status(500).json({ error: 'err', success: false })
+  if (result.verifyToken === null) return res.status(500).json({ error: 'err', success: false })
+
+  let payload = result.verifyToken?.payload
   if (typeof payload === 'string') {
     try {
-      payload = JSON.parse(payload);
+      payload = JSON.parse(payload)
     } catch {
-      payload = {};
+      payload = {}
     }
   }
-  const has_chatbot_access = payload?.has_chatbot_access === true;
+  const has_chatbot_access = payload?.has_chatbot_access === true
 
   res.status(200).json({ success: true, has_chatbot_access })
 }

--- a/next/pages/chatbot-lp.js
+++ b/next/pages/chatbot-lp.js
@@ -644,10 +644,9 @@ function Hero({ t }) {
     let cancelled = false;
 
     async function checkAccess() {
-      const token = cookies.get("token");
       const userRaw = cookies.get("userBD");
 
-      if (!token || !userRaw || userRaw === "undefined") {
+      if (!userRaw || userRaw === "undefined") {
         if (!cancelled) setHasChatbotAccess(false);
         return;
       }
@@ -660,8 +659,10 @@ function Hero({ t }) {
       }
 
       try {
-        const params = new URLSearchParams({ p: btoa(token) });
-        const res = await fetch(`/api/user/validateToken?${params}`);
+        const res = await fetch("/api/user/validateToken", {
+          method: "GET",
+          credentials: "same-origin",
+        });
         const data = await res.json();
 
         if (!cancelled) {

--- a/next/pages/chatbot.js
+++ b/next/pages/chatbot.js
@@ -19,7 +19,7 @@ import CrossIcon from "../public/img/icons/crossIcon";
 import BDLogoImage from "../public/img/logos/bd_logo";
 import useChatbot from "../hooks/useChatbot";
 import { ChatbotProvider } from "../context/ChatbotContext";
-import { redirectToChatbotCheckout } from "../utils";
+import { redirectToChatbotCheckout, clearClientSession } from "../utils";
 
 function getGreetingFirstNameFromCookie() {
   try {
@@ -33,19 +33,16 @@ function getGreetingFirstNameFromCookie() {
   }
 }
 
-function clearAuthCookiesAndRedirectLogin(router) {
+async function clearAuthCookiesAndRedirectLogin(router) {
   if (typeof window !== "undefined") {
     localStorage.setItem("previousPath", window.location.href);
   }
-  cookies.remove("userBD", { path: "/" });
-  cookies.remove("token", { path: "/" });
+  await clearClientSession();
   router.replace("/user/login");
 }
 
-function hasCompleteAuthCookies() {
-  const token = cookies.get("token");
+function hasUserCookie() {
   const userRaw = cookies.get("userBD");
-  if (!token || !String(token).trim()) return false;
   if (!userRaw || userRaw === "undefined") return false;
   try {
     JSON.parse(userRaw);
@@ -64,20 +61,19 @@ function ChatbotAccessGate({ children }) {
 
     async function checkAccess() {
       if (typeof window === "undefined") return;
-      if (!hasCompleteAuthCookies()) {
-        clearAuthCookiesAndRedirectLogin(router);
+      if (!hasUserCookie()) {
+        await clearAuthCookiesAndRedirectLogin(router);
         return;
       }
-      const token = cookies.get("token");
       try {
-        const params = new URLSearchParams({ p: btoa(token) });
-        const res = await fetch(`/api/user/validateToken?${params}`, {
-          method: "GET"
+        const res = await fetch("/api/user/validateToken", {
+          method: "GET",
+          credentials: "same-origin"
         });
         const data = await res.json();
         if (cancelled) return;
         if (!res.ok || !data.success) {
-          clearAuthCookiesAndRedirectLogin(router);
+          await clearAuthCookiesAndRedirectLogin(router);
           return;
         }
         if (!data.has_chatbot_access) {
@@ -86,7 +82,7 @@ function ChatbotAccessGate({ children }) {
         }
         setCanEnter(true);
       } catch {
-        if (!cancelled) clearAuthCookiesAndRedirectLogin(router);
+        if (!cancelled) await clearAuthCookiesAndRedirectLogin(router);
       }
     }
 

--- a/next/pages/dataset/[dataset].js
+++ b/next/pages/dataset/[dataset].js
@@ -196,7 +196,10 @@ export default function DatasetPage ({ dataset, userGuide, hiddenDataset }) {
       if (userBD?.isAdmin) {
         const id = userBD.id.split(":").pop();
         if (id) {
-          const response = await fetch(`/api/user/getUser?p=${btoa(id)}&q=${btoa(cookies.get("token"))}`, { method: "GET" });
+          const response = await fetch(`/api/user/getUser?p=${btoa(id)}`, {
+            method: "GET",
+            credentials: "same-origin",
+          });
           const userData = await response.json();
           newPermission.isAdmin = !!userData?.isAdmin;
           newPermission.email = userData?.email || "undefined";

--- a/next/pages/user/[username].js
+++ b/next/pages/user/[username].js
@@ -10,6 +10,7 @@ import { useTranslation } from "react-i18next";
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import { MainPageTemplate } from "../../components/templates/main";
 import { hasBDProSubscription } from "../../utils";
+import { serializeClearedTokenCookie } from "../../lib/authCookie";
 import TitleText from "../../components/atoms/Text/TitleText";
 import LabelText from "../../components/atoms/Text/LabelText";
 
@@ -29,7 +30,7 @@ export async function getServerSideProps(context) {
   if(req.cookies.userBD) user = JSON.parse(req.cookies.userBD)
 
   if (user === null || Object.keys(user).length < 0) {
-    res.setHeader('Set-Cookie', serialize('token', '', {maxAge: -1, path: '/', }))
+    res.setHeader('Set-Cookie', serializeClearedTokenCookie())
 
     return {
       redirect: {
@@ -39,16 +40,30 @@ export async function getServerSideProps(context) {
     }
   }
 
-  const validateTokenResponse = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL_FRONTEND}/api/user/validateToken?p=${btoa(req.cookies.token)}`, {method: "GET"})
+  const cookieHeader = req.headers.cookie || ''
+  const validateTokenResponse = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL_FRONTEND}/api/user/validateToken`, {
+    method: "GET",
+    headers: { Cookie: cookieHeader },
+  })
   const validateToken = await validateTokenResponse.json()
 
-  if(validateToken.error) {
-    const refreshTokenResponse = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL_FRONTEND}/api/user/refreshToken?p=${btoa(req.cookies.token)}`, {method: "GET"})
+  if(validateToken.error || !validateToken.success) {
+    const refreshTokenResponse = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL_FRONTEND}/api/user/refreshToken`, {
+      method: "GET",
+      headers: { Cookie: cookieHeader },
+    })
     const refreshToken = await refreshTokenResponse.json()
 
-    if(refreshToken.error) {
-      res.setHeader('Set-Cookie', serialize('token', '', {maxAge: -1, path: '/', }))
-      res.setHeader('Set-Cookie', serialize('userBD', '', { maxAge: -1, path: '/', }))
+    const refreshedCookie = refreshTokenResponse.headers.get('set-cookie')
+    if (refreshedCookie) {
+      res.setHeader('Set-Cookie', refreshedCookie)
+    }
+
+    if(refreshToken.error || !refreshToken.success) {
+      res.setHeader('Set-Cookie', [
+        serializeClearedTokenCookie(),
+        serialize('userBD', '', { maxAge: -1, path: '/' }),
+      ])
 
       return {
         redirect: {
@@ -62,12 +77,17 @@ export async function getServerSideProps(context) {
   const reg = new RegExp("(?<=:).*")
   const [ id ] = reg.exec(user.id)
 
-  const getUserResponse = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL_FRONTEND}/api/user/getUser?p=${btoa(id)}&q=${btoa(req.cookies.token)}`, {method: "GET"})
+  const getUserResponse = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL_FRONTEND}/api/user/getUser?p=${btoa(id)}`, {
+    method: "GET",
+    headers: { Cookie: cookieHeader },
+  })
   const getUser = await getUserResponse.json()
 
   if(getUser.errors) {
-    res.setHeader('Set-Cookie', serialize('token', '', {maxAge: -1, path: '/', }))
-    res.setHeader('Set-Cookie', serialize('userBD', '', { maxAge: -1, path: '/', }))
+    res.setHeader('Set-Cookie', [
+      serializeClearedTokenCookie(),
+      serialize('userBD', '', { maxAge: -1, path: '/' }),
+    ])
 
     return {
       redirect: {

--- a/next/pages/user/login.js
+++ b/next/pages/user/login.js
@@ -55,10 +55,25 @@ export default function Login() {
     if (loginSuccess === 'success') {
       setIsLoading(true)
       const token = urlParams.get('token')
-      if(token) {
-        cookies.set('token', token, { expires: 7, path: '/' })
+      const userId = urlParams.get('id')
+
+      const finishGoogleLogin = async () => {
+        if (token) {
+          try {
+            await fetch('/api/user/setSession', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ token }),
+            })
+          } catch (_) {}
+          urlParams.delete('token')
+          const cleaned = `${window.location.pathname}${urlParams.toString() ? `?${urlParams}` : ''}`
+          window.history.replaceState({}, '', cleaned)
+        }
+        fetchUser(userId)
       }
-      fetchUser(urlParams.get('id'));
+
+      finishGoogleLogin()
     }
 
     const error = urlParams.get('error');

--- a/next/utils.js
+++ b/next/utils.js
@@ -1,5 +1,12 @@
 import cookies from 'js-cookie';
 
+export async function clearClientSession() {
+  cookies.remove('userBD', { path: '/' });
+  try {
+    await fetch('/api/user/clearSession', { method: 'POST', credentials: 'same-origin' });
+  } catch (_) {}
+}
+
 export function filterOnlyValidValues(obj, validValues = null) {
   return Object.entries(obj).filter(
     ([k, v]) =>


### PR DESCRIPTION
### O que estava acontecendo
O token de login (a “chave” da sessão do usuário) estava sendo tratado de um jeito inseguro:

1. Ia na URL em algumas chamadas (codificado em base64, que qualquer um consegue ler de volta). Isso podia vazar em logs do servidor, histórico do navegador e cabeçalhos de referência.
2. Ficava acessível pelo JavaScript do site (cookie sem HttpOnly). Se existisse qualquer falha de XSS no site, o token podia ser roubado e a conta usada por outra pessoa.
3. O frontend do chatbot mandava o token manualmente nas requisições. O ideal é o servidor ler a sessão sozinho, sem o browser precisar “carregar” o token.

### O que isso causava na prática
- Risco real de vazamento de sessão (alguém usar a conta de outra pessoa).
- A “trava” de acesso ao chatbot existia só na tela. Quem soubesse chamar a API direto podia tentar burlar.
- Em falha de login/sessão, o cookie às vezes não era limpo de verdade, e a sessão “fantasma” podia continuar no navegador.

### O que resolvemos
- O token não vai mais na URL.
- O cookie de sessão passou a ser HttpOnly (o JavaScript da página não consegue lê-lo).
- As rotas do chatbot no Next leem a sessão no servidor e checam se o usuário tem acesso antes de seguir.
- Logout e erro de autenticação limpam a sessão corretamente.
- O cache de validação ficou mais curto, e 401/403 no chatbot levam de volta ao login.