### PR TITLE
fix: localize filter facet names when expanding "See more"

### DIFF
--- a/next/components/atoms/FilterAccordion.js
+++ b/next/components/atoms/FilterAccordion.js
@@ -117,7 +117,7 @@ export function CheckboxFilterAccordion({
   facet = ""
 }) {
   const { t } = useTranslation('search');
-  const { asPath } =  useRouter();
+  const { asPath, locale } =  useRouter();
   const [options, setOptions] = useState([]);
   const [allOptions, setAllOptions] = useState([]);
   const [search, setSearch] = useState("");
@@ -145,14 +145,14 @@ export function CheckboxFilterAccordion({
   const MoreOptions = useCallback(async () => {
     try {
       const params = asPath.replace("/search?", "");
-      const res = await MoreFacetSearch(facet, params);
+      const res = await MoreFacetSearch(facet, params, locale);
       setAllOptions(res.values);
       setOptions(res.values);
       setShowAll(true);
     } catch (error) {
       console.error("Failed to load more options", error);
     }
-  }, [asPath, facet]);
+  }, [asPath, facet, locale]);
 
   function toggleShowAll() {
     if (showAll) {

--- a/next/pages/api/datasets/getMoreFacetSearchDatasets.js
+++ b/next/pages/api/datasets/getMoreFacetSearchDatasets.js
@@ -2,9 +2,10 @@ import axios from "axios";
 
 const API_URL= `${process.env.NEXT_PUBLIC_API_URL}/facet_values/`
 
-export default async function getMoreFacetSearchDatasets(facet, params) {
+export default async function getMoreFacetSearchDatasets(facet, params, locale) {
   try {
-    const res = await axios.get(`${API_URL}?facet=${facet}&${params}`)
+    const localeParam = locale ? `&locale=${locale}` : ""
+    const res = await axios.get(`${API_URL}?facet=${facet}&${params}${localeParam}`)
     return res.data
   } catch (error) {
     console.error(error)


### PR DESCRIPTION
## What

On the translated sites, expanding **"See more"** in the search side filter (themes, organizations) made the extra names appear in Portuguese instead of the localized names.

## Why

The first 5 facet options are fetched through the search API, which sends `&locale=…`, so they are localized. The "See more" action calls `getMoreFacetSearchDatasets` (the `/facet_values/` endpoint), which omitted the locale — so the backend fell back to its default (Portuguese).

## Fix

Thread the router `locale` from `CheckboxFilterAccordion` through to `getMoreFacetSearchDatasets`, which now appends `&locale=…` when present. Same locale source (`useRouter().locale`) the search page already uses. Only `FilterAccordion` calls this function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
