### PR TITLE
feat: language-consistent experience — regional pricing, i18n, chatbot (→ staging)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,33 +6,34 @@
 Canonical reference: https://github.com/basedosdados/backend/wiki/Boas-Pr%C3%A1ticas#segue-o-fluxo
 
 ### The environment branches — never commit or push directly
-- `main` — production (basedosdados.org).
+- `main` — production (basedosdados.org). Source of truth: resets flow *from* `main`.
 - `staging` — pre-production / QA.
-- `development` — integration / testing. First target for new work.
-
-These three are **parallel, independently maintained** branches, not a linear chain.
-Their histories have diverged, so you never merge one environment branch into another to
-move a feature — that would drag the whole environment forward. Each feature is promoted
-into each environment **selectively**, via its own PR carrying only that feature.
+- `development` — integration / testing.
 
 Note: the integration branch here is named `development` (full word), not `dev`.
 
-### Feature workflow — promote the feature, not the environment
-1. Cut your feature branch off `development` (the branch you integrate and test in first).
-   Name it by intent: `feat/…`, `fix/…`, `chore/…`, `docs/…`, `refactor/…`.
-   Keep one logical change per branch, with tidy commits — you will cherry-pick them.
-2. Open a PR from that branch into `development`.
-3. To promote the same feature to `staging`, cut a new branch off `staging` and
-   cherry-pick only this feature's commit(s) onto it, then open a PR into `staging`.
-4. To promote to `main`, repeat: cut a branch off `main`, cherry-pick the same commit(s),
-   open a PR into `main`.
-5. Result: one clean PR per environment, each carrying only this feature.
+### How work flows
+Cut every feature off `main`, then merge the **same commits** into `development`, `staging`,
+and `main` — one PR per target. The three branches are meant to hold identical history for
+each feature. They drift apart as changes land at different times, so the team periodically
+**resets `staging` and `development` back to `main`** to re-align them. Because resets flow
+from `main`, a change must reach `main` to survive — anything living only on `staging` or
+`development` is discarded at the next reset.
+
+### Feature workflow — same commits into every branch
+1. Cut your feature branch off `main` (ideally just after a reset, when the branches are aligned).
+   Name it by intent: `feat/…`, `fix/…`, `chore/…`, `docs/…`, `refactor/…`. One logical change per branch.
+2. Open a PR from that branch into each target branch: `development`, `staging`, and `main`.
+3. Merge with a **merge commit or fast-forward — never squash, never cherry-pick** — so the
+   identical commit SHA lands on all three branches.
+4. If a target has drifted far from `main`, realign it via the periodic reset rather than
+   forcing a noisy cross-branch merge.
 
 ### Rules for agents working in this repo
-- Never commit or push to `main`, `staging`, or `development` directly.
-- Move a feature between environments by cherry-picking it onto a branch cut off the
-  target — never by merging `development → staging` or `staging → main`.
-- Each promotion branch is cut off its own target, so the PR diff is only this feature.
-- One logical change per branch; one PR at a time per target; keep commits clean for cherry-picking.
+- Never commit or push to `main`, `staging`, or `development` directly — always a feature branch + PR.
+- Cut features off `main` so the same commit can enter every environment.
+- Merge as merge-commit/FF, **never squash** (squash mints a new SHA per branch) and
+  **never cherry-pick** (also a new SHA) — both break the "same commits everywhere" rule.
+- Never merge one environment branch into another to promote a feature.
 - Before committing, verify you are on a feature branch: `git branch --show-current`.
 - Do not push without explicit permission.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,30 +10,36 @@ Canonical reference: https://github.com/basedosdados/backend/wiki/Boas-Pr%C3%A1t
 - `staging` — pre-production / QA.
 - `development` — integration / testing.
 
-Note: the integration branch here is named `development` (full word), not `dev`.
-
 ### How work flows
-Cut every feature off `main`, then merge the **same commits** into `development`, `staging`,
-and `main` — one PR per target. The three branches are meant to hold identical history for
-each feature. They drift apart as changes land at different times, so the team periodically
-**resets `staging` and `development` back to `main`** to re-align them. Because resets flow
-from `main`, a change must reach `main` to survive — anything living only on `staging` or
-`development` is discarded at the next reset.
+Every feature starts from `main` and is promoted back into the other environments using
+**one branch and three PRs** — the same head branch is PR'd into `development`, `staging`, and
+`main`. Merging the same branch into each target puts the *same commit objects* into all
+three, so the feature's own commits share SHAs everywhere. Only the merge commits differ,
+which is expected and fine.
 
-### Feature workflow — same commits into every branch
-1. Cut your feature branch off `main` (ideally just after a reset, when the branches are aligned).
-   Name it by intent: `feat/…`, `fix/…`, `chore/…`, `docs/…`, `refactor/…`. One logical change per branch.
-2. Open a PR from that branch into each target branch: `development`, `staging`, and `main`.
-3. Merge with a **merge commit or fast-forward — never squash, never cherry-pick** — so the
-   identical commit SHA lands on all three branches.
-4. If a target has drifted far from `main`, realign it via the periodic reset rather than
-   forcing a noisy cross-branch merge.
+The environments still drift apart as those merge commits accumulate at different times, so
+the team **resets `staging` and `development` back to `main` roughly every two weeks**. Because
+resets flow *from* `main`, a change must reach `main` to survive — anything living only on
+`staging` or `development` is discarded at the next reset.
+
+### Feature workflow — one branch, three PRs
+1. Cut your feature branch off `main` — never off `staging` or `development`.
+   Name it by intent: `feat/…`, `fix/…`, `chore/…`, `docs/…`, `refactor/…`.
+   One logical change per branch.
+2. From that **same branch**, open three PRs: one into `development`, one into `staging`, one
+   into `main`. Do not cut a separate branch per target, and do not cherry-pick.
+3. Merge with a **merge commit or fast-forward — never squash**. A squash mints a new,
+   unrelated commit on each branch and breaks the shared history the resets rely on.
+4. Timing: a `main`-based branch merges cleanly into `development`/`staging` when those are
+   aligned with `main` — in practice, shortly after a reset. The longer since the last
+   reset, the more of `main`'s accumulated commits the PR will drag along. If a target has
+   drifted far, wait for the reset rather than forcing a noisy merge.
 
 ### Rules for agents working in this repo
 - Never commit or push to `main`, `staging`, or `development` directly — always a feature branch + PR.
-- Cut features off `main` so the same commit can enter every environment.
-- Merge as merge-commit/FF, **never squash** (squash mints a new SHA per branch) and
-  **never cherry-pick** (also a new SHA) — both break the "same commits everywhere" rule.
+- Always cut features off `main`, never off `staging` or `development`.
+- Use **one branch for all three PRs**. Never a branch-per-target, never cherry-pick.
+- **Never squash-merge.** Merge commit or fast-forward only.
 - Never merge one environment branch into another to promote a feature.
 - Before committing, verify you are on a feature branch: `git branch --show-current`.
 - Do not push without explicit permission.

--- a/next/components/molecules/DataInformationQuery.js
+++ b/next/components/molecules/DataInformationQuery.js
@@ -29,7 +29,7 @@ import GreenTab from "../atoms/GreenTab";
 import Toggle from "../atoms/Toggle";
 import TableColumns from "./TableColumns";
 import { AlertDiscalimerBox} from "./DisclaimerBox";
-import { triggerGAEvent, triggerGAEventWithData, formatBytes, hasBDProSubscription } from "../../utils";
+import { triggerGAEvent, triggerGAEventWithData, formatBytes, hasBDProSubscription, localizeQueryTableAlias } from "../../utils";
 
 import {
   getBigTableQuery
@@ -225,14 +225,14 @@ const DataInformationQuery = memo(({ resource, datasetName, changeTab }) => {
   const SqlCodeString = useCallback(async () => {
     const result = await getBigTableQuery(resource?._id, checkedColumns, includeTranslation);
     if(result === null) return;
-    setSqlCode(result.trim());
+    setSqlCode(localizeQueryTableAlias(result.trim(), locale));
     setIsLoadingCode(false);
     setIsLoadingSpin(false);
     const tourBD = getTourBD();
     if(tourBD && tourBD.state === 'begin') {
       cookies.set('tourBD', '{"state":"table"}', { expires: 360 });
     }
-  }, [resource?._id, checkedColumns, includeTranslation, getTourBD]);
+  }, [resource?._id, checkedColumns, includeTranslation, getTourBD, locale]);
 
   const handleAccessIndexes = useCallback((index) => {
     const categoryValues = [t('table.bigQueryAndPackages'), t('table.download')];

--- a/next/components/molecules/Footer.js
+++ b/next/components/molecules/Footer.js
@@ -8,7 +8,7 @@ import Link from "../atoms/Link";
 import { isMobileMod } from "../../hooks/useCheckMobile.hook"
 import { useTranslation } from 'next-i18next';
 import { useRouter } from 'next/router';
-import { triggerGAEvent, trackNavigateToChatbotLp } from "../../utils";
+import { triggerGAEvent, trackNavigateToChatbotLp, getDiscordUrl } from "../../utils";
 import Display from "../atoms/Text/Display";
 import LabelText from "../atoms/Text/LabelText";
 import BodyText from "../atoms/Text/BodyText";
@@ -421,7 +421,7 @@ export default function Footer({ template, ocult = false }) {
               locale === 'es' ? "https://bsky.app/profile/basedelosdatos" :
               "https://bsky.app/profile/basedosdados"
             } icon={<BlueskyIcon alt="bluesky" {...IconKey}/>}/>
-            <SocialLink title="Discord" href="https://discord.gg/huKWpsVYx4" icon={<DiscordIcon alt="discord" {...IconKey}/>}/>
+            <SocialLink title="Discord" href={getDiscordUrl(locale)} icon={<DiscordIcon alt="discord" {...IconKey}/>}/>
             <SocialLink title="GitHub" href="https://github.com/basedosdados" icon={<GithubIcon alt="github" {...IconKey}/>}/>
             <SocialLink title="LinkedIn" href="https://www.linkedin.com/company/base-dos-dados/mycompany/" icon={<LinkedinIcon alt="linkedin" {...IconKey}/>}/>
             <SocialLink title="YouTube" href="https://www.youtube.com/basedosdados" icon={<YoutubeIcon alt="youtube" {...IconKey}/>}/>

--- a/next/components/molecules/Menu.js
+++ b/next/components/molecules/Menu.js
@@ -32,7 +32,7 @@ import { ControlledInputSimple } from "../atoms/ControlledInput";
 import Link from "../atoms/Link";
 import Button from "../atoms/Button";
 import HelpWidget from "../atoms/HelpWidget";
-import { triggerGAEvent, triggerGAEventWithData, hasBDProSubscription, hasChatbotSubscription, trackNavigateToChatbotLp, clearClientSession } from "../../utils";
+import { triggerGAEvent, triggerGAEventWithData, hasBDProSubscription, hasChatbotSubscription, trackNavigateToChatbotLp, clearClientSession, getDiscordUrl } from "../../utils";
 
 import LabelText from "../atoms/Text/LabelText";
 import BodyText from "../atoms/Text/BodyText";
@@ -988,7 +988,7 @@ function DesktopLinks({
                 {},
                 {
                   name: t("tooltip.discordCommunity"),
-                  url: "https://discord.gg/huKWpsVYx4",
+                  url: getDiscordUrl(locale),
                 },
                 {
                   name: t("tooltip.contactUs"),

--- a/next/components/molecules/Menu.js
+++ b/next/components/molecules/Menu.js
@@ -1218,7 +1218,7 @@ export default function MenuNav({ simpleTemplate = false, userTemplate = false }
       [t('solutions')]: [
         {
           name: [t('exclusive_data')],
-          href: "/en/bdpro"
+          href: "/bdpro"
         },
         {
           name: [t('chatbot_lp')],
@@ -1244,7 +1244,7 @@ export default function MenuNav({ simpleTemplate = false, userTemplate = false }
       [t('solutions')]: [
         {
           name: [t('exclusive_data')],
-          href: "/es/bdpro"
+          href: "/bdpro"
         },
         {
           name: [t('chatbot_lp')],

--- a/next/components/organisms/DatasetSearchCard.js
+++ b/next/components/organisms/DatasetSearchCard.js
@@ -38,6 +38,7 @@ const DatasetSearchCard= ({
   name,
   organizations,
   temporalCoverageText,
+  spatialCoverage,
   tables,
   rawDataSources,
   informationRequests,
@@ -257,11 +258,11 @@ const DatasetSearchCard= ({
                 {temporalCoverageText || t('notProvided')}
               </MetadataRow>
 
-              {/* {locale !== 'pt' && (
+              {locale !== 'pt' && (
                 <MetadataRow label={t('spatialCoverage')}>
                   {spatialCoverage || t('notProvided')}
                 </MetadataRow>
-              )} */}
+              )}
 
               <MetadataRow label={t('resources')}>
                 {resourcesText}

--- a/next/components/organisms/DatasetUserGuide.js
+++ b/next/components/organisms/DatasetUserGuide.js
@@ -366,7 +366,7 @@ export default function DatasetUserGuide({ data, locale = "pt", slug }) {
 
   const repository = () => {
     const baseUrl = process.env.NEXT_PUBLIC_BASE_URL_FRONTEND
-    if (baseUrl === "http://localhost:3000" || baseUrl === "https://development.basedosdados.org") return "development" 
+    if (baseUrl === "http://localhost:3000" || baseUrl === "https://development.basedosdados.org") return "staging"
     if (baseUrl === "https://staging.basedosdados.org") return "staging"
     if (baseUrl === "https://basedosdados.org") return "main" 
     return null

--- a/next/components/organisms/DatasetUserGuide.js
+++ b/next/components/organisms/DatasetUserGuide.js
@@ -18,6 +18,8 @@ import {
 } from "@chakra-ui/react";
 import { useEffect, useRef, useState } from "react";
 import { MDXRemote } from "next-mdx-remote";
+import NextLink from "next/link";
+import { useRouter } from "next/router";
 import { useTranslation } from 'next-i18next';
 import Button from "../atoms/Button";
 import TitleText from "../atoms/Text/TitleText";
@@ -220,17 +222,40 @@ export const mdxComponents = {
       </Stack>
     </Box>
   ),
-  a: (props) => (
-  <BodyText
-    typography="small"
-    as="a"
-    color="#0068C5"
-    _hover={{
-      color: "#0057A4"
-    }}
-    {...props} 
-  />
-  ),
+  a: (props) => {
+    const { locale } = useRouter();
+    const { href = "", ...rest } = props;
+    // Root-relative internal links (e.g. /faq) must carry the current locale;
+    // skip if already locale-prefixed or an external/anchor/mailto link.
+    const isInternal =
+      typeof href === "string" &&
+      href.startsWith("/") &&
+      !/^\/(pt|en|es)(\/|$)/.test(href);
+
+    const anchor = (
+      <BodyText
+        typography="small"
+        as="a"
+        color="#0068C5"
+        _hover={{ color: "#0057A4" }}
+        {...props}
+      />
+    );
+
+    if (!isInternal) return anchor;
+
+    return (
+      <NextLink href={href} locale={locale} passHref legacyBehavior>
+        <BodyText
+          typography="small"
+          as="a"
+          color="#0068C5"
+          _hover={{ color: "#0057A4" }}
+          {...rest}
+        />
+      </NextLink>
+    );
+  },
   hr: (props) => (
     <Divider
       borderWidth="0px"

--- a/next/components/organisms/chatbot/BrandLogo.js
+++ b/next/components/organisms/chatbot/BrandLogo.js
@@ -1,0 +1,13 @@
+import { useRouter } from "next/router";
+
+import BDLogoImage from "../../../public/img/logos/bd_logo";
+import DBLogoImage from "../../../public/img/logos/db_logo";
+
+// Locale-aware wordmark: Data Basis (DB) on the English site, Base dos Dados (BD)
+// otherwise. Mirrors the rule used by the main site nav
+// (components/molecules/Menu.js), driven by router.locale so it is SSR-safe.
+export default function BrandLogo(props) {
+  const { locale } = useRouter();
+  const Logo = locale === "en" ? DBLogoImage : BDLogoImage;
+  return <Logo {...props} />;
+}

--- a/next/components/organisms/chatbot/DownloadResults.js
+++ b/next/components/organisms/chatbot/DownloadResults.js
@@ -11,6 +11,7 @@ import {
   useToast,
 } from "@chakra-ui/react";
 import { Fragment, useState } from "react";
+import { useTranslation } from "next-i18next";
 
 import DownloadIcon from "../../../public/img/icons/downloadIcon";
 import TableChartViewIcon from "../../../public/img/icons/tableChartViewIcon";
@@ -67,7 +68,7 @@ const MenuItemProps = {
   _hover: { backgroundColor: "transparent", opacity: "0.7" },
 };
 
-function getExportErrorInfo(error) {
+function getExportErrorInfo(error, t) {
   const status = error?.response?.status;
   const data = error?.response?.data;
   const detail =
@@ -79,9 +80,8 @@ function getExportErrorInfo(error) {
 
   if (status === 410) {
     return {
-      title: "Resultado expirado",
-      description:
-        detail || "Estes resultados não estão mais disponíveis para download.",
+      title: t("ui.download.errors.expiredTitle"),
+      description: detail || t("ui.download.errors.expiredDescription"),
     };
   }
 
@@ -89,20 +89,21 @@ function getExportErrorInfo(error) {
     const isTooLarge =
       typeof detail === "string" && detail.toLowerCase().includes("grandes demais");
     return {
-      title: isTooLarge ? "Resultado muito grande" : "Formato não suportado",
+      title: isTooLarge
+        ? t("ui.download.errors.tooLargeTitle")
+        : t("ui.download.errors.unsupportedTitle"),
       description:
         detail ||
         (isTooLarge
-          ? "Estes resultados são grandes demais para baixar em um único arquivo."
-          : "O formato solicitado não está disponível para download."),
+          ? t("ui.download.errors.tooLargeDescription")
+          : t("ui.download.errors.unsupportedDescription")),
     };
   }
 
   if (status === 404) {
     return {
-      title: "Resultado não encontrado",
-      description:
-        "Não encontramos esse resultado. Ele pode ter expirado ou pertencer a outra conversa.",
+      title: t("ui.download.errors.notFoundTitle"),
+      description: t("ui.download.errors.notFoundDescription"),
     };
   }
 
@@ -110,8 +111,8 @@ function getExportErrorInfo(error) {
     typeof error?.message === "string" ? error.message.replace(/^\[Chatbot\]\s*/, "") : "";
 
   return {
-    title: "Falha ao baixar",
-    description: message || "Não foi possível baixar o resultado. Tente novamente.",
+    title: t("ui.download.errors.genericTitle"),
+    description: message || t("ui.download.errors.genericDescription"),
   };
 }
 
@@ -166,7 +167,7 @@ function DownloadToastContent({ status, title, description }) {
   );
 }
 
-async function downloadQueryResult({ toast, onExport, messageId, artifact }) {
+async function downloadQueryResult({ toast, onExport, messageId, artifact, t }) {
   if (!artifact?.query_ref) {
     console.error("downloadQueryResult: artifact sem query_ref", artifact);
     return false;
@@ -184,7 +185,10 @@ async function downloadQueryResult({ toast, onExport, messageId, artifact }) {
     duration: null,
     position: "bottom",
     render: () => (
-      <DownloadToastContent status="loading" title="Preparando o download..." />
+      <DownloadToastContent
+        status="loading"
+        title={t("ui.download.preparing")}
+      />
     ),
   });
 
@@ -201,13 +205,15 @@ async function downloadQueryResult({ toast, onExport, messageId, artifact }) {
 
     toast.update(toastId, {
       duration: 2500,
-      render: () => <DownloadToastContent status="success" title="Download iniciado" />,
+      render: () => (
+        <DownloadToastContent status="success" title={t("ui.download.started")} />
+      ),
     });
 
     return true;
   } catch (error) {
     console.error("Erro ao exportar resultado da consulta:", error);
-    const { title, description } = getExportErrorInfo(error);
+    const { title, description } = getExportErrorInfo(error, t);
 
     toast.update(toastId, {
       duration: 6000,
@@ -222,6 +228,7 @@ async function downloadQueryResult({ toast, onExport, messageId, artifact }) {
 }
 
 export function DownloadResultButton({ messageId, artifact, onExport, disabled }) {
+  const { t } = useTranslation("chatbot");
   const [status, setStatus] = useState("idle");
   const toast = useToast();
 
@@ -230,7 +237,7 @@ export function DownloadResultButton({ messageId, artifact, onExport, disabled }
     if (disabled || status === "loading" || !onExport || !messageId || !artifact) return;
 
     setStatus("loading");
-    const success = await downloadQueryResult({ toast, onExport, messageId, artifact });
+    const success = await downloadQueryResult({ toast, onExport, messageId, artifact, t });
     setStatus(success ? "idle" : "error");
     if (!success) {
       setTimeout(() => setStatus("idle"), 2000);
@@ -238,10 +245,10 @@ export function DownloadResultButton({ messageId, artifact, onExport, disabled }
   };
 
   const label = disabled
-    ? "Disponível assim que a resposta terminar"
+    ? t("ui.download.availableWhenDone")
     : status === "error"
-    ? "Falha ao baixar. Tente novamente."
-    : "Baixar CSV";
+    ? t("ui.download.retry")
+    : t("ui.download.csv");
 
   return (
     <Tooltip {...ActionTooltipProps} label={label}>
@@ -268,6 +275,7 @@ export function DownloadResultButton({ messageId, artifact, onExport, disabled }
 }
 
 export function DownloadResultsButton({ messageId, downloads, onExport }) {
+  const { t } = useTranslation("chatbot");
   const [statusByRef, setStatusByRef] = useState({});
   const toast = useToast();
 
@@ -279,7 +287,7 @@ export function DownloadResultsButton({ messageId, downloads, onExport }) {
     }
 
     setStatusByRef((prev) => ({ ...prev, [artifact.query_ref]: "loading" }));
-    const success = await downloadQueryResult({ toast, onExport, messageId, artifact });
+    const success = await downloadQueryResult({ toast, onExport, messageId, artifact, t });
     setStatusByRef((prev) => ({ ...prev, [artifact.query_ref]: success ? null : "error" }));
     if (!success) {
       setTimeout(() => {
@@ -294,7 +302,7 @@ export function DownloadResultsButton({ messageId, downloads, onExport }) {
         <>
           <Tooltip
             {...ActionTooltipProps}
-            label="Baixar resultados"
+            label={t("ui.download.label")}
             isDisabled={isOpen}
           >
             <MenuButton
@@ -346,7 +354,7 @@ export function DownloadResultsButton({ messageId, downloads, onExport }) {
                       )}
                       {status === "error" && (
                         <Box as="span" color="#E53E3E">
-                          Erro
+                          {t("ui.error")}
                         </Box>
                       )}
                     </Flex>

--- a/next/components/organisms/chatbot/FeedbackModal.js
+++ b/next/components/organisms/chatbot/FeedbackModal.js
@@ -4,6 +4,7 @@ import {
   Stack,
   Textarea,
 } from "@chakra-ui/react";
+import { useTranslation } from "next-i18next";
 import TitleText from "../../atoms/Text/TitleText";
 import {
   ModalGeneral,
@@ -18,6 +19,7 @@ export default function FeedbackModal({
   onSubmit,
   isSubmitting,
 }) {
+  const { t } = useTranslation("chatbot");
   const [feedbackText, setFeedbackText] = useState("");
   const isPositive = rating === 1;
 
@@ -41,7 +43,7 @@ export default function FeedbackModal({
       }}
     >
       <Stack spacing={0} marginBottom="16px">
-        <TitleText marginRight="24px">Feedback</TitleText>
+        <TitleText marginRight="24px">{t("ui.feedback.title")}</TitleText>
         <ModalCloseButton
           fontSize="14px"
           top="34px"
@@ -53,7 +55,7 @@ export default function FeedbackModal({
 
       <Stack spacing="16px" marginBottom="24px">
         <ExtraInfoTextForm marginBottom="0">
-          Dê os detalhes: (opcional)
+          {t("ui.feedback.detailsLabel")}
         </ExtraInfoTextForm>
 
         <Textarea
@@ -61,8 +63,8 @@ export default function FeedbackModal({
           onChange={(e) => setFeedbackText(e.target.value)}
           placeholder={
             isPositive
-              ? "O que foi satisfatório na resposta?"
-              : "O que foi insatisfatório na resposta?"
+              ? t("ui.feedback.positivePlaceholder")
+              : t("ui.feedback.negativePlaceholder")
           }
           minHeight="120px"
           resize="vertical"
@@ -100,7 +102,7 @@ export default function FeedbackModal({
           minWidth="120px"
           onClick={onClose}
         >
-          Cancelar
+          {t("ui.cancel")}
         </Button>
 
         <Button
@@ -109,7 +111,7 @@ export default function FeedbackModal({
           onClick={handleSubmit}
           isLoading={isSubmitting}
         >
-          Enviar
+          {t("ui.send")}
         </Button>
       </Stack>
     </ModalGeneral>

--- a/next/components/organisms/chatbot/Message.js
+++ b/next/components/organisms/chatbot/Message.js
@@ -7,6 +7,7 @@ import {
 } from "@chakra-ui/react";
 import { keyframes } from "@emotion/react";
 import React, { useMemo, useState } from "react";
+import { useTranslation } from "next-i18next";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm-v3";
 
@@ -66,6 +67,7 @@ const ActionButtonProps = {
 };
 
 function Message({ message, onFeedback, onExport, showFollowUpQuestions = false, onFollowUpClick }) {
+  const { t } = useTranslation("chatbot");
   const isUser = message.role === "user";
   const [feedback, setFeedback] = useState(message.rating ?? null);
   const [isFeedbackModalOpen, setIsFeedbackModalOpen] = useState(false);
@@ -129,7 +131,7 @@ function Message({ message, onFeedback, onExport, showFollowUpQuestions = false,
           fontSize="14px"
           lineHeight="20px"
         >
-          Obrigado pelo seu feedback!
+          {t("ui.feedback.thanks")}
         </Box>
       ),
     });
@@ -268,7 +270,7 @@ function Message({ message, onFeedback, onExport, showFollowUpQuestions = false,
                 <Flex gap="8px" alignItems="center">
                   <Tooltip
                     {...ActionTooltipProps}
-                    label={isCopied ? "Copiado!" : "Copiar resposta"}
+                    label={isCopied ? t("ui.copied") : t("ui.copyResponse")}
                   >
                     <Box
                       {...ActionButtonProps}
@@ -295,7 +297,7 @@ function Message({ message, onFeedback, onExport, showFollowUpQuestions = false,
                 </Flex>
 
                 <Flex gap="8px">
-                  <Tooltip {...ActionTooltipProps} label="Boa resposta">
+                  <Tooltip {...ActionTooltipProps} label={t("ui.goodResponse")}>
                     <Box
                       {...ActionButtonProps}
                       cursor={feedback != null ? "default" : "pointer"}
@@ -309,7 +311,7 @@ function Message({ message, onFeedback, onExport, showFollowUpQuestions = false,
                       <ThumbUpIcon width="18px" height="18px" />
                     </Box>
                   </Tooltip>
-                  <Tooltip {...ActionTooltipProps} label="Resposta ruim">
+                  <Tooltip {...ActionTooltipProps} label={t("ui.badResponse")}>
                     <Box
                       {...ActionButtonProps}
                       cursor={feedback != null ? "default" : "pointer"}

--- a/next/components/organisms/chatbot/OnboardingQuestions.js
+++ b/next/components/organisms/chatbot/OnboardingQuestions.js
@@ -1,5 +1,6 @@
 import { Box, Text } from "@chakra-ui/react";
 import { keyframes } from "@emotion/react";
+import { useTranslation } from "next-i18next";
 import DataStructureIcon from "../../../public/img/icons/dataStructureIcon";
 import TableChartViewIcon from "../../../public/img/icons/tableChartViewIcon";
 import DocIcon from "../../../public/img/icons/docIcon";
@@ -9,26 +10,7 @@ const fadeInUp = keyframes`
   to   { opacity: 1; transform: translateY(0); }
 `;
 
-export const OnboardingSuggestedQuestions = [
-  {
-    eyebrow: "Análises",
-    Icon: TableChartViewIcon,
-    question:
-      "Cruze os dados do CAGED e os dados de inflação do IPCA para calcular o Salário Real Médio das novas contratações em Recife no ano de 2025",
-  },
-  {
-    eyebrow: "Dados",
-    Icon: DataStructureIcon,
-    question:
-      "Qual é a diferença salarial média entre homens e mulheres no estado de São Paulo ao longo dos últimos cinco anos?",
-  },
-  {
-    eyebrow: "Documentos",
-    Icon: DocIcon,
-    question:
-      "Como estão organizados os dados de raça e cor na tabela de vínculos da RAIS e quais são os códigos utilizados no dicionário?",
-  },
-];
+const OnboardingIcons = [DataStructureIcon, TableChartViewIcon, DocIcon];
 
 const QuestionChipProps = {
   as: "button",
@@ -71,11 +53,15 @@ const QuestionChipProps = {
 };
 
 export default function OnboardingQuestions({ onQuestionClick, isDisabled }) {
-  const items = Array.isArray(OnboardingSuggestedQuestions)
-    ? OnboardingSuggestedQuestions.filter((item) =>
-        String(item?.question || "").trim()
-      )
-    : [];
+  const { t } = useTranslation("chatbot");
+  const rawItems = t("ui.onboarding.items", { returnObjects: true });
+  const items = (Array.isArray(rawItems) ? rawItems : [])
+    .map((item, index) => ({
+      eyebrow: item?.eyebrow,
+      question: item?.question,
+      Icon: OnboardingIcons[index] ?? DocIcon,
+    }))
+    .filter((item) => String(item?.question || "").trim());
 
   if (items.length === 0) return null;
 

--- a/next/components/organisms/chatbot/PulseDotLoader.js
+++ b/next/components/organisms/chatbot/PulseDotLoader.js
@@ -1,5 +1,6 @@
 import { Box } from "@chakra-ui/react";
 import { keyframes } from "@emotion/react";
+import { useTranslation } from "next-i18next";
 
 const dotSize = 8;
 const dotColor = "#2B8C4D";
@@ -10,12 +11,13 @@ const breathe = keyframes`
 `;
 
 export default function PulseDotLoader({ ...props }) {
+  const { t } = useTranslation("chatbot");
   return (
     <Box
       width={`${dotSize}px`}
       height={`${dotSize}px`}
       role="status"
-      aria-label="Pensando"
+      aria-label={t("ui.thinkingAria")}
       {...props}
     >
       <Box

--- a/next/components/organisms/chatbot/Search.js
+++ b/next/components/organisms/chatbot/Search.js
@@ -13,6 +13,7 @@ import {
   Box,
   Textarea,
 } from "@chakra-ui/react";
+import { useTranslation } from "next-i18next";
 import BodyText from "../../atoms/Text/BodyText";
 import SendIcon from "../../../public/img/icons/sendIcon";
 
@@ -30,6 +31,7 @@ const Search = forwardRef(function Search({
   isGenerating,
   showDisclaimer = true,
 }, ref) {
+  const { t } = useTranslation("chatbot");
   const textareaRef = useRef(null);
   const [isMultiLine, setIsMultiLine] = useState(false);
   const [value, setValue] = useState("");
@@ -173,10 +175,10 @@ const Search = forwardRef(function Search({
             transition="opacity 0.2s ease"
             placeholder={
               isBusy
-                ? "Faça uma pergunta..."
+                ? t("ui.search.placeholder")
                 : !showDisclaimer
-                  ? "Como posso ajudar você hoje?"
-                  : "Faça uma pergunta..."
+                  ? t("ui.helpQuestion")
+                  : t("ui.search.placeholder")
             }
             variant="unstyled"
             minHeight="38px"
@@ -250,12 +252,10 @@ const Search = forwardRef(function Search({
           textAlign="center"
         >
           <BodyText typography="small" color="#ACAEB1">
-            O chatbot pode cometer erros. Considere verificar informações
-            importantes.
+            {t("ui.search.disclaimer")}
           </BodyText>
           <BodyText typography="small" color="#ACAEB1">
-            Todas as informações aqui enviadas são registradas para análise e
-            melhoria do produto.
+            {t("ui.search.disclaimerPrivacy")}
           </BodyText>
         </VStack>
       )}

--- a/next/components/organisms/chatbot/Sidebar.js
+++ b/next/components/organisms/chatbot/Sidebar.js
@@ -8,7 +8,7 @@ import {
   useMediaQuery,
 } from '@chakra-ui/react'
 import { useTranslation } from 'next-i18next'
-import BDLogoImage from '../../../public/img/logos/bd_logo'
+import BrandLogo from './BrandLogo'
 import { clearClientSession } from '../../../utils'
 import SidebarIcon from '../../../public/img/icons/sidebarIcon'
 import CrossIcon from '../../../public/img/icons/crossIcon'
@@ -119,11 +119,11 @@ function Sidebar({
             position="relative"
             left="-2px"
           >
-            <BDLogoImage widthImage="58px" heightImage="25px" />
+            <BrandLogo widthImage="58px" heightImage="25px" />
           </Box>
 
           {!isOpen && !isHovering && (
-            <BDLogoImage
+            <BrandLogo
               display={{ base: "none", md: "block" }}
               widthImage="34px"
               heightImage="34px"

--- a/next/components/organisms/chatbot/Sidebar.js
+++ b/next/components/organisms/chatbot/Sidebar.js
@@ -7,6 +7,7 @@ import {
   HStack,
   useMediaQuery,
 } from '@chakra-ui/react'
+import { useTranslation } from 'next-i18next'
 import BDLogoImage from '../../../public/img/logos/bd_logo'
 import { clearClientSession } from '../../../utils'
 import SidebarIcon from '../../../public/img/icons/sidebarIcon'
@@ -22,6 +23,7 @@ function Sidebar({
   isMobileOpen = false,
   onMobileClose,
 }) {
+  const { t } = useTranslation('chatbot')
   const [isExpanded, setIsExpanded] = useState(true)
   const [isHovering, setIsHovering] = useState(false)
   const [isMobile] = useMediaQuery("(max-width: 767px)")
@@ -147,7 +149,7 @@ function Sidebar({
               backgroundColor: "#EEEEEE",
             }}
             onClick={handleToggle}
-            aria-label={isMobile ? "Fechar menu" : isExpanded ? "Recolher menu" : "Expandir menu"}
+            aria-label={isMobile ? t("ui.sidebar.closeMenu") : isExpanded ? t("ui.sidebar.collapseMenu") : t("ui.sidebar.expandMenu")}
           >
             <SidebarIcon
               width="18px"
@@ -219,7 +221,7 @@ function Sidebar({
               transition="opacity 0.2s ease, transform 0.2s ease, width 0.2s ease"
               transform={isOpen ? "translateX(0)" : "translateX(4px)"}
             >
-              Nova conversa
+              {t("ui.newChat")}
             </BodyText>
           </Box>
           <Box
@@ -278,7 +280,7 @@ function Sidebar({
               whiteSpace="nowrap"
               transition="opacity 0.2s ease, width 0.2s ease"
             >
-              Sair
+              {t("ui.signOut")}
             </BodyText>
           </HStack>
         </Box>

--- a/next/components/organisms/chatbot/StructuredResponse.js
+++ b/next/components/organisms/chatbot/StructuredResponse.js
@@ -5,6 +5,7 @@ import {
 } from "@chakra-ui/react";
 import { ArrowForwardIcon } from "@chakra-ui/icons";
 import React from "react";
+import { useTranslation } from "next-i18next";
 
 import BodyText from "../../atoms/Text/BodyText";
 import Link from "../../atoms/Link";
@@ -35,12 +36,13 @@ export function StructuredSectionHeader({ title }) {
 }
 
 export const DataSourcesList = React.memo(function DataSourcesList({ dataSources }) {
+  const { t } = useTranslation("chatbot");
   if (!Array.isArray(dataSources) || dataSources.length === 0) return null;
 
   return (
     <Box marginTop="8px">
       <Box paddingX="16px">
-        <StructuredSectionHeader title="Fontes dos Dados" />
+        <StructuredSectionHeader title={t("ui.sources.title")} />
       </Box>
       <VStack align="stretch" spacing={0} marginTop="4px" width="100%">
         {dataSources.map((source, index) => {
@@ -130,12 +132,13 @@ export const DataSourcesList = React.memo(function DataSourcesList({ dataSources
 });
 
 export const FollowUpQuestionsList = React.memo(function FollowUpQuestionsList({ followUpQuestions, onQuestionClick }) {
+  const { t } = useTranslation("chatbot");
   if (!Array.isArray(followUpQuestions) || followUpQuestions.length === 0) return null;
 
   return (
     <Box marginTop="24px">
       <Box paddingX="16px">
-        <StructuredSectionHeader title="Perguntas Sugeridas" />
+        <StructuredSectionHeader title={t("ui.suggestedQuestions")} />
       </Box>
       <VStack
         align="stretch"

--- a/next/components/organisms/chatbot/ThinkingSection.js
+++ b/next/components/organisms/chatbot/ThinkingSection.js
@@ -8,6 +8,7 @@ import {
 } from "@chakra-ui/react";
 import { ChevronDownIcon } from "@chakra-ui/icons";
 import React, { useState } from "react";
+import { useTranslation } from "next-i18next";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm-v3";
 
@@ -27,43 +28,20 @@ import {
 } from "./markdown";
 import { pensandoTextShimmer } from "./shimmer";
 
-const ToolPhrases = {
-  search_datasets: {
-    running: "Buscando conjuntos de dados",
-    done: "Conjuntos de dados encontrados",
-    Icon: SearchIcon,
-  },
-  get_dataset_details: {
-    running: "Explorando conjunto de dados",
-    done: "Conjunto de dados explorado",
-    Icon: DataBaseIcon,
-  },
-  get_table_details: {
-    running: "Explorando estrutura da tabela",
-    done: "Estrutura da tabela explorada",
-    Icon: DataStructureIcon,
-  },
-  execute_bigquery_sql: {
-    running: "Consultando o BigQuery",
-    done: "Consulta ao BigQuery concluída",
-    Icon: CodeIcon,
-  },
-  decode_table_values: {
-    running: "Decodificando valores da tabela",
-    done: "Valores da tabela decodificados",
-    Icon: DataStructureIcon,
-  },
+const ToolIcons = {
+  search_datasets: SearchIcon,
+  get_dataset_details: DataBaseIcon,
+  get_table_details: DataStructureIcon,
+  execute_bigquery_sql: CodeIcon,
+  decode_table_values: DataStructureIcon,
 };
 
-const FallbackToolPhrases = {
-  running: "Executando ferramenta",
-  done: "Ferramenta executada",
-  Icon: CodeIcon,
-};
-
-function getToolStepMeta(name, { done = false } = {}) {
-  const phrases = ToolPhrases[name] ?? FallbackToolPhrases;
-  return { label: done ? phrases.done : phrases.running, Icon: phrases.Icon };
+function getToolStepMeta(name, { done = false, t } = {}) {
+  const Icon = ToolIcons[name] ?? CodeIcon;
+  const keyBase = ToolIcons[name]
+    ? `ui.thinking.tools.${name}`
+    : "ui.thinking.tools.fallback";
+  return { label: t(`${keyBase}.${done ? "done" : "running"}`), Icon };
 }
 
 function isPlainObject(value) {
@@ -208,13 +186,14 @@ function ToolStepItem({
   messageLoading,
   onExport,
 }) {
+  const { t } = useTranslation("chatbot");
   const [isOpen, setIsOpen] = useState(false);
   const isOrphan = step.kind === "orphan_output";
   const call = isOrphan ? null : step.call;
   const status = isLoadingStep ? "loading" : "done";
   const { label, Icon } = isOrphan
-    ? { label: "Resultado adicional", Icon: CodeIcon }
-    : getToolStepMeta(call?.name, { done: status === "done" });
+    ? { label: t("ui.thinking.additionalResult"), Icon: CodeIcon }
+    : getToolStepMeta(call?.name, { done: status === "done", t });
   const hasOutput = Boolean(formatToolOutputText(step.output));
   const downloadProps =
     step.output?.artifact?.type === "query_result"
@@ -330,7 +309,7 @@ function ToolStepItem({
                   textTransform="uppercase"
                   letterSpacing="5%"
                 >
-                  Solicitação
+                  {t("ui.thinking.request")}
                 </BodyText>
                 <SolicitationArgsBlocks call={call} downloadProps={downloadProps} />
               </VStack>
@@ -354,7 +333,7 @@ function ToolStepItem({
                   textTransform="uppercase"
                   letterSpacing="5%"
                 >
-                  Resultado
+                  {t("ui.thinking.result")}
                 </BodyText>
                 <ToolResultView output={step.output} />
               </VStack>

--- a/next/components/organisms/chatbot/ThreadList.js
+++ b/next/components/organisms/chatbot/ThreadList.js
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import { useRouter } from 'next/router';
+import { useTranslation } from 'next-i18next';
 import {
   VStack,
   Box,
@@ -25,6 +26,7 @@ import TrashIcon from '../../../public/img/icons/trashIcon';
 import ReloadIcon from '../../../public/img/icons/reloadIcon';
 
 export default function ThreadList({ onSelectThread, currentThreadId, isSidebarOpen, onNewChat }) {
+  const { t } = useTranslation('chatbot');
   const router = useRouter();
   const { threads, isLoading, error, refetch, deleteThread, isDeleting } = useChatbotContext();
   const deleteModal = useDisclosure();
@@ -114,7 +116,7 @@ export default function ThreadList({ onSelectThread, currentThreadId, isSidebarO
       >
         <Stack spacing={0} marginBottom="16px">
           <TitleText marginRight="20px">
-            Confirmar exclusão de conversa
+            {t('ui.thread.deleteTitle')}
           </TitleText>
           <ModalCloseButton
             fontSize="14px"
@@ -127,8 +129,7 @@ export default function ThreadList({ onSelectThread, currentThreadId, isSidebarO
 
         <Stack spacing="24px" marginBottom="16px">
           <ExtraInfoTextForm>
-            Tem certeza que deseja excluir esta conversa? Esta ação não pode ser
-            desfeita.
+            {t('ui.thread.deleteConfirm')}
           </ExtraInfoTextForm>
         </Stack>
 
@@ -149,7 +150,7 @@ export default function ThreadList({ onSelectThread, currentThreadId, isSidebarO
             }}
             onClick={() => deleteModal.onClose()}
           >
-            Cancelar
+            {t('ui.cancel')}
           </Button>
 
           <Button
@@ -161,7 +162,7 @@ export default function ThreadList({ onSelectThread, currentThreadId, isSidebarO
             onClick={() => confirmDelete()}
             isLoading={isDeleting}
           >
-            Excluir
+            {t('ui.delete')}
           </Button>
         </Stack>
       </ModalGeneral>
@@ -197,7 +198,7 @@ export default function ThreadList({ onSelectThread, currentThreadId, isSidebarO
                 transition="opacity 0.2s ease, transform 0.2s ease"
                 transform={isSidebarOpen ? "translateX(0)" : "translateX(4px)"}
               >
-                Conversas
+                {t('ui.thread.historyTitle')}
               </BodyText>
               {isSidebarOpen && <AccordionIcon color="#252A32" />}
             </AccordionButton>
@@ -223,8 +224,8 @@ export default function ThreadList({ onSelectThread, currentThreadId, isSidebarO
                       isSidebarOpen ? "translateX(0)" : "translateX(4px)"
                     }
                   >
-                    <span>Erro ao carregar histórico.</span>
-                    <span>Tente novamente.</span>
+                    <span>{t('ui.thread.loadError')}</span>
+                    <span>{t('ui.thread.tryAgain')}</span>
                   </BodyText>
                   <ReloadIcon
                     cursor="pointer"

--- a/next/components/organisms/chatbot/markdown.js
+++ b/next/components/organisms/chatbot/markdown.js
@@ -16,6 +16,7 @@ import {
   Tooltip,
 } from "@chakra-ui/react";
 import React, { useMemo, useState } from "react";
+import { useTranslation } from "next-i18next";
 
 import "highlight.js/styles/github.css";
 import hljs from "highlight.js/lib/core";
@@ -54,6 +55,7 @@ export function CodeBlock({
   downloadProps = null,
   title = null,
 }) {
+  const { t } = useTranslation("chatbot");
   const code = String(children).replace(/\n$/, "");
   const { hasCopied, onCopy } = useClipboard(code);
   const hasHeader = title != null;
@@ -83,7 +85,7 @@ export function CodeBlock({
     <Flex alignItems="center" gap="8px" flexShrink={0}>
       <Tooltip
         {...ActionTooltipProps}
-        label={hasCopied ? "Copiado!" : "Copiar"}
+        label={hasCopied ? t("ui.copied") : t("ui.copy")}
       >
         <Box
           cursor="pointer"
@@ -375,6 +377,7 @@ function orderColumnsWithIdLast(columns, moveIdToEnd) {
 }
 
 function TruncatableCellContent({ text, maxChars }) {
+  const { t } = useTranslation("chatbot");
   const [expanded, setExpanded] = useState(false);
 
   if (!maxChars || text.length <= maxChars) {
@@ -401,7 +404,7 @@ function TruncatableCellContent({ text, maxChars }) {
           _hover={{ textDecoration: "underline" }}
           onClick={() => setExpanded(false)}
         >
-          ver menos
+          {t("ui.table.seeLess")}
         </Text>
       </>
     );
@@ -426,7 +429,7 @@ function TruncatableCellContent({ text, maxChars }) {
         _hover={{ textDecoration: "underline" }}
         onClick={() => setExpanded(true)}
       >
-        ver mais
+        {t("ui.table.seeMore")}
       </Text>
     </>
   );
@@ -546,6 +549,7 @@ function RecordsTable({
   moveIdToEnd = false,
   truncateCellMaxChars,
 }) {
+  const { t } = useTranslation("chatbot");
   const columns = [];
   const seen = new Set();
   for (const row of records) {
@@ -612,7 +616,7 @@ function RecordsTable({
       </ToolResultTableContainer>
       {records.length > MaxTableRows && (
         <Text fontSize="12px" color="#71757A" marginTop="4px">
-          Mostrando {MaxTableRows} de {records.length} resultados
+          {t("ui.table.showingRows", { shown: MaxTableRows, total: records.length })}
         </Text>
       )}
     </Box>

--- a/next/components/organisms/componentsUserPage/PlansAndPayment.js
+++ b/next/components/organisms/componentsUserPage/PlansAndPayment.js
@@ -24,6 +24,7 @@ import Toggle from "../../atoms/Toggle";
 import { SectionPrice } from "../../../pages/prices";
 import PaymentSystem from "../../organisms/PaymentSystem";
 import { triggerGAEvent, triggerGAEventWithData, hasBDProSubscription, hasChatbotSubscription, getChatbotStreamlitAppUrl, getSubscriptionStatusKey, isSubscriptionTrialing } from "../../../utils";
+import { selectPlans } from "../../../constants/stripePlans";
 
 const SubscriptionBadgeStyles = {
   active: { backgroundColor: "#D5E8DB", color: "#2B8C4D" },
@@ -198,39 +199,7 @@ export default function PlansAndPayment ({ userData }) {
           .then(res => res.json())
 
         if(result.success === true) {
-          function filterData(productName, interval, isActive, amount) {
-            let array = result.data
-
-            return array.filter(item => 
-              (productName ? item.node.productName === productName : true) &&
-              (interval ? item.node.interval === interval : true) &&
-              (amount ? item.node.amount === amount : true) &&
-              (isActive !== undefined ? item.node.isActive === isActive : true)
-            )
-          }
-
-          function filterChatbot(interval, amount) {
-            return result.data.filter((item) => {
-              const name = item.node.productName?.toLowerCase() || ""
-              const slug = item.node.productSlug?.toLowerCase() || ""
-              const isConsumerChatbot =
-                (name.includes("chatbot") || slug.includes("chatbot")) &&
-                !name.includes("empresas")
-              return isConsumerChatbot &&
-                item.node.interval === interval &&
-                item.node.amount === amount &&
-                item.node.isActive === true
-            })
-          }
-
-          const filteredPlans = {
-            bd_pro_month : filterData("BD Pro", "month", true, 47)[0].node,
-            bd_pro_year : filterData("BD Pro", "year", true, 444)[0].node,
-            bd_chatbot_month : filterChatbot("month", 30)[0]?.node,
-            bd_chatbot_year : filterChatbot("year", 326)[0]?.node,
-          }
-
-          setPlans(filteredPlans)
+          setPlans(selectPlans(result.data))
         }
       } catch (error) {
         console.error(error)

--- a/next/components/organisms/componentsUserPage/PlansAndPayment.js
+++ b/next/components/organisms/componentsUserPage/PlansAndPayment.js
@@ -24,7 +24,7 @@ import Toggle from "../../atoms/Toggle";
 import { SectionPrice } from "../../../pages/prices";
 import PaymentSystem from "../../organisms/PaymentSystem";
 import { triggerGAEvent, triggerGAEventWithData, hasBDProSubscription, hasChatbotSubscription, getChatbotStreamlitAppUrl, getSubscriptionStatusKey, isSubscriptionTrialing } from "../../../utils";
-import { selectPlans } from "../../../constants/stripePlans";
+import { selectPlans, localeToRegion, formatCurrency } from "../../../constants/stripePlans";
 
 const SubscriptionBadgeStyles = {
   active: { backgroundColor: "#D5E8DB", color: "#2B8C4D" },
@@ -199,7 +199,7 @@ export default function PlansAndPayment ({ userData }) {
           .then(res => res.json())
 
         if(result.success === true) {
-          setPlans(selectPlans(result.data))
+          setPlans(selectPlans(result.data, localeToRegion(router.locale)))
         }
       } catch (error) {
         console.error(error)
@@ -645,7 +645,7 @@ export default function PlansAndPayment ({ userData }) {
           <Text>{t('username.coupon')} {coupon.toUpperCase()} {limitText}</Text>
         </GridItem>
         <GridItem textAlign="end">
-          <Text>- {couponInfos?.discountAmount?.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL', minimumFractionDigits: 2 })}/{formattedPlanInterval(checkoutInfos?.interval, true)}</Text>
+          <Text>- {formatCheckoutAmount(couponInfos?.discountAmount)}/{formattedPlanInterval(checkoutInfos?.interval, true)}</Text>
         </GridItem>
       </>
     )
@@ -659,11 +659,9 @@ export default function PlansAndPayment ({ userData }) {
   }
 
   function formatCheckoutAmount(amount) {
-    return amount?.toLocaleString("pt-BR", {
-      style: "currency",
-      currency: "BRL",
-      minimumFractionDigits: 2,
-    })
+    // Currency follows the selected plan's region (br → BRL, latam/intl → USD),
+    // matching what the storefront showed and what the backend webhook charges.
+    return formatCurrency(amount, checkoutInfos?.region)
   }
 
   const TotalToPayDisplay = () => {
@@ -964,11 +962,7 @@ export default function PlansAndPayment ({ userData }) {
                 </GridItem>
                 <GridItem textAlign="end">
                   <Text>
-                    {checkoutInfos?.amount?.toLocaleString("pt-BR", {
-                      style: "currency",
-                      currency: "BRL",
-                      minimumFractionDigits: 2,
-                    })}
+                    {formatCheckoutAmount(checkoutInfos?.amount)}
                     /{formattedPlanInterval(checkoutInfos?.interval, true)}
                   </Text>
                 </GridItem>
@@ -987,11 +981,7 @@ export default function PlansAndPayment ({ userData }) {
                   º {formattedPlanInterval(checkoutInfos?.interval, true)}{" "}
                   {!hasSubscribed && "e 7º dia"}
                   {t("username.couponDuration", { returnObjects: true })[1]}
-                  {checkoutInfos?.amount?.toLocaleString("pt-BR", {
-                    style: "currency",
-                    currency: "BRL",
-                    minimumFractionDigits: 2,
-                  })}
+                  {formatCheckoutAmount(checkoutInfos?.amount)}
                   /{formattedPlanInterval(checkoutInfos?.interval, true)}.
                 </BodyText>
               )}

--- a/next/components/organisms/componentsUserPage/PlansAndPayment.js
+++ b/next/components/organisms/componentsUserPage/PlansAndPayment.js
@@ -332,6 +332,13 @@ export default function PlansAndPayment ({ userData }) {
   const isChatbotCheckout = checkoutInfos?.productName?.toLowerCase().includes("chatbot") || checkoutInfos?.productSlug?.toLowerCase().includes("chatbot")
   const hasSubscribed = isChatbotCheckout ? hasSubscribedChatbot : hasSubscribedBDPro
 
+  // Stripe product names are stored with the Portuguese brand ("BD Pro"). The English
+  // brand is "DB", so swap the brand token when rendering the product name in English.
+  const localizedProductName = (name) =>
+    router.locale === "en" && typeof name === "string"
+      ? name.replace(/\bBD\b/g, "DB")
+      : name
+
   function getCheckoutStepLabel() {
     if (checkoutStep === "plan") {
       return isChatbotCheckout ? t("username.step1of2") : t("username.step2of3")
@@ -828,7 +835,7 @@ export default function PlansAndPayment ({ userData }) {
               <Stack flexDirection="column" spacing={0} gap="16px">
                 <Box display="flex" flexDirection="row" gap="8px" width="100%">
                   <LabelText textTransform="capitalize">
-                    {checkoutInfos?.productName}
+                    {localizedProductName(checkoutInfos?.productName)}
                   </LabelText>
                   {!isChatbotCheckout && (
                     <BodyText
@@ -1067,7 +1074,7 @@ export default function PlansAndPayment ({ userData }) {
                     gap="16px"
                   >
                     <LabelText textTransform="capitalize">
-                      {checkoutInfos?.productName}
+                      {localizedProductName(checkoutInfos?.productName)}
                     </LabelText>
                     <BodyText typography="small" color="#71757A">
                       {formattedPlanInterval(checkoutInfos?.interval)}

--- a/next/components/organisms/componentsUserPage/PlansAndPayment.js
+++ b/next/components/organisms/componentsUserPage/PlansAndPayment.js
@@ -659,9 +659,9 @@ export default function PlansAndPayment ({ userData }) {
   }
 
   function formatCheckoutAmount(amount) {
-    // Currency follows the selected plan's region (br → BRL, latam/intl → USD),
-    // matching what the storefront showed and what the backend webhook charges.
-    return formatCurrency(amount, checkoutInfos?.region)
+    // Currency follows the domain (br → BRL, latam/intl → USD), matching the region whose price
+    // ids the storefront selected and what the backend webhook charges.
+    return formatCurrency(amount, localeToRegion(router.locale))
   }
 
   const TotalToPayDisplay = () => {

--- a/next/constants/stripePlans.js
+++ b/next/constants/stripePlans.js
@@ -1,0 +1,63 @@
+// The exact Stripe prices the site sells, selected by their stable Stripe price id ("price_…",
+// verifiable in the Stripe dashboard). Selecting by id is robust to other active prices existing
+// on the same product — legacy tiers, gift prices, and the per-currency prices being added for
+// the international rollout.
+//
+// These are the current consumer (BRL) prices. The international/USD prices are selected by the
+// upcoming currency logic, not here.
+//
+// The ids below are the production Stripe account's (staging shares the same account). Any
+// environment on a different Stripe account can override them via NEXT_PUBLIC_STRIPE_PRICE_IDS,
+// a JSON object keyed by the same plan keys.
+
+export const PLAN_KEYS = [
+  "bd_pro_month",
+  "bd_pro_year",
+  "bd_chatbot_month",
+  "bd_chatbot_year",
+]
+
+const DEFAULT_PRICE_IDS = {
+  bd_pro_month: "price_1OcrtHCKkCLMrYWYcxJtHMMa", // BD Pro — R$47/month
+  bd_pro_year: "price_1PWlKQCKkCLMrYWYxV3xodMC", // BD Pro — R$444/year
+  bd_chatbot_month: "price_1TCkdbCKkCLMrYWYFgOfi2cc", // Chatbot — R$30/month
+  bd_chatbot_year: "price_1TCkdwCKkCLMrYWYXQlflpIn", // Chatbot — R$326/year
+}
+
+function priceIds() {
+  let overrides = {}
+  try {
+    overrides = JSON.parse(process.env.NEXT_PUBLIC_STRIPE_PRICE_IDS || "{}")
+  } catch (e) {
+    console.error("Invalid NEXT_PUBLIC_STRIPE_PRICE_IDS JSON; ignoring it.", e)
+  }
+  return { ...DEFAULT_PRICE_IDS, ...overrides }
+}
+
+/**
+ * Resolve the plan nodes the site sells from the getPlans edges, by exact Stripe price id.
+ *
+ * @param {Array<{node: object}>} edges - getPlans result data (array of { node }).
+ * @returns {Record<string, object|undefined>} plan-key -> price node (undefined if the
+ *   configured id isn't among the active prices returned by getPlans).
+ */
+export function selectPlans(edges = []) {
+  const ids = priceIds()
+  const plans = {}
+
+  for (const key of PLAN_KEYS) {
+    const wantedId = ids[key]
+    const match = edges.find(({ node }) => node.stripePriceId === wantedId)
+
+    if (!match) {
+      console.warn(
+        `Stripe price "${key}" (${wantedId}) not found among active prices from getPlans — ` +
+          "check the id and that the price is active."
+      )
+    }
+
+    plans[key] = match?.node
+  }
+
+  return plans
+}

--- a/next/constants/stripePlans.js
+++ b/next/constants/stripePlans.js
@@ -1,17 +1,20 @@
-// The exact Stripe prices the site sells, selected by their stable Stripe price id ("price_…",
-// verifiable in the Stripe dashboard). Selecting by id is robust to other active prices existing
-// on the same product — legacy tiers, gift prices, and the per-currency prices added for the
-// international rollout.
+// The exact Stripe prices the site sells, pinned by their stable Stripe price id ("price_…",
+// verifiable in the Stripe dashboard) for each plan AND region. Selecting by id is deterministic:
+// a new, edited, or mis-tagged price in Stripe is simply ignored until its id is added here and the
+// site is redeployed. Nothing is inferred from price metadata, amounts, or intervals.
 //
-// The ids below anchor each plan to its consumer (BRL) price. On the international domains the
-// site shows the same plan in the visitor's currency by swapping to the price that carries the
-// matching `region` tag (same product and interval) — see selectPlans. This mirrors the backend
-// checkout webhook, which charges the region-correct price from the card's country, so what the
-// visitor sees is what they are charged.
+// Only the *selection* is pinned. The amount shown for each plan still comes live from the getPlans
+// GraphQL query, so a price change in Stripe reflects on the site automatically; only adding or
+// swapping which price is sold requires updating this map and redeploying.
+//
+// Currency follows the domain (see localeToRegion / regionCurrency): basedosdados.org bills BRL,
+// data-basis.org and basedelosdatos.org bill USD. The backend checkout webhook independently
+// enforces the region-correct price from the card's country (arbitrage guard), so what the visitor
+// sees here is what they are charged.
 //
 // The ids below are the production Stripe account's (staging shares the same account). Any
 // environment on a different Stripe account can override them via NEXT_PUBLIC_STRIPE_PRICE_IDS,
-// a JSON object keyed by the same plan keys.
+// a JSON object shaped like DEFAULT_PRICE_IDS below (keyed by region, then plan key).
 
 export const PLAN_KEYS = [
   "bd_pro_month",
@@ -20,17 +23,30 @@ export const PLAN_KEYS = [
   "bd_chatbot_year",
 ]
 
-// The three pricing regions, tagged on each Stripe price via its `region` metadata:
-//   br    — Brazil, in BRL (the anchor prices below)
-//   latam — Spanish-speaking Latin America, in USD
-//   intl  — the rest of the world, in USD
+// The three pricing regions the site sells in.
 const DEFAULT_REGION = "br"
 
+// Exact price id per region and plan. Amounts in the comments are for human reference only —
+// the live amount is read from getPlans, never from here.
 const DEFAULT_PRICE_IDS = {
-  bd_pro_month: "price_1OcrtHCKkCLMrYWYcxJtHMMa", // BD Pro — R$47/month
-  bd_pro_year: "price_1PWlKQCKkCLMrYWYxV3xodMC", // BD Pro — R$444/year
-  bd_chatbot_month: "price_1TCkdbCKkCLMrYWYFgOfi2cc", // Chatbot — R$30/month
-  bd_chatbot_year: "price_1TCkdwCKkCLMrYWYXQlflpIn", // Chatbot — R$326/year
+  br: {
+    bd_pro_month: "price_1OcrtHCKkCLMrYWYcxJtHMMa", // BD Pro — R$47/month
+    bd_pro_year: "price_1PWlKQCKkCLMrYWYxV3xodMC", // BD Pro — R$444/year
+    bd_chatbot_month: "price_1TCkdbCKkCLMrYWYFgOfi2cc", // Chatbot — R$30/month
+    bd_chatbot_year: "price_1TCkdwCKkCLMrYWYXQlflpIn", // Chatbot — R$326/year
+  },
+  latam: {
+    bd_pro_month: "price_1U0yCrCKkCLMrYWY2piPpKCg", // BD Pro — US$12/month
+    bd_pro_year: "price_1U0yE4CKkCLMrYWYsVrOB3i5", // BD Pro — US$115/year
+    bd_chatbot_month: "price_1U0yJSCKkCLMrYWYj2DSeGa8", // Chatbot — US$8/month
+    bd_chatbot_year: "price_1U0yJtCKkCLMrYWYOs7xvfpL", // Chatbot — US$77/year
+  },
+  intl: {
+    bd_pro_month: "price_1U0dw1CKkCLMrYWYUkFlGyHA", // BD Pro — US$19/month
+    bd_pro_year: "price_1U0yBTCKkCLMrYWYDXo7NRwV", // BD Pro — US$180/year
+    bd_chatbot_month: "price_1U0yHZCKkCLMrYWYR4KtKTSQ", // Chatbot — US$15/month
+    bd_chatbot_year: "price_1U0yIGCKkCLMrYWYrE2FzOLt", // Chatbot — US$144/year
+  },
 }
 
 /**
@@ -58,8 +74,8 @@ export function localeToRegion(locale) {
 /**
  * Currency presentation for a pricing region.
  *
- * br bills in BRL; latam and intl bill in USD. USD is formatted en-US ("$19.00")
- * and BRL pt-BR ("R$ 47,00").
+ * br bills in BRL; latam and intl bill in USD. USD is formatted en-US ("$19.00") and BRL pt-BR
+ * ("R$ 47,00").
  *
  * @param {"br"|"latam"|"intl"} region
  * @returns {{code: string, locale: string, symbol: string}}
@@ -78,8 +94,8 @@ export function regionCurrency(region) {
 /**
  * Format a numeric amount in the currency of a pricing region.
  *
- * Returns undefined for a nullish amount, preserving the `amount?.toLocaleString(...)`
- * semantics of the call sites this replaces (which render nothing until the amount loads).
+ * Returns undefined for a nullish amount, preserving the `amount?.toLocaleString(...)` semantics of
+ * the call sites this replaces (which render nothing until the amount loads).
  *
  * @param {number|undefined|null} amount
  * @param {"br"|"latam"|"intl"} region
@@ -96,68 +112,54 @@ export function formatCurrency(amount, region, { minimumFractionDigits = 2 } = {
   })
 }
 
-function priceIds() {
+/**
+ * Resolve the pinned price ids for a region, applying any environment override.
+ *
+ * NEXT_PUBLIC_STRIPE_PRICE_IDS, when set, is a JSON object shaped like DEFAULT_PRICE_IDS
+ * (region → plan key → id). Only the given region's entries override; the rest fall back to the
+ * defaults above.
+ *
+ * @param {"br"|"latam"|"intl"} region
+ * @returns {Record<string, string>} plan key → Stripe price id for this region.
+ */
+function priceIds(region) {
   let overrides = {}
   try {
     overrides = JSON.parse(process.env.NEXT_PUBLIC_STRIPE_PRICE_IDS || "{}")
   } catch (e) {
     console.error("Invalid NEXT_PUBLIC_STRIPE_PRICE_IDS JSON; ignoring it.", e)
   }
-  return { ...DEFAULT_PRICE_IDS, ...overrides }
+  return { ...DEFAULT_PRICE_IDS[region], ...(overrides[region] || {}) }
 }
 
 /**
- * Resolve the plan nodes the site sells from the getPlans edges.
+ * Resolve the plan nodes the site sells from the getPlans edges, by exact Stripe price id.
  *
- * Each plan is anchored to its BRL price by exact Stripe price id. For a non-BR region, the
- * anchor is swapped for the sibling price that carries the matching `region` tag and the same
- * product (`productSlug`) and `interval`. When no such sibling exists (or the region is br), the
- * BRL anchor is shown. This keeps id-based selection as the source of truth while adding the
- * currency dimension, and never shows a price for the wrong product or interval.
+ * Each plan is matched to the pinned id for the given region. No inference from amount, product, or
+ * interval, and no cross-region fallback: if a region's id is not among the active prices returned
+ * by getPlans, that plan resolves to undefined (and a warning is logged).
  *
  * @param {Array<{node: object}>} edges - getPlans result data (array of { node }).
  * @param {"br"|"latam"|"intl"} [region="br"] - pricing region for the current domain.
- * @returns {Record<string, object|undefined>} plan-key -> price node (undefined if the
- *   configured id isn't among the active prices returned by getPlans).
+ * @returns {Record<string, object|undefined>} plan key → price node (undefined if the pinned id
+ *   isn't among the active prices returned by getPlans).
  */
 export function selectPlans(edges = [], region = DEFAULT_REGION) {
-  const ids = priceIds()
+  const ids = priceIds(region)
   const plans = {}
 
   for (const key of PLAN_KEYS) {
     const wantedId = ids[key]
-    const anchor = edges.find(({ node }) => node.stripePriceId === wantedId)
+    const match = edges.find(({ node }) => node.stripePriceId === wantedId)
 
-    if (!anchor) {
+    if (!match) {
       console.warn(
-        `Stripe price "${key}" (${wantedId}) not found among active prices from getPlans — ` +
-          "check the id and that the price is active."
-      )
-      plans[key] = undefined
-      continue
-    }
-
-    if (region === DEFAULT_REGION) {
-      plans[key] = anchor.node
-      continue
-    }
-
-    // Swap to the regional sibling: same product and interval, tagged for this region.
-    const sibling = edges.find(
-      ({ node }) =>
-        node.region === region &&
-        node.productSlug === anchor.node.productSlug &&
-        node.interval === anchor.node.interval
-    )
-
-    if (!sibling) {
-      console.warn(
-        `No "${region}" price for plan "${key}" (${anchor.node.productSlug}/${anchor.node.interval}); ` +
-          "showing the BRL price. Add the regional price in Stripe with the matching `region` tag."
+        `Stripe price "${key}" for region "${region}" (${wantedId}) not found among active prices ` +
+          "from getPlans — check the id and that the price is active."
       )
     }
 
-    plans[key] = (sibling ?? anchor).node
+    plans[key] = match?.node
   }
 
   return plans

--- a/next/constants/stripePlans.js
+++ b/next/constants/stripePlans.js
@@ -1,10 +1,13 @@
 // The exact Stripe prices the site sells, selected by their stable Stripe price id ("price_…",
 // verifiable in the Stripe dashboard). Selecting by id is robust to other active prices existing
-// on the same product — legacy tiers, gift prices, and the per-currency prices being added for
-// the international rollout.
+// on the same product — legacy tiers, gift prices, and the per-currency prices added for the
+// international rollout.
 //
-// These are the current consumer (BRL) prices. The international/USD prices are selected by the
-// upcoming currency logic, not here.
+// The ids below anchor each plan to its consumer (BRL) price. On the international domains the
+// site shows the same plan in the visitor's currency by swapping to the price that carries the
+// matching `region` tag (same product and interval) — see selectPlans. This mirrors the backend
+// checkout webhook, which charges the region-correct price from the card's country, so what the
+// visitor sees is what they are charged.
 //
 // The ids below are the production Stripe account's (staging shares the same account). Any
 // environment on a different Stripe account can override them via NEXT_PUBLIC_STRIPE_PRICE_IDS,
@@ -17,11 +20,80 @@ export const PLAN_KEYS = [
   "bd_chatbot_year",
 ]
 
+// The three pricing regions, tagged on each Stripe price via its `region` metadata:
+//   br    — Brazil, in BRL (the anchor prices below)
+//   latam — Spanish-speaking Latin America, in USD
+//   intl  — the rest of the world, in USD
+const DEFAULT_REGION = "br"
+
 const DEFAULT_PRICE_IDS = {
   bd_pro_month: "price_1OcrtHCKkCLMrYWYcxJtHMMa", // BD Pro — R$47/month
   bd_pro_year: "price_1PWlKQCKkCLMrYWYxV3xodMC", // BD Pro — R$444/year
   bd_chatbot_month: "price_1TCkdbCKkCLMrYWYFgOfi2cc", // Chatbot — R$30/month
   bd_chatbot_year: "price_1TCkdwCKkCLMrYWYXQlflpIn", // Chatbot — R$326/year
+}
+
+/**
+ * Map the site locale (domain) to a pricing region.
+ *
+ * basedosdados.org (pt) → br, basedelosdatos.org (es) → latam, data-basis.org (en) → intl.
+ * Anything unknown falls back to the BRL region, the site's historical behavior.
+ *
+ * @param {string|undefined} locale - next-i18next locale for the current domain.
+ * @returns {"br"|"latam"|"intl"} the pricing region.
+ */
+export function localeToRegion(locale) {
+  switch (locale) {
+    case "en":
+      return "intl"
+    case "es":
+      return "latam"
+    case "pt":
+      return "br"
+    default:
+      return DEFAULT_REGION
+  }
+}
+
+/**
+ * Currency presentation for a pricing region.
+ *
+ * br bills in BRL; latam and intl bill in USD. USD is formatted en-US ("$19.00")
+ * and BRL pt-BR ("R$ 47,00").
+ *
+ * @param {"br"|"latam"|"intl"} region
+ * @returns {{code: string, locale: string, symbol: string}}
+ */
+export function regionCurrency(region) {
+  switch (region) {
+    case "intl":
+    case "latam":
+      return { code: "USD", locale: "en-US", symbol: "$" }
+    case "br":
+    default:
+      return { code: "BRL", locale: "pt-BR", symbol: "R$" }
+  }
+}
+
+/**
+ * Format a numeric amount in the currency of a pricing region.
+ *
+ * Returns undefined for a nullish amount, preserving the `amount?.toLocaleString(...)`
+ * semantics of the call sites this replaces (which render nothing until the amount loads).
+ *
+ * @param {number|undefined|null} amount
+ * @param {"br"|"latam"|"intl"} region
+ * @param {{minimumFractionDigits?: number}} [opts]
+ * @returns {string|undefined}
+ */
+export function formatCurrency(amount, region, { minimumFractionDigits = 2 } = {}) {
+  if (amount === null || amount === undefined) return undefined
+  const { code, locale } = regionCurrency(region)
+  return amount.toLocaleString(locale, {
+    style: "currency",
+    currency: code,
+    minimumFractionDigits,
+  })
 }
 
 function priceIds() {
@@ -35,28 +107,57 @@ function priceIds() {
 }
 
 /**
- * Resolve the plan nodes the site sells from the getPlans edges, by exact Stripe price id.
+ * Resolve the plan nodes the site sells from the getPlans edges.
+ *
+ * Each plan is anchored to its BRL price by exact Stripe price id. For a non-BR region, the
+ * anchor is swapped for the sibling price that carries the matching `region` tag and the same
+ * product (`productSlug`) and `interval`. When no such sibling exists (or the region is br), the
+ * BRL anchor is shown. This keeps id-based selection as the source of truth while adding the
+ * currency dimension, and never shows a price for the wrong product or interval.
  *
  * @param {Array<{node: object}>} edges - getPlans result data (array of { node }).
+ * @param {"br"|"latam"|"intl"} [region="br"] - pricing region for the current domain.
  * @returns {Record<string, object|undefined>} plan-key -> price node (undefined if the
  *   configured id isn't among the active prices returned by getPlans).
  */
-export function selectPlans(edges = []) {
+export function selectPlans(edges = [], region = DEFAULT_REGION) {
   const ids = priceIds()
   const plans = {}
 
   for (const key of PLAN_KEYS) {
     const wantedId = ids[key]
-    const match = edges.find(({ node }) => node.stripePriceId === wantedId)
+    const anchor = edges.find(({ node }) => node.stripePriceId === wantedId)
 
-    if (!match) {
+    if (!anchor) {
       console.warn(
         `Stripe price "${key}" (${wantedId}) not found among active prices from getPlans — ` +
           "check the id and that the price is active."
       )
+      plans[key] = undefined
+      continue
     }
 
-    plans[key] = match?.node
+    if (region === DEFAULT_REGION) {
+      plans[key] = anchor.node
+      continue
+    }
+
+    // Swap to the regional sibling: same product and interval, tagged for this region.
+    const sibling = edges.find(
+      ({ node }) =>
+        node.region === region &&
+        node.productSlug === anchor.node.productSlug &&
+        node.interval === anchor.node.interval
+    )
+
+    if (!sibling) {
+      console.warn(
+        `No "${region}" price for plan "${key}" (${anchor.node.productSlug}/${anchor.node.interval}); ` +
+          "showing the BRL price. Add the regional price in Stripe with the matching `region` tag."
+      )
+    }
+
+    plans[key] = (sibling ?? anchor).node
   }
 
   return plans

--- a/next/content/FAQ/en/access-external-links.md
+++ b/next/content/FAQ/en/access-external-links.md
@@ -1,0 +1,8 @@
+---
+question: How can I access the original sources?
+categories: [Dados]
+keywords: access, query, original source, external
+id: access-external-links
+---
+
+You can access the original data sources by clicking the redirect button that links out to the external platform.

--- a/next/content/FAQ/en/access-information-requests.md
+++ b/next/content/FAQ/en/access-information-requests.md
@@ -1,0 +1,8 @@
+---
+question: How can I access the LAI (freedom of information) requests?
+categories: [Dados]
+keywords: access, query, LAI, freedom of information, law
+id: access-information-requests
+---
+
+You can access the LAI requests by clicking the redirect button that links out to the external platform.

--- a/next/content/FAQ/en/access-tables.md
+++ b/next/content/FAQ/en/access-tables.md
@@ -1,0 +1,8 @@
+---
+question: How can I access the processed tables?
+categories: [Dados]
+keywords: access, query, processed, treated, DB, download, package, SQL, BigQuery, Python, R
+id: access-tables
+---
+
+You can query DB's processed tables in different ways. Besides downloading directly on the platform, you can explore the data with SQL through BigQuery or with the Python and R packages.

--- a/next/content/FAQ/en/bd-edu-certificates.md
+++ b/next/content/FAQ/en/bd-edu-certificates.md
@@ -1,0 +1,8 @@
+---
+question: Do DB Edu courses come with a certificate?
+categories: [BD Edu]
+keywords: db edu, education, training, course, certificate
+id: bd-edu-certificates
+---
+
+Yes, whenever a course is completed we issue an official DB certificate with the student's personal information and course details. The certificate is verifiable and can be shared on social media or attached to your résumé.

--- a/next/content/FAQ/en/bd-edu-contact.md
+++ b/next/content/FAQ/en/bd-edu-contact.md
@@ -1,0 +1,8 @@
+---
+question: I have questions about DB Edu courses, is there a dedicated contact channel?
+categories: [BD Edu]
+keywords: db edu, education, training, course, certificate
+id: bd-edu-contact
+---
+
+Yes, you can send your questions to [suporte.bdedu@basedosdados.org](mailto:suporte.bdedu@basedosdados.org). Our team checks this inbox daily to provide the best support possible.

--- a/next/content/FAQ/en/bd-edu-courses.md
+++ b/next/content/FAQ/en/bd-edu-courses.md
@@ -1,0 +1,8 @@
+---
+question: What courses does DB Edu offer?
+categories: [BD Edu]
+keywords: db edu, education, training, course
+id: bd-edu-courses
+---
+
+We currently offer data analysis courses covering tools that matter in the job market, such as SQL, Python, spreadsheet editors, and Google Cloud. Our team is also equipped to develop courses on demand, and we are working to launch new training formats.

--- a/next/content/FAQ/en/bd-edu-platform.md
+++ b/next/content/FAQ/en/bd-edu-platform.md
@@ -1,0 +1,8 @@
+---
+question: Which platform is used for DB Edu course activities?
+categories: [BD Edu]
+keywords: db edu, education, training, course, platform
+id: bd-edu-platform
+---
+
+We use the coda.io platform, which works as a document editor combining features of spreadsheets, presentations, word processors, and apps. There you'll find our Student Area, where you can access the schedule, links to live classes, recorded classes, an exercise submission page, a Q&A forum, extra materials, and more.

--- a/next/content/FAQ/en/bd-edu-teacher.md
+++ b/next/content/FAQ/en/bd-edu-teacher.md
@@ -1,0 +1,8 @@
+---
+question: Who organizes and teaches the DB Edu courses?
+categories: [BD Edu]
+keywords: db edu, education, training, course, support
+id: bd-edu-teacher
+---
+
+Our courses are developed and reviewed by specialists who work on the Data Basis team. You can check everyone's profile on our [institutional page](https://basedosdados.org/about-us).

--- a/next/content/FAQ/en/bd-edu.md
+++ b/next/content/FAQ/en/bd-edu.md
@@ -1,0 +1,8 @@
+---
+question: What is DB Edu?
+categories: [BD Edu]
+keywords: db edu, education, training, course
+id: bd-edu
+---
+
+DB Edu is our education arm, with the mission of empowering people to solve problems with data. We have provided training services to organizations such as Vetor Brasil, Souk Analytics, and ProForest, in addition to our courses open to the public. We offer live and asynchronous courses, and all proceeds are reinvested in Data Basis.

--- a/next/content/FAQ/en/bd-lab-origin.md
+++ b/next/content/FAQ/en/bd-lab-origin.md
@@ -1,0 +1,8 @@
+---
+question: How did DB Lab come about?
+categories: [BD Lab]
+keywords: db lab, consulting, project, origin
+id: bd-lab-origin
+---
+
+DB Lab was created to ensure the organization's sustainability, so as to maintain and expand our products free of charge. Providing data services and carrying out projects with partners has been key not only to generating revenue, but also to strengthening our position as a reference in making quality data available.

--- a/next/content/FAQ/en/bd-lab.md
+++ b/next/content/FAQ/en/bd-lab.md
@@ -1,0 +1,8 @@
+---
+question: What is DB Lab?
+categories: [BD Lab]
+keywords: db lab, consulting, project
+id: bd-lab
+---
+
+DB Lab is our services, partnerships, and projects arm. It is through DB Lab that we interact with other organizations, providing our accumulated expertise in technology and data. We see these projects as an indispensable component of our mission to promote the use of data for social well-being.

--- a/next/content/FAQ/en/best-practices-performance.md
+++ b/next/content/FAQ/en/best-practices-performance.md
@@ -1,0 +1,30 @@
+---
+question: What are the best practices for running a query in BigQuery?
+categories: [BigQuery]
+keywords: practice, tip, optimization, performance, query, BigQuery, select, filter
+id: best-practices-performance
+---
+
+To check a sample of all the variables in the table, use:
+
+
+```sql
+SELECT * FROM dataset.table_name LIMIT 100
+```
+
+- The first valuable tip is to select only the columns you are going to use. BigQuery works using a columnar model, so the fewer columns you use, the better your query's performance will be. This means avoiding the classic
+
+  ```sql
+  SELECT * FROM table_name
+  ```
+and choosing the columns you are interested in instead. It sounds tedious, but it helps a lot!
+
+- For large tables, a good practice is to filter the years and states you are interested in with the
+
+  ```sql
+  WHERE
+  ```
+
+clause. Since we use a partitioning system, this will drastically reduce processing cost and time.
+
+These are the simplest and quickest tips to apply. To learn more about best practices, check out the [complete manual](https://cloud.google.com/bigquery/docs/best-practices-performance-overview?hl=pt-br) provided by Google Cloud.

--- a/next/content/FAQ/en/bigquery-partitions.md
+++ b/next/content/FAQ/en/bigquery-partitions.md
@@ -1,0 +1,8 @@
+---
+question: What are partitions in BigQuery?
+categories: [BigQuery]
+keywords: partition, partitioning, optimization, performance, BigQuery
+id: bigquery-partitions
+---
+
+Partitions are divisions made in a table to make data management and querying easier. By segmenting a large table into smaller partitions, the number of bytes read is reduced, which helps control costs and improves query performance.

--- a/next/content/FAQ/en/bigquery-types.md
+++ b/next/content/FAQ/en/bigquery-types.md
@@ -1,0 +1,8 @@
+---
+question: What are the types in BigQuery?
+categories: [BigQuery]
+keywords: type, category, BigQuery, INTEGER, STRING, DATE, FLOAT, GEOGRAPHY
+id: bigquery-types
+---
+
+These are the data types of Google Standard SQL. Their categories include: INTEGER, STRING, DATE, FLOAT64 (Decimal), GEOGRAPHY, among others.

--- a/next/content/FAQ/en/data-limit.md
+++ b/next/content/FAQ/en/data-limit.md
@@ -1,0 +1,8 @@
+---
+question: What happens if I exceed Google Cloud's free 1 TB monthly limit?
+categories: [BigQuery]
+keywords: limit, terabyte, TB, Google, Cloud
+id: data-limit
+---
+
+If you exceed the limit, you are charged 5 dollars per Terabyte of data your query processes. However, we note that Google's 1 Terabyte limit is usually sufficient, even for analyses using larger datasets, such as RAIS or the School Census.

--- a/next/content/FAQ/en/data-proposal.md
+++ b/next/content/FAQ/en/data-proposal.md
@@ -1,0 +1,8 @@
+---
+question: Where can I suggest adding new data to the platform?
+categories: [Dados]
+keywords: inclusion, request, proposal, suggestion
+id: data-proposal
+---
+
+It is very important for us to know which data our community needs, so the team can add the requested datasets to the data prioritization process. We have a Discord channel set up to receive your proposals and suggestions — just follow the steps indicated there. Access it [here](https://discord.gg/tx57ek6zqQ).

--- a/next/content/FAQ/en/data-resources.md
+++ b/next/content/FAQ/en/data-resources.md
@@ -1,0 +1,8 @@
+---
+question: What types of data can I find on DB?
+categories: [Dados]
+keywords: type, category
+id: data-resources
+---
+
+On our platform, you can find three types of data: treated tables, original sources, and LAI requests.

--- a/next/content/FAQ/en/data-updated.md
+++ b/next/content/FAQ/en/data-updated.md
@@ -1,0 +1,8 @@
+---
+question: Is DB's data updated automatically?
+categories: [Dados]
+keywords: update, automation, frequency
+id: data-updated
+---
+
+Some data is updated automatically and some is not. We are committed to automatically updating any dataset with monthly or higher frequency. This data is available on our advanced plans, Pro and Orgs.

--- a/next/content/FAQ/en/datalake.md
+++ b/next/content/FAQ/en/datalake.md
@@ -1,0 +1,8 @@
+---
+question: What is DB's datalake on BigQuery?
+categories: [BigQuery]
+keywords: BigQuery, Google, Cloud, datalake, DB
+id: datalake
+---
+
+It is a public database hosted on BigQuery, Google Cloud's powerful data storage and analysis tool, with all of DB's treated tables for you to query directly from your browser. The advantages of using our *datalake* on BigQuery relate to processing speed, scalability, and cost savings.

--- a/next/content/FAQ/en/directories.md
+++ b/next/content/FAQ/en/directories.md
@@ -1,0 +1,8 @@
+---
+question: What are directories?
+categories: [Dados]
+keywords: directory, entity, identifier, key, primary
+id: directories
+---
+
+These are tables that link various institutional codes and information from different Brazilian entities. This matters because it solves the problem of there being no unique identifier for entities — such as state, municipality, school, district, census tract, ICD-10 and ICD-9 categories, CBO-2002 and CBO-1992, etc. — across institutions, or of identifiers and names changing, with typos, across years and institutions. To learn more, check out our [tutorial](https://medium.com/basedosdados/diret%C3%B3rios-brasileiros-como-essa-base-facilita-sua-an%C3%A1lise-40dc8ce2ca2) on Brazilian Directories.

--- a/next/content/FAQ/en/do-i-have-to-pay.md
+++ b/next/content/FAQ/en/do-i-have-to-pay.md
@@ -1,0 +1,12 @@
+---
+question: Do I have to pay to access DB's data?
+categories: [Dados]
+keywords: pay, cost, free, no cost, subscription fee
+id: do-i-have-to-pay
+---
+
+Access to most of the data offered by DB is free. Payment may be required in only two cases:
+
+1. Some data is part of our advanced plans, Pro and Orgs, as indicated on the table pages. In this case, a subscription is required to access the data.
+
+2. One way to access our data is through BigQuery, on Google Cloud, which offers up to 1 free Terabyte per month for its users. We note that this limit is usually sufficient, even for analyses using larger datasets, such as RAIS or the School Census. If you exceed this limit, BigQuery charges 5 dollars per terabyte of data your query processes.

--- a/next/content/FAQ/en/download-limit.md
+++ b/next/content/FAQ/en/download-limit.md
@@ -1,0 +1,11 @@
+---
+question: What is the download limit for DB data on the platform?
+categories: [Dados]
+keywords: limit, download, file size, maximum, file
+id: download-limit
+---
+
+The download limit for data on our platform is 200,000 rows.
+To access tables that exceed this limit, use our *datalake* on BigQuery or our Python and R packages.
+
+

--- a/next/content/FAQ/en/download.md
+++ b/next/content/FAQ/en/download.md
@@ -1,0 +1,9 @@
+---
+question: Can I download DB's data?
+categories: [Dados]
+keywords: download, CSV, file
+id: download
+---
+
+Yes, you can download the complete CSV file of the processed tables directly on the platform.
+However, tables with more than 200,000 rows can only be accessed through our data lake on BigQuery or our Python and R packages.

--- a/next/content/FAQ/en/external-links.md
+++ b/next/content/FAQ/en/external-links.md
@@ -1,0 +1,8 @@
+---
+question: What are original sources?
+categories: [Dados]
+keywords: original source, external
+id: external-links
+---
+
+These are links to pages outside the platform with useful information about the dataset. Most of these are data we have not yet made available on DB as processed tables. We always try to provide the closest possible path to the source to download the original data.

--- a/next/content/FAQ/en/financing.md
+++ b/next/content/FAQ/en/financing.md
@@ -1,0 +1,8 @@
+---
+question: How is DB funded?
+categories: [Institucional]
+keywords: funding, sustainability, accounting, service, partnership
+id: financing
+---
+
+Over the years, DB has grown with the financial support of users and people who identify with our mission. Today, we also rely on our Services and Partnerships area (DB Lab) and our plans for access to exclusive, updated data (DB Pro). Learn more about the organization's accounting on our [Transparency](https://basedosdados.org/transparency) page.

--- a/next/content/FAQ/en/google-account.md
+++ b/next/content/FAQ/en/google-account.md
@@ -1,0 +1,8 @@
+---
+question: Why do I need a Google Cloud account?
+categories: [BigQuery]
+keywords: account, sign up, BigQuery, Google, Cloud
+id: google-account
+---
+
+Our public database is hosted on BigQuery, a powerful Google Cloud data storage and analysis tool. For this service, Google Cloud offers up to 1 Terabyte free per month to its users. You therefore need to create an account to link the database's queries to you and track the total processing used in the month. Creating the account requires no card or prior payment method, since BigQuery starts automatically in Sandbox mode, which lets you use the resources without adding a payment method.

--- a/next/content/FAQ/en/google-cloud-project.md
+++ b/next/content/FAQ/en/google-cloud-project.md
@@ -1,0 +1,12 @@
+---
+question: How do I create a project on Google Cloud?
+categories: [BigQuery]
+keywords: create, sign up, project, Google, Cloud
+id: google-cloud-project
+---
+
+To create a project on Google Cloud, you just need an email registered with Google. You need to have your own project, even if empty, to run queries on our public *datalake*.
+
+1. Go to [Google Cloud](https://console.cloud.google.com/projectselector2/home/dashboard). If it's your first time, accept the Terms of Service.
+2. Click *Create Project*. Choose a good name for the project.
+3. Click *Create*.

--- a/next/content/FAQ/en/information-requests.md
+++ b/next/content/FAQ/en/information-requests.md
@@ -1,0 +1,10 @@
+---
+question: What are LAI requests?
+categories: [Dados]
+keywords: LAI, access to information, law
+id: information-requests
+---
+
+These are requests made under the Access to Information Law (LAI).
+
+The LAI, Law No. 12,527/2011, regulates the constitutional right of any person to request and receive public information produced or held by public bodies and entities, across all levels of government and branches of power.

--- a/next/content/FAQ/en/legal-nature.md
+++ b/next/content/FAQ/en/legal-nature.md
@@ -1,0 +1,8 @@
+---
+question: Is DB a company?
+categories: [Institucional]
+keywords: legal nature, company, nonprofit, NGO
+id: legal-nature
+---
+
+No. DB is constituted as a nonprofit association called "Instituto Base dos Dados," headquartered in Rio de Janeiro, with company registration number (CNPJ) 42.494.318/0001-16.

--- a/next/content/FAQ/en/level-of-observation.md
+++ b/next/content/FAQ/en/level-of-observation.md
@@ -1,0 +1,8 @@
+---
+question: What is the level of observation?
+categories: [Dados]
+keywords: level, observation, key, primary
+id: level-of-observation
+---
+
+The level of observation indicates what each row of the table represents. It is as if the combination of columns that make up the level of observation were a primary key. This information is useful because it indicates the smallest possible granularity of analysis with that data. For example, a table with a state-level observation allows analysis at the country level (broader than state), but not at the municipality level (a more specific breakdown).

--- a/next/content/FAQ/en/packages.md
+++ b/next/content/FAQ/en/packages.md
@@ -1,0 +1,8 @@
+---
+question: How do I use DB's packages?
+categories: [Dados]
+keywords: package, Python, R, installation, documentation
+id: packages
+---
+
+Our packages allow direct access to the public *datalake* from your computer or development environment. To start exploring our data in Python or R, follow the package installation tutorials in our [documentation](https://basedosdados.org/docs/access_data_packages/).

--- a/next/content/FAQ/en/personal-data.md
+++ b/next/content/FAQ/en/personal-data.md
@@ -1,0 +1,10 @@
+---
+question: How does DB collect personal data?
+categories: [Institucional]
+keywords: privacy, use, lgpd
+id: personal-data
+---
+
+We collect personal information that you provide directly to us when using our services. This may include your name, email address, payment information, and other information you choose to share with us. We also collect information automatically, through cookies, including usage data, IP address, browser type, and information about the device you use to access our services.
+
+We use your personal information to provide and improve our services, including processing payments, providing customer support, and personalizing the user experience. We will not sell, rent, or share your personal information with unaffiliated third parties without your explicit consent. For more information, see our Terms of Use and Privacy Policy [here](http://basedosdados.org/terms).

--- a/next/content/FAQ/en/public-or-private.md
+++ b/next/content/FAQ/en/public-or-private.md
@@ -1,0 +1,8 @@
+---
+question: Is DB's data public or private?
+categories: [Dados]
+keywords: public, private
+id: public-or-private
+---
+
+The vast majority of the datasets found on our platform are public. However, some private datasets are also listed. Our organization is nonprofit, so we do not charge for listing datasets on our platform. We believe it is useful to list private datasets, since people may be interested in acquiring them after finding them on our site.

--- a/next/content/FAQ/en/reference.md
+++ b/next/content/FAQ/en/reference.md
@@ -1,0 +1,14 @@
+---
+question: How do I cite DB?
+categories: [Institucional]
+keywords: cite, citation, reference
+id: reference
+---
+
+You can reference us in two ways:
+
+- Just with the name "Base dos Dados" (in Portuguese), "Data Basis" (in English), or "Base de los Datos" (in Spanish);
+
+- From the *white paper* [Data Basis: Universalizing Access to High-Quality Data](https://osf.io/preprints/socarxiv/r76yg).
+
+> Dahis et al. (2022) Data Basis: Universalizing Access to High-Quality Data. Available at: {`<osf.io/preprints/socarxiv/r76yg>`}

--- a/next/content/FAQ/en/subscriptions-data-update.md
+++ b/next/content/FAQ/en/subscriptions-data-update.md
@@ -1,0 +1,8 @@
+---
+question: How is DB Pro data updated?
+categories: [Planos Pagos]
+keywords: pro, orgs, subscription, exclusive data, update
+id: subscriptions-data-update
+---
+
+All data available on DB Pro is updated automatically through our flow management technology. DB uses state-of-the-art data engineering to guarantee the highest quality and consistency in what we provide.

--- a/next/content/FAQ/en/subscriptions-data.md
+++ b/next/content/FAQ/en/subscriptions-data.md
@@ -1,0 +1,8 @@
+---
+question: What data can I access with the paid plans?
+categories: [Planos Pagos]
+keywords: pro, orgs, subscription, exclusive data, pay, cost, free, monthly fee
+id: subscriptions-data
+---
+
+The subscription grants access to up-to-date data. This can sometimes be a subset of a larger processed table, or an entire processed table. Our search engine and specific dataset pages indicate what is available for free and what is covered by the paid plan subscriptions.

--- a/next/content/FAQ/en/subscriptions-prices.md
+++ b/next/content/FAQ/en/subscriptions-prices.md
@@ -1,0 +1,8 @@
+---
+question: How much does a DB Pro subscription cost?
+categories: [Planos Pagos]
+keywords: pro, orgs, subscription, price
+id: subscriptions-prices
+---
+
+We currently have two plans. The Pro plan costs R$47 per month, giving a single user access to all up-to-date data. The Orgs plan costs R$385 per month, including access for 10 accounts and priority support from our team.

--- a/next/content/FAQ/en/subscriptions.md
+++ b/next/content/FAQ/en/subscriptions.md
@@ -1,0 +1,8 @@
+---
+question: What are the Pro and Orgs plans?
+categories: [Planos Pagos]
+keywords: pro, orgs, subscription, exclusive data, pay, cost, free, monthly fee
+id: subscriptions
+---
+
+In addition to the free plan, DB offers advanced plans: Pro, for individual users, and Orgs, for up to 10 users from the same organization. These plans provide, on top of the data already available in DB's public data lake, dozens of exclusive datasets prioritized to solve problems and help you, your team, your organization, or your research. Besides exclusive datasets, the plans offer access to the most up-to-date version of some of our key tables, such as CNES, CNPJ data, and Brasileirão data, among many others.

--- a/next/content/FAQ/en/tables.md
+++ b/next/content/FAQ/en/tables.md
@@ -1,0 +1,8 @@
+---
+question: What are processed tables?
+categories: [Dados]
+keywords: processed, treated, DB, table, data lake, cross-reference, crossing, standardization, compatibilization
+id: tables
+---
+
+These are tables ready for analysis, available via SQL, Python, and R. The process of preparing the tables involves standardizing variable names and making codes compatible, which makes it as simple to cross-reference tables from different institutions and topics as it is to run any other query.

--- a/next/content/FAQ/es/access-external-links.md
+++ b/next/content/FAQ/es/access-external-links.md
@@ -1,0 +1,8 @@
+---
+question: ¿Cómo acceder a las fuentes originales?
+categories: [Dados]
+keywords: acceso, consulta, fuente original, externo
+id: access-external-links
+---
+
+Puedes acceder a las fuentes originales de los datos haciendo clic en el botón de redireccionamiento hacia el enlace externo a la plataforma.

--- a/next/content/FAQ/es/access-information-requests.md
+++ b/next/content/FAQ/es/access-information-requests.md
@@ -1,0 +1,8 @@
+---
+question: ¿Cómo acceder a las solicitudes LAI?
+categories: [Dados]
+keywords: acceso, consulta, LAI, acceso a la información, ley
+id: access-information-requests
+---
+
+Puedes acceder a las solicitudes LAI haciendo clic en el botón de redireccionamiento hacia el enlace externo a la plataforma.

--- a/next/content/FAQ/es/access-tables.md
+++ b/next/content/FAQ/es/access-tables.md
@@ -1,0 +1,8 @@
+---
+question: ¿Cómo acceder a las tablas tratadas?
+categories: [Dados]
+keywords: acceso, consulta, tratada, tratado, BD, descarga, descargar, paquete, SQL, BigQuery, Python, R
+id: access-tables
+---
+
+Puedes consultar las tablas tratadas de BD de diferentes maneras. Además de descargarlas directamente en la plataforma, es posible explorar los datos con SQL a través de BigQuery o con los paquetes en Python y R.

--- a/next/content/FAQ/es/bd-edu-certificates.md
+++ b/next/content/FAQ/es/bd-edu-certificates.md
@@ -1,0 +1,8 @@
+---
+question: ¿Los cursos de BD Edu tienen certificado?
+categories: [BD Edu]
+keywords: bd edu, educación, formación, curso, certificado
+id: bd-edu-certificates
+---
+
+Sí, cada vez que se completa un curso emitimos un certificado oficial de BD con la información personal del alumno y los datos del curso. El certificado es verificable y se puede compartir en redes sociales o adjuntar a tu currículum.

--- a/next/content/FAQ/es/bd-edu-contact.md
+++ b/next/content/FAQ/es/bd-edu-contact.md
@@ -1,0 +1,8 @@
+---
+question: Tengo dudas sobre los cursos de BD Edu, ¿existe un canal especializado de contacto?
+categories: [BD Edu]
+keywords: bd edu, educación, formación, curso, certificado
+id: bd-edu-contact
+---
+
+Sí, puedes resolver tus dudas escribiendo a [suporte.bdedu@basedosdados.org](mailto:suporte.bdedu@basedosdados.org). Nuestro equipo revisa este correo diariamente para ofrecerte el mejor soporte posible.

--- a/next/content/FAQ/es/bd-edu-courses.md
+++ b/next/content/FAQ/es/bd-edu-courses.md
@@ -1,0 +1,8 @@
+---
+question: ¿Qué cursos ofrece BD Edu?
+categories: [BD Edu]
+keywords: bd edu, educación, formación, curso
+id: bd-edu-courses
+---
+
+Actualmente ofrecemos cursos de análisis de datos con herramientas importantes para el mercado laboral, como SQL, Python, editores de hojas de cálculo y Google Cloud. Además, nuestro equipo está capacitado para desarrollar cursos a demanda y trabajamos continuamente para lanzar nuevos formatos de formación.

--- a/next/content/FAQ/es/bd-edu-platform.md
+++ b/next/content/FAQ/es/bd-edu-platform.md
@@ -1,0 +1,8 @@
+---
+question: ¿Qué plataforma se utiliza para las actividades de los cursos de BD Edu?
+categories: [BD Edu]
+keywords: bd edu, educación, formación, curso, plataforma
+id: bd-edu-platform
+---
+
+Utilizamos la plataforma coda.io, que funciona como un editor de documentos que combina funciones de hojas de cálculo, presentaciones, procesadores de texto y aplicaciones. Allí tenemos nuestra Área del Alumno(a), donde puedes encontrar el cronograma, enlaces a las clases en vivo, clases grabadas, la página de entrega de ejercicios, el foro de dudas, materiales adicionales y más.

--- a/next/content/FAQ/es/bd-edu-teacher.md
+++ b/next/content/FAQ/es/bd-edu-teacher.md
@@ -1,0 +1,8 @@
+---
+question: ¿Quién organiza y dicta los cursos de BD Edu?
+categories: [BD Edu]
+keywords: bd edu, educación, formación, curso, soporte
+id: bd-edu-teacher
+---
+
+Nuestros cursos son desarrollados y revisados por especialistas que trabajan en el equipo de Base de los Datos. Puedes consultar el perfil de todos en nuestra [página institucional](https://basedosdados.org/about-us).

--- a/next/content/FAQ/es/bd-edu.md
+++ b/next/content/FAQ/es/bd-edu.md
@@ -1,0 +1,8 @@
+---
+question: ¿Qué es BD Edu?
+categories: [BD Edu]
+keywords: bd edu, educación, formación, curso
+id: bd-edu
+---
+
+BD Edu es nuestro brazo de educación, con la misión de capacitar a las personas para resolver problemas con datos. Ya hemos prestado servicios de formación a organizaciones como Vetor Brasil, Souk Analytics y ProForest, además de nuestros cursos abiertos al público. Ofrecemos cursos en vivo y asincrónicos, y todo lo recaudado se reinvierte en Base de los Datos.

--- a/next/content/FAQ/es/bd-lab-origin.md
+++ b/next/content/FAQ/es/bd-lab-origin.md
@@ -1,0 +1,8 @@
+---
+question: ¿Cómo surgió BD Lab?
+categories: [BD Lab]
+keywords: bd lab, consultoría, proyecto, origen
+id: bd-lab-origin
+---
+
+BD Lab fue creada para garantizar la sostenibilidad de la organización, de modo de mantener y expandir nuestros productos de forma gratuita. La prestación de servicios de datos y la realización de proyectos con socios ha sido clave no solo para la generación de ingresos, sino también para fortalecer nuestra posición de referencia en la disponibilización de datos de calidad.

--- a/next/content/FAQ/es/bd-lab.md
+++ b/next/content/FAQ/es/bd-lab.md
@@ -1,0 +1,8 @@
+---
+question: ¿Qué es BD Lab?
+categories: [BD Lab]
+keywords: bd lab, consultoría, proyecto
+id: bd-lab
+---
+
+BD Lab es nuestro brazo de servicios, alianzas y proyectos. Es a través de BD Lab que interactuamos con otras organizaciones, aportando nuestra experiencia acumulada en tecnología y datos. Vemos estos proyectos como un componente indispensable de nuestra misión de promover el uso de datos para el bienestar social.

--- a/next/content/FAQ/es/best-practices-performance.md
+++ b/next/content/FAQ/es/best-practices-performance.md
@@ -1,0 +1,30 @@
+---
+question: ¿Cuáles son las mejores prácticas para hacer una consulta en BigQuery?
+categories: [BigQuery]
+keywords: práctica, consejo, optimización, rendimiento, consulta, BigQuery, seleccionar, filtrar
+id: best-practices-performance
+---
+
+Para verificar una muestra de todas las variables de la tabla, usa:
+
+
+```sql
+SELECT * FROM dataset.table_name LIMIT 100
+```
+
+- El primer consejo valioso es seleccionar las columnas que vas a usar. BigQuery funciona con un modelo columnar, por lo que cuantas menos columnas uses, mejor será el rendimiento de tu consulta. Esto significa evitar el clásico
+
+  ```sql
+  SELECT * FROM table_name
+  ```
+y elegir las columnas de tu interés. Parece tedioso, ¡pero ayuda mucho!
+
+- Para tablas grandes, una buena práctica es filtrar los años y estados de tu interés con la cláusula
+
+  ```sql
+  WHERE
+  ```
+
+Como utilizamos el sistema de particionamiento, esto reducirá drásticamente el costo y el tiempo de procesamiento.
+
+Estos son los consejos más simples y rápidos de aplicar. Para saber más sobre buenas prácticas, consulta el [manual completo](https://cloud.google.com/bigquery/docs/best-practices-performance-overview?hl=pt-br) disponibilizado por Google Cloud.

--- a/next/content/FAQ/es/bigquery-partitions.md
+++ b/next/content/FAQ/es/bigquery-partitions.md
@@ -1,0 +1,8 @@
+---
+question: ¿Qué son las particiones en BigQuery?
+categories: [BigQuery]
+keywords: partición, particionamiento, optimización, rendimiento, BigQuery
+id: bigquery-partitions
+---
+
+Las particiones son divisiones que se hacen en una tabla para facilitar la gestión y la consulta de los datos. Al segmentar una tabla grande en particiones más pequeñas, se reduce la cantidad de bytes leídos, lo que ayuda a controlar los costos y mejora el rendimiento de la consulta.

--- a/next/content/FAQ/es/bigquery-types.md
+++ b/next/content/FAQ/es/bigquery-types.md
@@ -1,0 +1,8 @@
+---
+question: ¿Qué son los tipos en BigQuery?
+categories: [BigQuery]
+keywords: tipo, categoría, BigQuery, INTEGER, STRING, DATE, FLOAT, GEOGRAPHY
+id: bigquery-types
+---
+
+Son los tipos de datos de Google Standard SQL. Sus categorías incluyen: INTEGER (Entero), STRING (Texto), DATE (Fecha), FLOAT64 (Decimal), GEOGRAPHY (Geográfico), entre otras.

--- a/next/content/FAQ/es/data-limit.md
+++ b/next/content/FAQ/es/data-limit.md
@@ -1,0 +1,8 @@
+---
+question: ¿Qué pasa si supero el límite mensual gratuito de 1 TB de Google Cloud?
+categories: [BigQuery]
+keywords: límite, terabyte, TB, Google, Cloud
+id: data-limit
+---
+
+Si supera el límite, se cobran 5 dólares por cada Terabyte de datos que su consulta procese. Sin embargo, destacamos que el límite de 1 Terabyte de Google suele ser suficiente, incluso para análisis con bases más robustas, como la RAIS o el Censo Escolar.

--- a/next/content/FAQ/es/data-proposal.md
+++ b/next/content/FAQ/es/data-proposal.md
@@ -1,0 +1,8 @@
+---
+question: ¿Dónde puedo sugerir la inclusión de nuevos datos en la plataforma?
+categories: [Dados]
+keywords: inclusión, solicitud, propuesta, sugerencia
+id: data-proposal
+---
+
+Es muy importante saber qué datos necesita nuestra comunidad para que el equipo agregue los conjuntos solicitados al proceso de priorización de datos. Tenemos un canal en Discord preparado para recibir sus propuestas y sugerencias; solo debe seguir los pasos indicados allí. Ingrese [aquí](https://discord.gg/nNfQYcmrvM).

--- a/next/content/FAQ/es/data-resources.md
+++ b/next/content/FAQ/es/data-resources.md
@@ -1,0 +1,8 @@
+---
+question: ¿Qué tipos de datos encuentro en BD?
+categories: [Dados]
+keywords: tipo, categoría
+id: data-resources
+---
+
+En nuestra plataforma, encontrará tres tipos de datos: tablas tratadas, fuentes originales y solicitudes LAI.

--- a/next/content/FAQ/es/data-updated.md
+++ b/next/content/FAQ/es/data-updated.md
@@ -1,0 +1,8 @@
+---
+question: ¿Los datos de BD se actualizan automáticamente?
+categories: [Dados]
+keywords: actualización, automatización, frecuencia
+id: data-updated
+---
+
+Algunos datos se actualizan automáticamente y otros no. Tenemos el compromiso de actualizar automáticamente cualquier base con frecuencia mensual o mayor. Estos datos están disponibles en nuestros planes avanzados, Pro y Orgs.

--- a/next/content/FAQ/es/datalake.md
+++ b/next/content/FAQ/es/datalake.md
@@ -1,0 +1,8 @@
+---
+question: ¿Qué es el datalake de BD en BigQuery?
+categories: [BigQuery]
+keywords: BigQuery, Google, Cloud, datalake, BD
+id: datalake
+---
+
+Es una base de datos pública alojada en BigQuery, la potente herramienta de almacenamiento y análisis de datos de Google Cloud, con todas las tablas tratadas de BD para que las consulte directamente desde su navegador. Las ventajas de utilizar nuestro *datalake* en BigQuery están relacionadas con la velocidad de procesamiento, la escalabilidad y el ahorro de costos.

--- a/next/content/FAQ/es/directories.md
+++ b/next/content/FAQ/es/directories.md
@@ -1,0 +1,8 @@
+---
+question: ¿Qué son los directorios?
+categories: [Dados]
+keywords: directorio, entidad, identificador, clave, primaria
+id: directories
+---
+
+Son tablas que vinculan diversos códigos institucionales e información de diferentes entidades brasileñas. Esto es importante porque resuelve el problema de que no exista un identificador único para entidades —como estado, municipio, escuela, distrito, sector censal, categorías CIE-10 y CIE-9, CBO-2002 y CBO-1992, etc.— entre instituciones, o bien el cambio de identificadores y nombres con errores tipográficos entre años e instituciones. Para saber más, consulte nuestro [tutorial](https://medium.com/basedosdados/diret%C3%B3rios-brasileiros-como-essa-base-facilita-sua-an%C3%A1lise-40dc8ce2ca2) sobre Directorios Brasileños.

--- a/next/content/FAQ/es/do-i-have-to-pay.md
+++ b/next/content/FAQ/es/do-i-have-to-pay.md
@@ -1,0 +1,12 @@
+---
+question: ¿Tengo que pagar para acceder a los datos de BD?
+categories: [Dados]
+keywords: pagar, costo, gratuito, gratis, cuota mensual
+id: do-i-have-to-pay
+---
+
+El acceso a la mayoría de los datos ofrecidos por BD es gratuito. Solo en dos casos puede ser necesario un pago. Estos son:
+
+1. Algunos datos forman parte de nuestros planes avanzados, Pro y Orgs, como se indica en las páginas de las tablas. En ese caso, es necesaria una suscripción para acceder a los datos.
+
+2. Una forma de acceder a nuestros datos es a través de BigQuery, en Google Cloud, que ofrece hasta 1 Terabyte gratuito por mes a sus usuarios. Destacamos que este límite suele ser suficiente, incluso para análisis con bases más robustas, como la RAIS o el Censo Escolar. Si supera este límite, BigQuery cobra 5 dólares por terabyte de datos que su consulta procese.

--- a/next/content/FAQ/es/download-limit.md
+++ b/next/content/FAQ/es/download-limit.md
@@ -1,0 +1,11 @@
+---
+question: ¿Cuál es el límite de descarga de los datos de BD en la plataforma?
+categories: [Dados]
+keywords: límite, descarga, descargar, tamaño, máximo, archivo
+id: download-limit
+---
+
+El límite para la descarga de datos en nuestra plataforma es de 200.000 filas.
+Para acceder a tablas que superan ese límite, utiliza nuestro *datalake* en BigQuery o nuestros paquetes en Python y R.
+
+

--- a/next/content/FAQ/es/download.md
+++ b/next/content/FAQ/es/download.md
@@ -1,0 +1,9 @@
+---
+question: ¿Es posible descargar los datos de BD?
+categories: [Dados]
+keywords: descarga, descargar, CSV, archivo
+id: download
+---
+
+Sí, puedes descargar el archivo CSV completo de las tablas tratadas directamente en la plataforma.
+Sin embargo, las tablas con más de 200.000 filas solo pueden accederse a través de nuestro data lake en BigQuery o de nuestros paquetes en Python y R.

--- a/next/content/FAQ/es/external-links.md
+++ b/next/content/FAQ/es/external-links.md
@@ -1,0 +1,8 @@
+---
+question: ¿Qué son las fuentes originales?
+categories: [Dados]
+keywords: fuente original, externo
+id: external-links
+---
+
+Son enlaces a páginas externas a la plataforma con información útil sobre el conjunto de datos. La mayoría de estos son datos que aún no hemos puesto a disposición en BD como tablas tratadas. Siempre intentamos ofrecer el camino más cercano posible a la fuente para descargar los datos originales.

--- a/next/content/FAQ/es/financing.md
+++ b/next/content/FAQ/es/financing.md
@@ -1,0 +1,8 @@
+---
+question: ¿Cómo se financia BD?
+categories: [Institucional]
+keywords: financiamiento, sostenibilidad, contabilidad, servicio, alianza
+id: financing
+---
+
+A lo largo de los años, BD ha crecido con el apoyo financiero de usuarios y de personas que se identifican con nuestra misión. Hoy, también contamos con nuestra área de Servicios y Alianzas (BD Lab) y nuestros planes de acceso a datos exclusivos y actualizados (BD Pro). Conoce más sobre la contabilidad de la organización en nuestra página de [Transparencia](https://basedosdados.org/transparency).

--- a/next/content/FAQ/es/google-account.md
+++ b/next/content/FAQ/es/google-account.md
@@ -1,0 +1,8 @@
+---
+question: ¿Por qué necesito una cuenta en Google Cloud?
+categories: [BigQuery]
+keywords: cuenta, registro, BigQuery, Google, Cloud
+id: google-account
+---
+
+Nuestra base de datos pública está alojada en BigQuery, una potente herramienta de almacenamiento y análisis de datos de Google Cloud. Para este servicio, Google Cloud ofrece hasta 1 Terabyte gratuito al mes para sus usuarios. Por eso, es necesario que crees una cuenta para asociar las consultas de la base de datos contigo y contabilizar el total de procesamiento utilizado en el mes. La creación de la cuenta no requiere ninguna tarjeta ni forma de pago previa, es decir, BigQuery se inicia automáticamente en modo Sandbox, que te permite usar los recursos sin agregar un método de pago.

--- a/next/content/FAQ/es/google-cloud-project.md
+++ b/next/content/FAQ/es/google-cloud-project.md
@@ -1,0 +1,12 @@
+---
+question: ¿Cómo crear un proyecto en Google Cloud?
+categories: [BigQuery]
+keywords: crear, registrar, proyecto, Google, Cloud
+id: google-cloud-project
+---
+
+Para crear un proyecto en Google Cloud, basta con tener un correo registrado en Google. Es necesario tener un proyecto propio, aunque esté vacío, para poder hacer consultas en nuestro *datalake* público.
+
+1. Accede a [Google Cloud](https://console.cloud.google.com/projectselector2/home/dashboard). Si es tu primera vez, acepta los Términos de Servicio.
+2. Haz clic en *Create Project/Crear Proyecto*. Elige un buen nombre para el proyecto.
+3. Haz clic en *Create/Crear*.

--- a/next/content/FAQ/es/information-requests.md
+++ b/next/content/FAQ/es/information-requests.md
@@ -1,0 +1,10 @@
+---
+question: ¿Qué son las solicitudes LAI?
+categories: [Dados]
+keywords: LAI, acceso a la información, ley
+id: information-requests
+---
+
+Son solicitudes realizadas a través de la Ley de Acceso a la Información (LAI).
+
+La LAI, Ley n.º 12.527/2011, regula el derecho, previsto en la Constitución, de cualquier persona a solicitar y recibir de los órganos y entidades públicos, de todos los entes y Poderes, información pública producida o custodiada por ellos.

--- a/next/content/FAQ/es/legal-nature.md
+++ b/next/content/FAQ/es/legal-nature.md
@@ -1,0 +1,8 @@
+---
+question: ¿BD es una empresa?
+categories: [Institucional]
+keywords: naturaleza legal, empresa, ong, lucro
+id: legal-nature
+---
+
+No. BD está constituida como una asociación sin fines de lucro llamada "Instituto Base dos Dados", con sede en Río de Janeiro y con CNPJ 42.494.318/0001-16.

--- a/next/content/FAQ/es/level-of-observation.md
+++ b/next/content/FAQ/es/level-of-observation.md
@@ -1,0 +1,8 @@
+---
+question: ¿Qué es el nivel de observación?
+categories: [Dados]
+keywords: nivel, observación, clave, primaria
+id: level-of-observation
+---
+
+El nivel de observación indica qué representa cada fila de la tabla. Es como si la combinación de columnas que componen el nivel de observación fuera una clave primaria. Esta información es útil porque indica cuál es la menor granularidad posible de análisis con ese dato. Por ejemplo, una tabla con nivel de observación de estado permite realizar un análisis a nivel país (por ser más amplio que estado), pero no un análisis por municipio (que ya sería un recorte más específico).

--- a/next/content/FAQ/es/packages.md
+++ b/next/content/FAQ/es/packages.md
@@ -1,0 +1,8 @@
+---
+question: ¿Cómo utilizar los paquetes de BD?
+categories: [Dados]
+keywords: paquete, Python, R, instalación, documentación
+id: packages
+---
+
+Nuestros paquetes permiten el acceso al *datalake* público directamente desde tu computadora o entorno de desarrollo. Para comenzar a explorar nuestros datos en Python o R, sigue los tutoriales de instalación de los paquetes disponibles en nuestra [documentación](https://basedosdados.org/docs/access_data_packages/).

--- a/next/content/FAQ/es/personal-data.md
+++ b/next/content/FAQ/es/personal-data.md
@@ -1,0 +1,10 @@
+---
+question: ¿Cómo recopila BD datos personales?
+categories: [Institucional]
+keywords: privacidad, uso, lgpd
+id: personal-data
+---
+
+Recopilamos información personal que nos proporcionas directamente al usar nuestros servicios. Esto puede incluir tu nombre, dirección de correo electrónico, información de pago y otra información que decidas compartir con nosotros. También recopilamos información de forma automática, a través de cookies, incluyendo datos de uso, dirección IP, tipo de navegador e información sobre el dispositivo que utilizas para acceder a nuestros servicios.
+
+Utilizamos tu información personal para proporcionar y mejorar nuestros servicios, incluyendo el procesamiento de pagos, la provisión de soporte al cliente y la personalización de la experiencia del usuario. No venderemos, alquilaremos ni compartiremos tu información personal con terceros no afiliados sin tu consentimiento explícito. Para más información, consulta nuestros Términos de Uso y Política de Privacidad [aquí](http://basedosdados.org/terms).

--- a/next/content/FAQ/es/public-or-private.md
+++ b/next/content/FAQ/es/public-or-private.md
@@ -1,0 +1,8 @@
+---
+question: ¿Los datos de BD son públicos o privados?
+categories: [Dados]
+keywords: público, privado
+id: public-or-private
+---
+
+En su gran mayoría, las bases de datos que se encuentran en nuestra plataforma son públicas. Sin embargo, también se incluyen algunas bases privadas. Nuestra organización no tiene fines de lucro, por lo que no comercializamos la inclusión de bases en nuestra plataforma. Creemos que es útil listar conjuntos de datos privados, ya que las personas pueden estar interesadas en adquirirlos al encontrarlos en nuestro sitio.

--- a/next/content/FAQ/es/reference.md
+++ b/next/content/FAQ/es/reference.md
@@ -1,0 +1,14 @@
+---
+question: ¿Cómo citar a BD?
+categories: [Institucional]
+keywords: citar, cita, referencia
+id: reference
+---
+
+Puedes referenciarnos de dos maneras:
+
+- Solo con el nombre "Base dos Dados" (en portugués), "Data Basis" (en inglés) o "Base de los Datos" (en español);
+
+- A partir del *white paper* [Data Basis: Universalizing Access to High-Quality Data](https://osf.io/preprints/socarxiv/r76yg).
+
+> Dahis et al. (2022) Data Basis: Universalizing Access to High-Quality Data. Disponible en: {`<osf.io/preprints/socarxiv/r76yg>`}

--- a/next/content/FAQ/es/subscriptions-data-update.md
+++ b/next/content/FAQ/es/subscriptions-data-update.md
@@ -1,0 +1,8 @@
+---
+question: ¿Cómo se actualizan los datos de BD Pro?
+categories: [Planos Pagos]
+keywords: pro, orgs, suscripción, datos exclusivos, actualización
+id: subscriptions-data-update
+---
+
+Todos los datos disponibles en BD Pro se actualizan automáticamente mediante nuestra tecnología de gestión de flujos. BD utiliza lo más moderno en ingeniería de datos para garantizar la más alta calidad y consistencia en lo que ponemos a disposición.

--- a/next/content/FAQ/es/subscriptions-data.md
+++ b/next/content/FAQ/es/subscriptions-data.md
@@ -1,0 +1,8 @@
+---
+question: ¿A qué datos tengo acceso con los planes pagos?
+categories: [Planos Pagos]
+keywords: pro, orgs, suscripción, datos exclusivos, pagar, costo, gratuito, gratis, mensualidad
+id: subscriptions-data
+---
+
+La suscripción da acceso a datos actualizados. Estos pueden ser a veces un subconjunto de una tabla tratada más grande, o una tabla tratada completa. Nuestro buscador y las páginas específicas de cada conjunto indican qué está disponible de forma gratuita y qué está cubierto por la suscripción de los planes pagos.

--- a/next/content/FAQ/es/subscriptions-prices.md
+++ b/next/content/FAQ/es/subscriptions-prices.md
@@ -1,0 +1,8 @@
+---
+question: ¿Cuánto cuesta una suscripción a BD Pro?
+categories: [Planos Pagos]
+keywords: pro, orgs, suscripción, precio
+id: subscriptions-prices
+---
+
+Actualmente tenemos dos planes. El plan Pro cuesta R$47 al mes y da acceso a todos los datos actualizados para un único usuario. El plan Orgs cuesta R$385 al mes, e incluye acceso para 10 cuentas y soporte prioritario de nuestro equipo.

--- a/next/content/FAQ/es/subscriptions.md
+++ b/next/content/FAQ/es/subscriptions.md
@@ -1,0 +1,8 @@
+---
+question: ¿Qué son los planes Pro y Orgs?
+categories: [Planos Pagos]
+keywords: pro, orgs, suscripción, datos exclusivos, pagar, costo, gratuito, gratis, mensualidad
+id: subscriptions
+---
+
+Además del plan gratuito, BD cuenta con planes avanzados: Pro, para usuarios individuales, y Orgs, para hasta 10 usuarios de una misma organización. En estos planes están disponibles, además de los datos ya existentes en el data lake público de BD, decenas de conjuntos de datos exclusivos priorizados para resolver problemas y ayudarte a ti, a tu equipo, a tu organización o a tu investigación. Además de los conjuntos de datos exclusivos, los planes ofrecen acceso a la versión más actualizada de algunas de nuestras principales tablas, como CNES, datos de CNPJ, del Brasileirão, entre muchas otras.

--- a/next/content/FAQ/es/tables.md
+++ b/next/content/FAQ/es/tables.md
@@ -1,0 +1,8 @@
+---
+question: ¿Qué son las tablas tratadas?
+categories: [Dados]
+keywords: tratada, tratado, BD, tabla, data lake, cruzar, cruce, estandarización, compatibilización
+id: tables
+---
+
+Son tablas listas para análisis, disponibles vía SQL, Python y R. El proceso de tratamiento de las tablas implica la estandarización de nombres de variables y la compatibilización de códigos, lo que permite que el cruce de tablas de diferentes instituciones y temas sea tan simple como cualquier otra consulta.

--- a/next/content/bdPro/FAQ/en/access-bases.md
+++ b/next/content/bdPro/FAQ/en/access-bases.md
@@ -1,0 +1,9 @@
+---
+question: Which datasets do I have access to?
+categories: []
+keywords: []
+order: 4
+id: access-bases
+---
+
+All datasets with automatic updates included in the subscription are listed in the [metadata catalog](/search?contains=temporalcoverage_paid&page=1). There you can filter, explore and check the temporal coverage of each one.

--- a/next/content/bdPro/FAQ/en/access-to-recent-data.md
+++ b/next/content/bdPro/FAQ/en/access-to-recent-data.md
@@ -1,0 +1,9 @@
+---
+question: How do I get access to the most recent data?
+categories: []
+keywords: []
+order: 3
+id: access-to-recent-data
+---
+
+The most recent data is available exclusively to BD Pro subscribers. To get access, simply [subscribe to the service](#pricing) — any person or organization can subscribe without restrictions. As soon as payment is completed, access is granted automatically and you can start using the updated data on the platform.

--- a/next/content/bdPro/FAQ/en/access-to-recent-data.md
+++ b/next/content/bdPro/FAQ/en/access-to-recent-data.md
@@ -6,4 +6,4 @@ order: 3
 id: access-to-recent-data
 ---
 
-The most recent data is available exclusively to BD Pro subscribers. To get access, simply [subscribe to the service](#pricing) — any person or organization can subscribe without restrictions. As soon as payment is completed, access is granted automatically and you can start using the updated data on the platform.
+The most recent data is available exclusively to DB Pro subscribers. To get access, simply [subscribe to the service](#pricing) — any person or organization can subscribe without restrictions. As soon as payment is completed, access is granted automatically and you can start using the updated data on the platform.

--- a/next/content/bdPro/FAQ/en/data-access-limit.md
+++ b/next/content/bdPro/FAQ/en/data-access-limit.md
@@ -1,5 +1,5 @@
 ---
-question: Is there a usage limit for BD Pro data?
+question: Is there a usage limit for DB Pro data?
 categories: []
 keywords: []
 order: 8

--- a/next/content/bdPro/FAQ/en/data-access-limit.md
+++ b/next/content/bdPro/FAQ/en/data-access-limit.md
@@ -1,0 +1,9 @@
+---
+question: Is there a usage limit for BD Pro data?
+categories: []
+keywords: []
+order: 8
+id: data-access-limit
+---
+
+There is no usage limit imposed by BD. What exists is a free quota of 1 TB/month granted by Google to all users — if it is exceeded and billing is enabled on your project, Google Cloud may generate extra costs.

--- a/next/content/bdPro/FAQ/en/data-access-limit.md
+++ b/next/content/bdPro/FAQ/en/data-access-limit.md
@@ -6,4 +6,4 @@ order: 8
 id: data-access-limit
 ---
 
-There is no usage limit imposed by BD. What exists is a free quota of 1 TB/month granted by Google to all users — if it is exceeded and billing is enabled on your project, Google Cloud may generate extra costs.
+There is no usage limit imposed by DB. What exists is a free quota of 1 TB/month granted by Google to all users — if it is exceeded and billing is enabled on your project, Google Cloud may generate extra costs.

--- a/next/content/bdPro/FAQ/en/difference-open-pro.md
+++ b/next/content/bdPro/FAQ/en/difference-open-pro.md
@@ -1,14 +1,14 @@
 ---
-question: Why are there BD Pro tables that are also open?
+question: Why are there DB Pro tables that are also open?
 categories: []
 keywords: []
 order: 2
 id: difference-open-pro
 ---
 
-Some datasets are available both in the free version of the platform and in the BD Pro subscription — the difference is the temporal coverage. The BD Pro version always brings the most recent data, while the open version keeps a six-month lag.
+Some datasets are available both in the free version of the platform and in the DB Pro subscription — the difference is the temporal coverage. The DB Pro version always brings the most recent data, while the open version keeps a six-month lag.
 
-You can check the difference between the open version and the BD Pro version of the tables on the 'datasets page' of our platform.
+You can check the difference between the open version and the DB Pro version of the tables on the 'datasets page' of our platform.
 
 
 ![table-coverage](https://storage.googleapis.com/basedosdados-website/bdpro/faq/table-coverage.png)

--- a/next/content/bdPro/FAQ/en/difference-open-pro.md
+++ b/next/content/bdPro/FAQ/en/difference-open-pro.md
@@ -1,0 +1,19 @@
+---
+question: Why are there BD Pro tables that are also open?
+categories: []
+keywords: []
+order: 2
+id: difference-open-pro
+---
+
+Some datasets are available both in the free version of the platform and in the BD Pro subscription — the difference is the temporal coverage. The BD Pro version always brings the most recent data, while the open version keeps a six-month lag.
+
+You can check the difference between the open version and the BD Pro version of the tables on the 'datasets page' of our platform.
+
+
+![table-coverage](https://storage.googleapis.com/basedosdados-website/bdpro/faq/table-coverage.png)
+
+
+When you select a table, you can check its update frequency and temporal coverage on the table page:
+
+![update-frequency](https://storage.googleapis.com/basedosdados-website/bdpro/faq/table-update-frequency.png)

--- a/next/content/bdPro/FAQ/en/extra-billing.md
+++ b/next/content/bdPro/FAQ/en/extra-billing.md
@@ -1,0 +1,13 @@
+---
+question: Can I incur extra charges for using BD Pro data?
+categories: []
+keywords: []
+id: extra-billing
+order: 9
+---
+
+Data Basis will never charge extra fees without you having confirmed and processed the payment yourself on our payment platform.
+
+However, Google Cloud may charge you if you exceed the project's free quota and have billing enabled. Currently, the BigQuery analysis cost is US$5 per additional TB processed.
+
+You can check the up-to-date BigQuery costs on the [Google Cloud Platform](https://cloud.google.com/bigquery/pricing) site.

--- a/next/content/bdPro/FAQ/en/extra-billing.md
+++ b/next/content/bdPro/FAQ/en/extra-billing.md
@@ -1,5 +1,5 @@
 ---
-question: Can I incur extra charges for using BD Pro data?
+question: Can I incur extra charges for using DB Pro data?
 categories: []
 keywords: []
 id: extra-billing

--- a/next/content/bdPro/FAQ/en/how-to-access-data.md
+++ b/next/content/bdPro/FAQ/en/how-to-access-data.md
@@ -6,12 +6,12 @@ order: 5
 id: how-to-access-data
 ---
 
-BD Pro data can be accessed in different ways:
+DB Pro data can be accessed in different ways:
 
 * Directly in Google BigQuery, using SQL to run queries
 * Through the BD packages for Python, R and Stata
 * Through BI tools, such as Power BI, Tableau, Qlik and others.
 
-In all cases you will need to create a project in BigQuery with the email registered in BD Pro.
+In all cases you will need to create a project in BigQuery with the email registered in DB Pro.
 
 For more details, see our [documentation](/docs/home)

--- a/next/content/bdPro/FAQ/en/how-to-access-data.md
+++ b/next/content/bdPro/FAQ/en/how-to-access-data.md
@@ -9,7 +9,7 @@ id: how-to-access-data
 DB Pro data can be accessed in different ways:
 
 * Directly in Google BigQuery, using SQL to run queries
-* Through the BD packages for Python, R and Stata
+* Through the DB packages for Python, R and Stata
 * Through BI tools, such as Power BI, Tableau, Qlik and others.
 
 In all cases you will need to create a project in BigQuery with the email registered in DB Pro.

--- a/next/content/bdPro/FAQ/en/how-to-access-data.md
+++ b/next/content/bdPro/FAQ/en/how-to-access-data.md
@@ -1,0 +1,17 @@
+---
+question: How can I access the data?
+categories: []
+keywords: []
+order: 5
+id: how-to-access-data
+---
+
+BD Pro data can be accessed in different ways:
+
+* Directly in Google BigQuery, using SQL to run queries
+* Through the BD packages for Python, R and Stata
+* Through BI tools, such as Power BI, Tableau, Qlik and others.
+
+In all cases you will need to create a project in BigQuery with the email registered in BD Pro.
+
+For more details, see our [documentation](/docs/home)

--- a/next/content/bdPro/FAQ/en/how-to-create-bq-project.md
+++ b/next/content/bdPro/FAQ/en/how-to-create-bq-project.md
@@ -1,0 +1,9 @@
+---
+question: How do I create a project in BigQuery?
+categories: []
+keywords: []
+order: 6
+id: how-to-create-bq-project
+---
+
+Go to the [tutorial](/docs/access_data_bq) to create a project in Google BigQuery and start using the Pro subscription.

--- a/next/content/bdPro/FAQ/en/how-to-use-python-r-stata.md
+++ b/next/content/bdPro/FAQ/en/how-to-use-python-r-stata.md
@@ -1,0 +1,9 @@
+---
+question: How can I use the subscription's Python, R and Stata packages?
+categories: []
+keywords: []
+order: 7
+id: how-to-use-python-r-stata
+---
+
+See the [full documentation](/docs/access_data_packages) on how to use the Data Basis packages to access BD Pro data.

--- a/next/content/bdPro/FAQ/en/how-to-use-python-r-stata.md
+++ b/next/content/bdPro/FAQ/en/how-to-use-python-r-stata.md
@@ -6,4 +6,4 @@ order: 7
 id: how-to-use-python-r-stata
 ---
 
-See the [full documentation](/docs/access_data_packages) on how to use the Data Basis packages to access BD Pro data.
+See the [full documentation](/docs/access_data_packages) on how to use the Data Basis packages to access DB Pro data.

--- a/next/content/bdPro/FAQ/en/what-is-bdpro.md
+++ b/next/content/bdPro/FAQ/en/what-is-bdpro.md
@@ -1,0 +1,11 @@
+---
+question: What is BD Pro?
+categories: [data]
+keywords: []
+order: 1
+id: what-is-bdpro
+---
+
+BD Pro is the Data Basis subscription that gives you access to the most up-to-date public data. With it, you access the country's main datasets — always up to date, cleaned, integrated and ready for analysis via SQL, Python or R. The subscription also includes automatic update notifications and expanded limits for direct download.
+
+By subscribing to BD Pro, you support the Data Basis mission — a nonprofit organization that extracts, standardizes and freely provides thousands of other datasets, democratizing access to information and accelerating the work of researchers, journalists, public managers and companies.

--- a/next/content/bdPro/FAQ/en/what-is-bdpro.md
+++ b/next/content/bdPro/FAQ/en/what-is-bdpro.md
@@ -1,11 +1,11 @@
 ---
-question: What is BD Pro?
+question: What is DB Pro?
 categories: [data]
 keywords: []
 order: 1
 id: what-is-bdpro
 ---
 
-BD Pro is the Data Basis subscription that gives you access to the most up-to-date public data. With it, you access the country's main datasets — always up to date, cleaned, integrated and ready for analysis via SQL, Python or R. The subscription also includes automatic update notifications and expanded limits for direct download.
+DB Pro is the Data Basis subscription that gives you access to the most up-to-date public data. With it, you access the country's main datasets — always up to date, cleaned, integrated and ready for analysis via SQL, Python or R. The subscription also includes automatic update notifications and expanded limits for direct download.
 
-By subscribing to BD Pro, you support the Data Basis mission — a nonprofit organization that extracts, standardizes and freely provides thousands of other datasets, democratizing access to information and accelerating the work of researchers, journalists, public managers and companies.
+By subscribing to DB Pro, you support the Data Basis mission — a nonprofit organization that extracts, standardizes and freely provides thousands of other datasets, democratizing access to information and accelerating the work of researchers, journalists, public managers and companies.

--- a/next/content/bdPro/FAQ/en/what-is-integrated-data.md
+++ b/next/content/bdPro/FAQ/en/what-is-integrated-data.md
@@ -1,0 +1,11 @@
+---
+question: What is integrated data?
+categories: [data]
+keywords: []
+order: 11
+id: what-is-integrated-data
+---
+
+Integrated data is data from different sources, organized and standardized to allow joint analysis — without you needing to process anything yourself.
+
+All BD datasets are integrated. For example, you can cross a region's import data with its socioeconomic indicators in a single SQL, Python or R query.

--- a/next/content/bdPro/FAQ/en/what-is-integrated-data.md
+++ b/next/content/bdPro/FAQ/en/what-is-integrated-data.md
@@ -8,4 +8,4 @@ id: what-is-integrated-data
 
 Integrated data is data from different sources, organized and standardized to allow joint analysis — without you needing to process anything yourself.
 
-All BD datasets are integrated. For example, you can cross a region's import data with its socioeconomic indicators in a single SQL, Python or R query.
+All DB datasets are integrated. For example, you can cross a region's import data with its socioeconomic indicators in a single SQL, Python or R query.

--- a/next/content/bdPro/FAQ/es/access-bases.md
+++ b/next/content/bdPro/FAQ/es/access-bases.md
@@ -1,0 +1,9 @@
+---
+question: ¿A qué conjuntos de datos tengo acceso?
+categories: []
+keywords: []
+order: 4
+id: access-bases
+---
+
+Todos los conjuntos de datos con actualización automática incluidos en la suscripción están listados en el [catálogo de metadatos](/search?contains=temporalcoverage_paid&page=1). Allí puedes filtrar, explorar y comprobar la cobertura temporal de cada uno.

--- a/next/content/bdPro/FAQ/es/access-to-recent-data.md
+++ b/next/content/bdPro/FAQ/es/access-to-recent-data.md
@@ -1,0 +1,9 @@
+---
+question: ¿Cómo hago para tener acceso a los datos más recientes?
+categories: []
+keywords: []
+order: 3
+id: access-to-recent-data
+---
+
+Los datos más recientes están disponibles exclusivamente para suscriptores BD Pro. Para tener acceso, basta con [suscribirte al servicio](#pricing) — cualquier persona u organización puede suscribirse sin restricciones. En cuanto se completa el pago, el acceso se habilita automáticamente y ya puedes utilizar los datos actualizados en la plataforma.

--- a/next/content/bdPro/FAQ/es/data-access-limit.md
+++ b/next/content/bdPro/FAQ/es/data-access-limit.md
@@ -1,0 +1,9 @@
+---
+question: ¿Existe un límite de uso de los datos BD Pro?
+categories: []
+keywords: []
+order: 8
+id: data-access-limit
+---
+
+No hay límite de uso impuesto por BD. Lo que existe es una cuota gratuita de 1 TB/mes concedida por Google a todos los usuarios — si se excede y la facturación está habilitada en tu proyecto, Google Cloud puede generar costos extra.

--- a/next/content/bdPro/FAQ/es/difference-open-pro.md
+++ b/next/content/bdPro/FAQ/es/difference-open-pro.md
@@ -1,0 +1,19 @@
+---
+question: ¿Por qué hay tablas BD Pro que también están abiertas?
+categories: []
+keywords: []
+order: 2
+id: difference-open-pro
+---
+
+Algunos conjuntos de datos están disponibles tanto en la versión gratuita de la plataforma como en la suscripción BD Pro — la diferencia está en la cobertura temporal. La versión BD Pro siempre trae los datos más recientes, mientras que la versión abierta mantiene un desfase de seis meses.
+
+Puedes comprobar la diferencia entre la versión abierta y la versión BD Pro de las tablas en la 'página de conjuntos' de nuestra plataforma.
+
+
+![table-coverage](https://storage.googleapis.com/basedosdados-website/bdpro/faq/table-coverage.png)
+
+
+Al seleccionar una tabla, puedes comprobar su frecuencia de actualización y cobertura temporal en la página de la tabla:
+
+![update-frequency](https://storage.googleapis.com/basedosdados-website/bdpro/faq/table-update-frequency.png)

--- a/next/content/bdPro/FAQ/es/extra-billing.md
+++ b/next/content/bdPro/FAQ/es/extra-billing.md
@@ -1,0 +1,13 @@
+---
+question: ¿Puedo tener cargos extra por usar los datos BD Pro?
+categories: []
+keywords: []
+id: extra-billing
+order: 9
+---
+
+Base de los Datos nunca cobrará tarifas extra sin que hayas confirmado y procesado el pago por tu cuenta en nuestra plataforma de pago.
+
+Sin embargo, Google Cloud puede cobrar si excedes la cuota gratuita del proyecto y tienes la facturación habilitada. Actualmente, el costo de análisis de BigQuery es de US$5 por TB adicional procesado.
+
+Puedes consultar los costos actualizados de BigQuery en el sitio de [Google Cloud Platform](https://cloud.google.com/bigquery/pricing).

--- a/next/content/bdPro/FAQ/es/how-to-access-data.md
+++ b/next/content/bdPro/FAQ/es/how-to-access-data.md
@@ -1,0 +1,17 @@
+---
+question: ¿Cómo puedo acceder a los datos?
+categories: []
+keywords: []
+order: 5
+id: how-to-access-data
+---
+
+Los datos BD Pro pueden accederse de diferentes formas:
+
+* Directamente en Google BigQuery, utilizando SQL para hacer consultas
+* Mediante los paquetes de BD para Python, R y Stata
+* A través de herramientas de BI, como Power BI, Tableau, Qlik entre otras.
+
+En todos los casos necesitarás crear un proyecto en BigQuery con tu correo registrado en BD Pro.
+
+Para más detalles, accede a nuestra [documentación](/docs/home)

--- a/next/content/bdPro/FAQ/es/how-to-create-bq-project.md
+++ b/next/content/bdPro/FAQ/es/how-to-create-bq-project.md
@@ -1,0 +1,9 @@
+---
+question: ¿Cómo crear un proyecto en BigQuery?
+categories: []
+keywords: []
+order: 6
+id: how-to-create-bq-project
+---
+
+Accede al [tutorial](/docs/access_data_bq) para crear un proyecto en Google BigQuery y empezar a utilizar la suscripción Pro.

--- a/next/content/bdPro/FAQ/es/how-to-use-python-r-stata.md
+++ b/next/content/bdPro/FAQ/es/how-to-use-python-r-stata.md
@@ -1,0 +1,9 @@
+---
+question: ¿Cómo puedo usar los paquetes de Python, R y Stata de la suscripción?
+categories: []
+keywords: []
+order: 7
+id: how-to-use-python-r-stata
+---
+
+Accede a la [documentación completa](/docs/access_data_packages) sobre cómo utilizar los paquetes de Base de los Datos para acceder a los datos de BD Pro.

--- a/next/content/bdPro/FAQ/es/what-is-bdpro.md
+++ b/next/content/bdPro/FAQ/es/what-is-bdpro.md
@@ -1,0 +1,11 @@
+---
+question: ¿Qué es BD Pro?
+categories: [data]
+keywords: []
+order: 1
+id: what-is-bdpro
+---
+
+BD Pro es la suscripción de Base de los Datos que da acceso a los datos públicos más actualizados. Con ella, accedes a los principales conjuntos de datos del país — siempre actualizados, tratados, integrados y listos para análisis vía SQL, Python o R. La suscripción incluye además notificaciones automáticas de actualización y límites ampliados para descarga directa.
+
+Al suscribirte a BD Pro, contribuyes a la misión de Base de los Datos — una organización sin fines de lucro que extrae, estandariza y pone a disposición gratuitamente miles de otros conjuntos de datos, democratizando el acceso a la información y acelerando el trabajo de investigadores, periodistas, gestores públicos y empresas.

--- a/next/content/bdPro/FAQ/es/what-is-integrated-data.md
+++ b/next/content/bdPro/FAQ/es/what-is-integrated-data.md
@@ -1,0 +1,11 @@
+---
+question: ¿Qué son los datos integrados?
+categories: [data]
+keywords: []
+order: 11
+id: what-is-integrated-data
+---
+
+Los datos integrados son aquellos provenientes de diferentes fuentes, organizados y estandarizados para permitir análisis conjuntos — sin que necesites tratar nada por tu cuenta.
+
+Todos los conjuntos de datos de BD son integrados. Por ejemplo, puedes cruzar datos de importaciones de una región con sus indicadores socioeconómicos en una única consulta SQL, Python o R.

--- a/next/content/caseStudies/en/jota.md
+++ b/next/content/caseStudies/en/jota.md
@@ -5,7 +5,7 @@ thumbnail: "https://storage.googleapis.com/basedosdados-website/estudos_de_caso/
 title: "Platform brings more transparency to the accountability of candidates and parties in the 2022 Elections"
 img: "https://storage.googleapis.com/basedosdados-website/estudos_de_caso/imagens/estudo_de_caso_jota.png"
 imgDescription: "Photo: Superior Electoral Court (TSE)"
-description: "Created by BD in partnership with JOTA, a journalism and technology company, the 'Follow the Money' platform helped the population and press monitor campaign financing during the 2022 elections. The project became an important tool for public transparency and combating corruption in the electoral process."
+description: "Created by DB in partnership with JOTA, a journalism and technology company, the 'Follow the Money' platform helped the population and press monitor campaign financing during the 2022 elections. The project became an important tool for public transparency and combating corruption in the electoral process."
 logo: {
   img: "https://storage.googleapis.com/basedosdados-website/estudos_de_caso/logos/jota.svg",
   width: 222,

--- a/next/content/chatbot/FAQ/en/available-data-chatbot.md
+++ b/next/content/chatbot/FAQ/en/available-data-chatbot.md
@@ -6,4 +6,4 @@ order: 3
 id: available-data-chatbot
 ---
 
-The chatbot is connected to more than 740 tables that make up BD's public datalake. It is a valuable and constantly expanding source, with data on diverse topics: economy, health, education, demography, environment and much more.
+The chatbot is connected to more than 740 tables that make up DB's public datalake. It is a valuable and constantly expanding source, with data on diverse topics: economy, health, education, demography, environment and much more.

--- a/next/content/chatbot/FAQ/en/available-data-chatbot.md
+++ b/next/content/chatbot/FAQ/en/available-data-chatbot.md
@@ -1,0 +1,9 @@
+---
+question: What data is available to query?
+categories: []
+keywords: []
+order: 3
+id: available-data-chatbot
+---
+
+The chatbot is connected to more than 740 tables that make up BD's public datalake. It is a valuable and constantly expanding source, with data on diverse topics: economy, health, education, demography, environment and much more.

--- a/next/content/chatbot/FAQ/en/chatbot-no-answer.md
+++ b/next/content/chatbot/FAQ/en/chatbot-no-answer.md
@@ -1,0 +1,9 @@
+---
+question: What should I do if the chatbot can't find an answer?
+categories: []
+keywords: []
+order: 9
+id: chatbot-no-answer
+---
+
+For complex questions, we recommend breaking the request into smaller, simpler questions. Another useful tip is to mention the specific name of a column (such as "municipality") or explicitly ask the chatbot to search within a dataset you already know.

--- a/next/content/chatbot/FAQ/en/free-trial-chatbot.md
+++ b/next/content/chatbot/FAQ/en/free-trial-chatbot.md
@@ -1,0 +1,9 @@
+---
+question: Can I try the chatbot for free?
+categories: []
+keywords: []
+order: 5
+id: free-trial-chatbot
+---
+
+Yes. We offer a 7-day free trial so you can get to know the tool. After that period, the chatbot is part of a subscription plan that guarantees unlimited questions and helps us keep our public datalake free.

--- a/next/content/chatbot/FAQ/en/how-download-response-data.md
+++ b/next/content/chatbot/FAQ/en/how-download-response-data.md
@@ -1,0 +1,9 @@
+---
+question: How can I download the data from the answer?
+categories: []
+keywords: []
+order: 6
+id: how-download-response-data
+---
+
+Every chatbot analysis comes with an SQL query. You can copy that code and use it in BigQuery (a Google tool) to extract the full table and create your own visualizations or reports.

--- a/next/content/chatbot/FAQ/en/programming-sql-not-required.md
+++ b/next/content/chatbot/FAQ/en/programming-sql-not-required.md
@@ -1,0 +1,9 @@
+---
+question: Do I need to know how to program or know SQL to use the Chatbot?
+categories: []
+keywords: []
+order: 2
+id: programming-sql-not-required
+---
+
+No. The Chatbot was designed so anyone can explore public data using natural language. Even extracting the data used in an answer requires no prior SQL knowledge: the chatbot generates the query and lets you go straight to the data you need.

--- a/next/content/chatbot/FAQ/en/sql-bigquery-download-steps.md
+++ b/next/content/chatbot/FAQ/en/sql-bigquery-download-steps.md
@@ -1,0 +1,20 @@
+---
+question: How do I use the SQL query to download the data from the answer?
+categories: []
+keywords: []
+order: 8
+id: sql-bigquery-download-steps
+---
+
+The Chatbot always returns an SQL query along with the answer. You can copy that query and use [Google BigQuery](https://cloud.google.com/bigquery) — Google's data query and visualization tool — to extract a table with the data used in the analysis.
+
+To do so, follow these steps:
+
+1. Go to the [Google BigQuery](https://cloud.google.com/bigquery) site.
+2. If you land on the product's home page, click something like **Try in Console** or **Console** to open the query interface.
+3. Sign in with a Google account and create a project, if you don't have one yet.
+4. Once the project is created, open **SQL Query** (or the equivalent in the console) to access the editor.
+5. Paste the query provided by the chatbot and run it.
+6. After running it, you can save the results in your preferred format or open them with other Google tools for visualization.
+
+If you run into trouble with this flow, our team and community can help on the [Data Basis Discord](https://discord.gg/huKWpsVYx4).

--- a/next/content/chatbot/FAQ/en/sql-bigquery-download-steps.md
+++ b/next/content/chatbot/FAQ/en/sql-bigquery-download-steps.md
@@ -17,4 +17,4 @@ To do so, follow these steps:
 5. Paste the query provided by the chatbot and run it.
 6. After running it, you can save the results in your preferred format or open them with other Google tools for visualization.
 
-If you run into trouble with this flow, our team and community can help on the [Data Basis Discord](https://discord.gg/huKWpsVYx4).
+If you run into trouble with this flow, our team and community can help on the [Data Basis Discord](https://discord.gg/tx57ek6zqQ).

--- a/next/content/chatbot/FAQ/en/technical-support-chatbot.md
+++ b/next/content/chatbot/FAQ/en/technical-support-chatbot.md
@@ -1,0 +1,9 @@
+---
+question: Is there technical support?
+categories: []
+keywords: []
+order: 7
+id: technical-support-chatbot
+---
+
+Yes. Subscribers get priority support via email and Discord. You can also send questions and suggestions directly to our community and technical team.

--- a/next/content/chatbot/FAQ/en/use-results-own-reports.md
+++ b/next/content/chatbot/FAQ/en/use-results-own-reports.md
@@ -1,0 +1,9 @@
+---
+question: Can I use the results in my own reports and charts?
+categories: []
+keywords: []
+order: 4
+id: use-results-own-reports
+---
+
+Yes. In addition to the text analysis, you receive the code to download the data via BigQuery. This gives you the flexibility to take the information into Excel, Google Sheets or visualization tools and create your own maps and dashboards.

--- a/next/content/chatbot/FAQ/en/what-is-bd-chatbot.md
+++ b/next/content/chatbot/FAQ/en/what-is-bd-chatbot.md
@@ -1,0 +1,9 @@
+---
+question: What is the BD Chatbot?
+categories: []
+keywords: []
+order: 1
+id: what-is-bd-chatbot
+---
+
+It is a query interface that uses natural language so anyone can explore the Data Basis public datalake. It uses Google's Gemini model to turn your questions into precise data queries.

--- a/next/content/chatbot/FAQ/en/what-is-bd-chatbot.md
+++ b/next/content/chatbot/FAQ/en/what-is-bd-chatbot.md
@@ -1,5 +1,5 @@
 ---
-question: What is the BD Chatbot?
+question: What is the DB Chatbot?
 categories: []
 keywords: []
 order: 1

--- a/next/content/chatbot/FAQ/en/why-beta-version.md
+++ b/next/content/chatbot/FAQ/en/why-beta-version.md
@@ -1,0 +1,9 @@
+---
+question: Why is the tool in Beta?
+categories: []
+keywords: []
+order: 10
+id: why-beta-version
+---
+
+Beta means the chatbot is constantly improving. That's why your feedback through the like and dislike buttons (👍/👎) on each answer is essential for us to calibrate the model and improve the accuracy of the results.

--- a/next/content/chatbot/FAQ/es/available-data-chatbot.md
+++ b/next/content/chatbot/FAQ/es/available-data-chatbot.md
@@ -1,0 +1,9 @@
+---
+question: ¿Qué datos están disponibles para consultar?
+categories: []
+keywords: []
+order: 3
+id: available-data-chatbot
+---
+
+El chatbot está conectado a más de 740 tablas que componen el datalake público de BD. Es una fuente valiosa y en constante expansión, con datos sobre temas diversos: economía, salud, educación, demografía, medio ambiente y mucho más.

--- a/next/content/chatbot/FAQ/es/chatbot-no-answer.md
+++ b/next/content/chatbot/FAQ/es/chatbot-no-answer.md
@@ -1,0 +1,9 @@
+---
+question: ¿Qué hacer si el chatbot no encuentra una respuesta?
+categories: []
+keywords: []
+order: 9
+id: chatbot-no-answer
+---
+
+Para preguntas complejas, recomendamos dividir la solicitud en preguntas más pequeñas y simples. Otro consejo útil es mencionar el nombre específico de una columna (como "municipio") o pedir explícitamente al chatbot que busque en un conjunto de datos que ya conozcas.

--- a/next/content/chatbot/FAQ/es/free-trial-chatbot.md
+++ b/next/content/chatbot/FAQ/es/free-trial-chatbot.md
@@ -1,0 +1,9 @@
+---
+question: ¿Puedo probar el chatbot gratuitamente?
+categories: []
+keywords: []
+order: 5
+id: free-trial-chatbot
+---
+
+Sí. Ofrecemos un período de prueba gratuito de 7 días para que conozcas la herramienta. Después de ese período, el chatbot forma parte de un plan de suscripción que garantiza preguntas ilimitadas y nos ayuda a mantener nuestro datalake público gratuito.

--- a/next/content/chatbot/FAQ/es/how-download-response-data.md
+++ b/next/content/chatbot/FAQ/es/how-download-response-data.md
@@ -1,0 +1,9 @@
+---
+question: ¿Cómo puedo descargar los datos de la respuesta?
+categories: []
+keywords: []
+order: 6
+id: how-download-response-data
+---
+
+Todo análisis del chatbot va acompañado de una consulta SQL. Puedes copiar ese código y utilizarlo en BigQuery (herramienta de Google) para extraer la tabla completa y crear tus propias visualizaciones o informes.

--- a/next/content/chatbot/FAQ/es/programming-sql-not-required.md
+++ b/next/content/chatbot/FAQ/es/programming-sql-not-required.md
@@ -1,0 +1,9 @@
+---
+question: ¿Necesito saber programar o conocer SQL para usar el Chatbot?
+categories: []
+keywords: []
+order: 2
+id: programming-sql-not-required
+---
+
+No. El Chatbot fue diseñado para que cualquier persona explore datos públicos usando lenguaje natural. El propio proceso de extraer los datos utilizados en una respuesta no exige conocimientos previos de SQL: el chatbot genera la consulta y te permite ir directo a los datos que necesitas.

--- a/next/content/chatbot/FAQ/es/sql-bigquery-download-steps.md
+++ b/next/content/chatbot/FAQ/es/sql-bigquery-download-steps.md
@@ -17,4 +17,4 @@ Para ello, sigue estos pasos:
 5. Pega la consulta proporcionada por el chatbot y ejecútala.
 6. Tras ejecutarla, puedes guardar los resultados en el formato que prefieras o abrirlos con otras herramientas de Google para visualización.
 
-Si tienes problemas con este flujo, nuestro equipo y comunidad pueden ayudarte en el [Discord de Base de los Datos](https://discord.gg/huKWpsVYx4).
+Si tienes problemas con este flujo, nuestro equipo y comunidad pueden ayudarte en el [Discord de Base de los Datos](https://discord.gg/nNfQYcmrvM).

--- a/next/content/chatbot/FAQ/es/sql-bigquery-download-steps.md
+++ b/next/content/chatbot/FAQ/es/sql-bigquery-download-steps.md
@@ -1,0 +1,20 @@
+---
+question: ¿Cómo usar la consulta SQL para descargar los datos de la respuesta?
+categories: []
+keywords: []
+order: 8
+id: sql-bigquery-download-steps
+---
+
+El Chatbot siempre devuelve una consulta SQL junto con la respuesta. Puedes copiar esa consulta y usar [Google BigQuery](https://cloud.google.com/bigquery) — herramienta de consulta y visualización de datos de Google — para extraer una tabla con los datos utilizados en el análisis.
+
+Para ello, sigue estos pasos:
+
+1. Accede al sitio de [Google BigQuery](https://cloud.google.com/bigquery).
+2. Si te dirige a la página de inicio del producto, haz clic en algo como **Prueba en la Consola** o **Consola** para abrir la interfaz de consultas.
+3. Inicia sesión con una cuenta de Google y crea un proyecto, si aún no tienes uno.
+4. Después de crear el proyecto, abre **Consulta SQL** (o el equivalente en la consola) para acceder al editor.
+5. Pega la consulta proporcionada por el chatbot y ejecútala.
+6. Tras ejecutarla, puedes guardar los resultados en el formato que prefieras o abrirlos con otras herramientas de Google para visualización.
+
+Si tienes problemas con este flujo, nuestro equipo y comunidad pueden ayudarte en el [Discord de Base de los Datos](https://discord.gg/huKWpsVYx4).

--- a/next/content/chatbot/FAQ/es/technical-support-chatbot.md
+++ b/next/content/chatbot/FAQ/es/technical-support-chatbot.md
@@ -1,0 +1,9 @@
+---
+question: ¿Existe algún soporte técnico?
+categories: []
+keywords: []
+order: 7
+id: technical-support-chatbot
+---
+
+Sí. Los suscriptores cuentan con soporte prioritario por correo electrónico y Discord. También puedes enviar dudas y sugerencias directamente a nuestra comunidad y equipo técnico.

--- a/next/content/chatbot/FAQ/es/use-results-own-reports.md
+++ b/next/content/chatbot/FAQ/es/use-results-own-reports.md
@@ -1,0 +1,9 @@
+---
+question: ¿Puedo usar los resultados en mis propios informes y gráficos?
+categories: []
+keywords: []
+order: 4
+id: use-results-own-reports
+---
+
+Sí. Además del análisis en texto, recibes el código para descargar los datos vía BigQuery. Esto te da flexibilidad para llevar la información a Excel, Google Sheets o herramientas de visualización y crear tus propios mapas y dashboards.

--- a/next/content/chatbot/FAQ/es/what-is-bd-chatbot.md
+++ b/next/content/chatbot/FAQ/es/what-is-bd-chatbot.md
@@ -1,0 +1,9 @@
+---
+question: ¿Qué es el Chatbot de BD?
+categories: []
+keywords: []
+order: 1
+id: what-is-bd-chatbot
+---
+
+Es una interfaz de consulta que utiliza lenguaje natural para que cualquier persona explore el datalake público de Base de los Datos. Utiliza el modelo Gemini, de Google, para transformar tus preguntas en consultas de datos precisas.

--- a/next/content/chatbot/FAQ/es/why-beta-version.md
+++ b/next/content/chatbot/FAQ/es/why-beta-version.md
@@ -1,0 +1,9 @@
+---
+question: ¿Por qué la herramienta está en versión Beta?
+categories: []
+keywords: []
+order: 10
+id: why-beta-version
+---
+
+La versión Beta significa que el chatbot está en constante mejora. Por eso, tu feedback mediante los botones de me gusta y no me gusta (👍/👎) en cada respuesta es fundamental para calibrar el modelo y mejorar la precisión de los resultados.

--- a/next/content/docs/en/access_data_bq.md
+++ b/next/content/docs/en/access_data_bq.md
@@ -86,9 +86,9 @@ Just click **Run** and you're done!
 
 ## Understanding BigQuery's Free Usage
 
-This section is dedicated to presenting tips on how to reduce processing costs to maximize the data from BD! 
+This section is dedicated to presenting tips on how to reduce processing costs to maximize the data from DB! 
 
-For users who access data in public projects like the BD, the only type of cost associated is the cost of **processing queries**. The good news, as mentioned above, is that every user gets *1 TB free per month for querying data*. If you still don't have a project in BQ, consult [the section above](#getting-started) to create one.
+For users who access data in public projects like the DB, the only type of cost associated is the cost of **processing queries**. The good news, as mentioned above, is that every user gets *1 TB free per month for querying data*. If you still don't have a project in BQ, consult [the section above](#getting-started) to create one.
 
 - Knowing the basics of the BQ interface is important for understanding the article. If you don't have familiariadade or want to revisit the interface, we recommend 3 tracks:
 1. Our guide using the [RAIS - Annual Relation of Information Society](https://dev.to/basedosdados/bigquery-101-45pk) tables 
@@ -98,7 +98,7 @@ For users who access data in public projects like the BD, the only type of cost 
 
 ### See how to maximize the benefits of free queries
 
-In this section, we present some simple tips to reduce the costs of queries in Big Query and maximize the data from BD! Before moving on to the examples, we'll introduce the basic mechanism for predicting query processing costs in Big Query (BQ). 
+In this section, we present some simple tips to reduce the costs of queries in Big Query and maximize the data from DB! Before moving on to the examples, we'll introduce the basic mechanism for predicting query processing costs in Big Query (BQ). 
 
 <Tip caption="Cost estimates"/>
   In the upper right corner of the BQ interface, there's a notice with an estimate of the processing cost that will be charged to your project after the query execution.
@@ -106,7 +106,7 @@ In this section, we present some simple tips to reduce the costs of queries in B
 <Image src="/docs/bq_query_estimated_costs.png"/>
 
 
-- This is the basic and readily accessible mechanism for predictability of processing costs. Unfortunately, it doesn't work for all tables. Due to limitations within Big Query itself, queries to specific tables don't display cost estimates. This is the case of tables with **Row Access Policy**. This means that the number of accessible rows is limited depending on the user. This is the case of tables that are part of the [BD Pro](https://info.basedosdados.org/en/bd-pro) service
+- This is the basic and readily accessible mechanism for predictability of processing costs. Unfortunately, it doesn't work for all tables. Due to limitations within Big Query itself, queries to specific tables don't display cost estimates. This is the case of tables with **Row Access Policy**. This means that the number of accessible rows is limited depending on the user. This is the case of tables that are part of the [DB Pro](https://info.basedosdados.org/en/bd-pro) service
 
 - Example of the `agencia` table from the `br_bcb_estban` dataset. 
 
@@ -148,7 +148,7 @@ SELECT sequencial_obito, tipo_obito, data_obito FROM `basedosdados.br_ms_sim.mic
 
 - How to know which column was used to partition and cluster a specific table?
 
-  1. By the metadata on the table page on the BD website
+  1. By the metadata on the table page on the DB website
 
 <Image src="/docs/website_metadata_table_partitions.gif"/>
 

--- a/next/content/docs/en/api_reference_python.md
+++ b/next/content/docs/en/api_reference_python.md
@@ -137,7 +137,7 @@ Raises
 
 - `Exception`: If either `table_id`, `dataset_id` or `query` are empty.
 
-Functions to get metadata from BD's API.
+Functions to get metadata from DB's API.
 
 ## get_datasets
 

--- a/next/content/docs/en/colab_data.md
+++ b/next/content/docs/en/colab_data.md
@@ -115,7 +115,7 @@ The RAIS architecture tables [can be found here](https://docs.google.com/spreads
 
 #### To fill in each table in your set, follow these steps:
 
-<Tip caption="A each beginning and end of step, consult our [style guide](style_data) to ensure you're following the BD standardization"/>
+<Tip caption="A each beginning and end of step, consult our [style guide](style_data) to ensure you're following the DB standardization"/>
 
 1. List all data variables in the `original_name` column
 - Note: If the database changes the names of variables over the years (such as RAIS), it is necessary to make all variables compatible between years by filling in the `original_name_YYYY` column for each available year or month

--- a/next/content/docs/en/colab_data.md
+++ b/next/content/docs/en/colab_data.md
@@ -48,7 +48,7 @@ Some knowledge is required to perform this process:
 
 <Tip caption="Don't have any of these skills, but want to collaborate?">
 
-We have a data team that can help you. Just join [our Discord](https://discord.gg/huKWpsVYx4) and send a message to #quero-contribuir.
+We have a data team that can help you. Just join [our Discord](https://discord.gg/tx57ek6zqQ) and send a message to #quero-contribuir.
 </Tip>
 
 ### How does the process work?
@@ -191,7 +191,7 @@ It already has the standard structure we use for dictionaries.
 All done! Now all that's left is to upload it to Google Cloud and send it for review.
 To do this, we will use the `basedosdados` client (available in Python), which facilitates the settings and steps of the process.
 
-<Tip caption="Since there is a cost for storage, to complete this step we will need to provide you with a specific api_key for volunteers to upload the data to our development environment. So, join our [Discord channel](https://discord.gg/huKWpsVYx4), call us at ‘quero-contribuir’ and tag `@equipe_dados`"/>
+<Tip caption="Since there is a cost for storage, to complete this step we will need to provide you with a specific api_key for volunteers to upload the data to our development environment. So, join our [Discord channel](https://discord.gg/tx57ek6zqQ), call us at ‘quero-contribuir’ and tag `@equipe_dados`"/>
 
 #### Configure your credentials locally
 **7.1** Install our client on your terminal: `pip install basedosdados`.

--- a/next/content/docs/en/colab_infrastructure.md
+++ b/next/content/docs/en/colab_infrastructure.md
@@ -18,7 +18,7 @@ Our infrastructure consists of 3 main fronts:
 
 Currently, it's possible to collaborate on all fronts, with emphasis on developing checks and balances and website updates.
 
-<Tip caption="We suggest joining our [Discord channel](https://discord.gg/huKWpsVYx4) to ask questions and interact with other contributors! :)"/>
+<Tip caption="We suggest joining our [Discord channel](https://discord.gg/tx57ek6zqQ) to ask questions and interact with other contributors! :)"/>
 
 
 ## Data ingestion system

--- a/next/content/docs/en/home.md
+++ b/next/content/docs/en/home.md
@@ -52,8 +52,8 @@ tables with:
 
 Base dos Dados packages allow access to the public *data lake*
 directly from your computer or development environment.
-{/* Another way to access BD resources is directly through the endpoints, as
-documented in [BD Open API](https://basedosdados.org/openapi).
+{/* Another way to access DB resources is directly through the endpoints, as
+documented in [DB Open API](https://basedosdados.org/openapi).
 */}
 The currently available packages are:
 

--- a/next/content/docs/en/style_data.md
+++ b/next/content/docs/en/style_data.md
@@ -281,4 +281,4 @@ The field refers to the data in the raw data source, which has not yet passed th
 
 ## **Thought of improvements for the standards defined?**
 
-Open an [issue on our Github](https://github.com/basedosdados/sdk/labels/docs) or send a message on [Discord](https://discord.gg/huKWpsVYx4) to talk to us :)
+Open an [issue on our Github](https://github.com/basedosdados/sdk/labels/docs) or send a message on [Discord](https://discord.gg/tx57ek6zqQ) to talk to us :)

--- a/next/content/docs/en/style_data.md
+++ b/next/content/docs/en/style_data.md
@@ -231,7 +231,7 @@ OPTIONS (Description='Description of the table')
 
 - BigQuery accepts up to 4,000 partitions per table.
 
-- In our BD, tables are usually partitioned by: `year`, `month`, `quarter`, and `state_code`.
+- In our DB, tables are usually partitioned by: `year`, `month`, `quarter`, and `state_code`.
 
 - Note that when partitioning a table, it is necessary to exclude the corresponding column. Example: it is necessary to exclude the `year` column when partitioning by `year`.
 

--- a/next/content/docs/es/colab_data.md
+++ b/next/content/docs/es/colab_data.md
@@ -33,7 +33,7 @@ Para facilitar la explicación, seguiremos un ejemplo ya preparado con datos de 
 
 <Tip caption="Puede navegar por los pasos en el menú de la izquierda">
 
- ¡Le recomendamos encarecidamente que se una a nuestro [canal en Discord](https://discord.gg/huKWpsVYx4) para resolver dudas e interactuar con el equipo y otros colaboradores! 😉
+ ¡Le recomendamos encarecidamente que se una a nuestro [canal en Discord](https://discord.gg/nNfQYcmrvM) para resolver dudas e interactuar con el equipo y otros colaboradores! 😉
 </Tip>
 
 ### Antes de empezar
@@ -48,7 +48,7 @@ Para llevar a cabo este proceso, es necesario tener algunos conocimientos:
 
 <Tip caption="¿No tienes ninguna de estas habilidades, pero quieres colaborar?">
 
-Tenemos un equipo de datos que puede ayudarte, solo tienes que entrar en [nuestro Discord](https://discord.gg/huKWpsVYx4) y enviar un mensaje a #quiero-contribuir.
+Tenemos un equipo de datos que puede ayudarte, solo tienes que entrar en [nuestro Discord](https://discord.gg/nNfQYcmrvM) y enviar un mensaje a #quiero-contribuir.
 </Tip>
 
 ### ¿Cómo funciona el proceso?
@@ -184,7 +184,7 @@ El diccionario completo [se puede consultar aquí](https://docs.google.com/sprea
 
 ¡Todo listo! Ahora solo falta subirlo a Google Cloud y enviarlo para su revisión. Para ello, utilizaremos el cliente `basedosdados` (disponible en Python), que facilita la configuración y los pasos del proceso.
 
-<Tip caption="Dado que el almacenamiento tiene un coste, para finalizar este paso necesitaremos proporcionarte una api_key específica para voluntarios para subir los datos a nuestro entorno de desarrollo. Para ello, entra en nuestro [canal de Discord](https://discord.gg/huKWpsVYx4), envíanos un mensaje con «quiero-contribuir» y etiqueta a `@equipe_dados`."/>
+<Tip caption="Dado que el almacenamiento tiene un coste, para finalizar este paso necesitaremos proporcionarte una api_key específica para voluntarios para subir los datos a nuestro entorno de desarrollo. Para ello, entra en nuestro [canal de Discord](https://discord.gg/nNfQYcmrvM), envíanos un mensaje con «quiero-contribuir» y etiqueta a `@equipe_dados`."/>
 
 
 #### Configure sus credenciales localmente

--- a/next/content/docs/es/colab_infrastructure.md
+++ b/next/content/docs/es/colab_infrastructure.md
@@ -23,7 +23,7 @@ Nuestra infraestructura se compone de 3 frentes principales:
 Actualmente es posible colaborar en todos los frentes, con énfasis en el
 desarrollo de los pesos y contrapesos y la actualización del sitio.
 
-<Tip caption="¡Sugerimos que te unas a nuestro [canal de Discord](https://discord.gg/huKWpsVYx4) para resolver dudas e interactuar con otros(as) colaboradores(as)! :)"/>
+<Tip caption="¡Sugerimos que te unas a nuestro [canal de Discord](https://discord.gg/nNfQYcmrvM) para resolver dudas e interactuar con otros(as) colaboradores(as)! :)"/>
 
 ## Sistema de ingestión de datos
 

--- a/next/content/docs/es/style_data.md
+++ b/next/content/docs/es/style_data.md
@@ -313,4 +313,4 @@ El campo se refiere a los datos en la fuente original, que aún no han pasado po
 
 ## **¿Pensaste en mejoras para los estándares definidos?**
 
-Abre un [issue en nuestro Github](https://github.com/basedosdados/sdk/labels/docs) o envía un mensaje en [Discord](https://discord.gg/huKWpsVYx4) para conversar :)
+Abre un [issue en nuestro Github](https://github.com/basedosdados/sdk/labels/docs) o envía un mensaje en [Discord](https://discord.gg/nNfQYcmrvM) para conversar :)

--- a/next/content/services/FAQ/en/chatbot_prerequisites.md
+++ b/next/content/services/FAQ/en/chatbot_prerequisites.md
@@ -9,4 +9,4 @@ You will need three things:
 
 - A data storage environment already populated with your data
 - Your data needs to have organized metadata
-- An internal server to run the chatbot (or you can use BD's server)
+- An internal server to run the chatbot (or you can use DB's server)

--- a/next/content/services/FAQ/en/dashboard_technologies.md
+++ b/next/content/services/FAQ/en/dashboard_technologies.md
@@ -1,5 +1,5 @@
 ---
-question: What technologies does BD typically use for this type of service?
+question: What technologies does DB typically use for this type of service?
 categories: [Painel Gerencial]
 id: dashboard_technologies
 order: 3

--- a/next/content/services/FAQ/en/data_architecture_service_components.md
+++ b/next/content/services/FAQ/en/data_architecture_service_components.md
@@ -15,7 +15,7 @@ The service includes:\
 **Processing**:  
 - Development of a Style Manual to standardize data and metadata throughout the data lifecycle  
 - Implementation of tools to ensure data quality, following business rules  
-- Planning processes to maintain and expand infrastructure, with the option to train your team or rely on BD's services  
+- Planning processes to maintain and expand infrastructure, with the option to train your team or rely on DB's services  
 
 **Availability**:  
 - Integration with applications, chatbots, and other tools  

--- a/next/content/services/FAQ/en/existing_architecture_support.md
+++ b/next/content/services/FAQ/en/existing_architecture_support.md
@@ -5,4 +5,4 @@ id: existing_architecture_support
 order: 5
 ---
 
-Yes! Our team can work with different technology stacks, always following BD's best practices for data governance.
+Yes! Our team can work with different technology stacks, always following DB's best practices for data governance.

--- a/next/content/services/FAQ/en/standalone_training.md
+++ b/next/content/services/FAQ/en/standalone_training.md
@@ -1,8 +1,8 @@
 ---
-question: Is training only available for those who have contracted other BD services?
+question: Is training only available for those who have contracted other DB services?
 categories: [Formação]
 id: standalone_training
 order: 7
 ---
 
-No. We offer standalone training programs, designed for any team that wants to strengthen their data skills — even if they haven't contracted other BD services.
+No. We offer standalone training programs, designed for any team that wants to strengthen their data skills — even if they haven't contracted other DB services.

--- a/next/content/services/FAQ/en/target_institutions_dashboard.md
+++ b/next/content/services/FAQ/en/target_institutions_dashboard.md
@@ -5,4 +5,4 @@ id: target_institutions_dashboard
 order: 2
 ---
 
-BD's managerial dashboard service is useful for any institution, but we primarily focus on public agencies and third-sector organizations.
+DB's managerial dashboard service is useful for any institution, but we primarily focus on public agencies and third-sector organizations.

--- a/next/content/services/FAQ/en/target_institutions_data_architecture.md
+++ b/next/content/services/FAQ/en/target_institutions_data_architecture.md
@@ -5,4 +5,4 @@ id: target_institutions_data_architecture
 order: 2
 ---
 
-BD's data architecture service is useful for any institution, but we primarily focus on public agencies and third-sector organizations.
+DB's data architecture service is useful for any institution, but we primarily focus on public agencies and third-sector organizations.

--- a/next/content/services/FAQ/en/tech_stack_data_architecture.md
+++ b/next/content/services/FAQ/en/tech_stack_data_architecture.md
@@ -1,8 +1,8 @@
 ---
-question: What technologies does BD typically use for this type of service?
+question: What technologies does DB typically use for this type of service?
 categories: [Arquitetura de Dados]
 id: tech_stack_data_architecture
 order: 3
 ---
 
-Our technological stack was developed at BD and is used as a reference by major organizations such as Fundação Lemann, Rio de Janeiro City Hall, and the Ministry of Education.
+Our technological stack was developed at DB and is used as a reference by major organizations such as Fundação Lemann, Rio de Janeiro City Hall, and the Ministry of Education.

--- a/next/content/services/FAQ/en/training_instructors.md
+++ b/next/content/services/FAQ/en/training_instructors.md
@@ -5,4 +5,4 @@ id: training_instructors
 order: 6
 ---
 
-The courses are taught by BD team members with both technical and teaching experience. These are professionals who also work on our projects — meaning they understand both data and day-to-day challenges well.
+The courses are taught by DB team members with both technical and teaching experience. These are professionals who also work on our projects — meaning they understand both data and day-to-day challenges well.

--- a/next/content/userGuide/en/br-ibge-censo-2022.md
+++ b/next/content/userGuide/en/br-ibge-censo-2022.md
@@ -1,0 +1,62 @@
+---
+title: Usage guide for the 2022 Census dataset
+description: >-
+  Usage guide for the Annual Social Information Report (RAIS). This material contains information on the most important variables, frequently asked questions, and usage examples for the RAIS dataset 
+date:
+  created: "2024-11-28T18:18:06.419Z"
+thumbnail: 
+categories: [guia-de-uso]
+authors:
+  - name: Laura Amaral
+    role: Text
+---
+
+# Introduction
+
+> This guide contains detailed information about the data. For questions about accessing or using the platform, see our [Frequently Asked Questions page](/faq).
+
+This dataset has 2 microdata tables: 
+- **Establishment Microdata:** Each row represents an establishment in a given year. The columns describe characteristics of the company and its employees.
+- **Employment Ties Microdata:** Each row represents an employment tie in a given year. The columns describe characteristics of the type of tie, the employee, and the hiring company.
+
+# Considerations for analysis
+## Employment ties and data filtering
+The Employment Ties table includes every employment tie registered by a company during the year. Therefore, if an employee was dismissed and another hired for the same position in the same year, both will have a row for that position at the company. If the goal is to assess the total number of active employees in a sector or region, the `vinculo_ativo_3112` column must be used to filter for only the ties that are active on the date indicated.
+
+# Limitations
+* The data made available are limited to workers with a formal employment tie, and do not include information on informal or self-employed workers.
+* The public data are anonymized.
+
+# Inconsistencies
+## Columns quantidade_vinculos_ativos and tamanho_estabelecimento
+The `quantidade_vinculos_ativos` and `tamanho_estabelecimento` columns in the establishments table contain information that is inconsistent with each other. The first is an integer representing the total number of ties at that establishment, and the second is a category defined by the total number of ties. However, we found several cases in which the number of ties does not fall within the range defined by the establishment size. It is not yet known why this inconsistency occurs.
+
+# Observations over time
+These tables do not allow tracking of variables over time. To make comparisons across years, the microdata available in the Census microdata dataset must be aggregated.
+
+# Duplicate rows
+No evidence of duplicate rows has been found in the tables of this dataset so far.
+
+# Cross-referencing
+The Census tables can be cross-referenced with others using geographic breakdowns; we have geolocated information at the census tract level. Cross-referencing with other datasets that include municipality information is also possible.
+
+# Downloading the data
+Most of the Census tables are not very large; some can be downloaded directly through our platform, while others must be downloaded via Python or R.
+
+# Collection instrument
+Data collection was conducted, in general, through in-person interviews (direct, face-to-face interviews with household residents). In addition to this traditional method, the 2022 Demographic Census introduced the possibility of collection via the Internet. The census taker could offer this alternative at the resident's request, when there were access restrictions to specific areas (for example, in gated communities), or when any other difficulty arose in conducting the in-person interview. There was also an increase in data collection among Traditional Peoples and Communities, where quilombola communities were surveyed for the first time.
+
+# Changes in collection
+Since the data in this dataset refer only to 2022, the collection methodology is the same across the entire dataset.
+
+# Updates
+The 2022 Census data have no updates, but IBGE frequently makes new datasets available. The upcoming datasets are scheduled according to the [calendar](https://censo2022.ibge.gov.br/panorama/calendario.html?localidade=BR).
+
+# Processing done by DB
+Processing of the tables is minimal: 
+* Inclusion of id_municipio.
+* Merging of information on households, population, area, literacy rate, median age, aging index, indigenous population, and quilombola population into a single municipality table.
+* Creation of the `idade_anos` and `grupo_idade` columns to facilitate numeric operations on tables that contain age information.
+
+# Supporting materials
+* [Technical notes on the 2022 census](https://www.ibge.gov.br/estatisticas/sociais/trabalho/22827-censo-demografico-2022.html?=&t=notas-tecnicas): Relevant information on how each part of the survey was conducted, important for context and useful as inspiration for analyses.

--- a/next/content/userGuide/en/br-inep-censo-escolar.md
+++ b/next/content/userGuide/en/br-inep-censo-escolar.md
@@ -1,0 +1,72 @@
+---
+title: Usage guide for School Census data
+description: >-
+  Usage guide for Football Championships data. This material contains information on the most important variables, frequently asked questions, and usage examples for the dataset.
+date:
+  created: "2024-11-28T18:18:06.419Z"
+thumbnail: 
+categories: [guia-de-uso]
+authors:
+  - name: Laura Amaral
+    role: Text
+---
+
+# Introduction
+
+> This guide contains detailed information about the data. For questions about accessing or using the platform, see our [Frequently Asked Questions page](/faq).
+
+This dataset has four microdata tables:  
+- **Schools:** The only table made available by INEP starting in 2021, each row represents a school. The columns include school characteristics, such as available physical infrastructure, the pedagogical staff, pedagogical infrastructure, features of the school year, and aggregated information on enrollments, teachers, and classes.
+- **Classes:** Table made available through requests filed under the LAI (Access to Information Law). Each row represents a class active during the school year, and the columns contain information on the subjects taught to the class, the start time of classes, the number of students in the class, and the level of education.
+- **Enrollments:** Kept for historical reference, but not updated since 2021. Each row represents an enrollment, and the columns include sociodemographic variables, activities the student engages in, and the mode of transportation used to reach school.
+- **Teachers:** Kept for historical reference, but not updated since 2021. Each row represents the assignment of a teacher to a class at a school during a given year, and the columns hold sociodemographic characteristics, information on education and training, and details of the teacher's activity at the school.
+
+# Considerations for analysis
+## Variable selection
+We do not make all the variables that appear in the Census available. We selected variables that appeared 8 or more times between 2009 and 2020, in addition to other variables we judged to be crucial because they are important identifiers. This means that, if a variable appears in only 2 years in the original source, for example, it was not included in our tables.
+
+## Race and color information
+Race and color information in the School Census is filled in by the school, but many records are left blank. This can cause distortions in analyses on this topic using this dataset.
+
+We know this because the SAEB exam also collects students' race, but in a different way: the students themselves report it. School Census and SAEB data end up being quite different because of these different methodologies.
+
+# Limitations
+* Data are available from 2009 onward, since that is when the survey adopted a more uniform format. This makes comparison across years easier and ensures greater compatibility.
+
+# Inconsistencies
+No inconsistencies have been reported in this dataset yet.
+
+# Observations over time
+Students and teachers have anonymized information, so it is not possible to track these entities across years in the enrollment and teacher tables. Schools, on the other hand, are identifiable and can be tracked over the years.
+It is also worth noting that the enrollment and teacher tables stopped being made available in 2020.
+
+# Duplicate rows
+No evidence of duplicate rows has been found in the tables of this dataset yet.
+
+# Cross-referencing
+Within the dataset itself, the tables can be cross-referenced using the keys id_escola, id_turma, and ano. 
+In addition, these tables can be complemented with information from other INEP datasets:  
+1. **INEP School Indicators**: The INEP School Indicators bring a series of measurements on the quality of education at different levels of aggregation, enabling more detailed analyses of the educational context in schools, municipalities, and states.  
+2. **Basic Education Statistical Synopses**: The Basic Education Statistical Synopses present School Census information in an aggregated and simplified way, facilitating quick analyses and comparisons across different levels of education and regions.  
+3. **Basic Education Development Index (Ideb)**: The br_inep_ideb dataset provides tables that identify student scores on education-quality assessments, such as the SAEB exams, in addition to information on performance rates, such as pass, fail, and dropout rates, and school performance on the IDEB. Together with the Census tables, one can assess, for example, how schools with more teachers holding a master's degree perform on these exams relative to schools with teachers who do not hold a graduate degree.
+
+# Downloading the data
+These tables are too large to download directly; it is very important to select specific columns and apply temporal or geographic filters before downloading the data.
+
+The microdata add up to more than 300 GB. To avoid overloading your computer, we recommend using queries in BigQuery to process the data in the cloud before downloading it. Filter by the partition columns (such as ano and UF) and select only the relevant columns.
+
+# Collection instrument
+School Census data are collected in two stages. In the first half of the year, schools fill out five forms (schools, administrators, classes, students, and classroom staff) with information on all basic and vocational education institutions. At the end of the school year, the second stage records students' status, indicating whether they were promoted, held back, transferred, stopped attending, or died.
+
+# Changes in collection
+The main change over the years was the replacement of the enrollment, teacher, and school administrator tables with a single school table containing aggregated data. Starting in 2021, this new table included 123 new variables, providing access to some information on enrollments, teachers, and school administrators in summarized form.
+
+# Updates
+Data are updated annually, early in the year following data collection.
+
+# Processing done by DB:
+
+
+# Supporting materials
+[INEP website on the School Census](https://www.gov.br/inep/pt-br/areas-de-atuacao/pesquisas-estatisticas-e-indicadores/censo-escolar): Documents and instructions about the School Census, useful for better understanding the context and obtaining complementary materials such as the forms that are filled out, release and collection dates, among other information. 
+[DB note on the change in the release of School Census data](https://basedosdados.org/blog/nota-sobre-divulgacao-dos-dados-do-inep): Note laying out DB's position on the change that occurred in 2021

--- a/next/content/userGuide/en/br-inmet-bdmep.md
+++ b/next/content/userGuide/en/br-inmet-bdmep.md
@@ -62,7 +62,7 @@ These tables have been consistent since 2000; we have no record of changes to th
 The data are updated at the original source every hour. At Data Basis, we update this information monthly.
 
 # Treatments applied by DB:
-In this guide, the treatments are described in more accessible language. In addition, [the extraction and treatment code](https://github.com/basedosdados/pipelines/blob/main/pipelines/datasets/br_inmet_bdmep/flows.py) and the [modifications made in BigQuery](https://github.com/basedosdados/queries-basedosdados/blob/main/models/br_inmet_bdmep/br_inmet_bdmep__microdados.sql) are available in the GitHub repository for reference.
+In this guide, the treatments are described in more accessible language. In addition, [the extraction and treatment code](https://github.com/basedosdados/pipelines/blob/main/pipelines/datasets/br_inmet_bdmep/flows.py) and the [modifications made in BigQuery](https://github.com/basedosdados/pipelines/blob/main/models/br_inmet_bdmep/br_inmet_bdmep__microdados.sql) are available in the GitHub repository for reference.
 The treatments applied to the microdata table were:
 * Renaming columns to conform to DB's style manual.
 * Replacing invalid codes ("-9999") with null values.

--- a/next/content/userGuide/en/br-inmet-bdmep.md
+++ b/next/content/userGuide/en/br-inmet-bdmep.md
@@ -1,0 +1,74 @@
+---
+title: BDMEP Usage Guide
+description: >-
+  Usage guide for BDMEP Meteorological Data. This material contains information on the most important variables, frequently asked questions, and usage examples for the dataset
+date:
+  created: "2024-11-28T18:18:06.419Z"
+thumbnail: 
+categories: [guia-de-uso]
+authors:
+  - name: Laura Amaral
+    role: Text
+---
+
+# Introduction
+
+> This guide contains detailed information about the data. For questions about accessing or using the platform, consult our [Frequently Asked Questions page](/faq).
+
+This dataset has two microdata tables:  
+- **Microdata:** Each row represents a collection of measurements from a station at a given time. The columns provide information on precipitation, pressure, radiation, temperature, humidity, and wind.  
+- **Station:** Each row represents a meteorological station. The columns provide geographic information about that station.
+
+# Considerations for analysis
+
+## Calculation method
+Before performing operations with BDMEP data, it is crucial to understand how each measure was calculated. Some columns present average values, while others contain maximum or minimum values. The choice of the appropriate variable will depend on the specific needs of the analysis.
+
+## Empty rows, failures, and missing data
+INMET-BDMEP data have gaps, such as empty rows caused by sensor and communication problems at the meteorological stations. These gaps can be identified by all value columns being null. It is important to account for these gaps when performing analyses.
+
+## Time conversion
+All time information is in UTC. To convert it to official Brasília time, subtract 3 hours. For example, 12:00 UTC is equivalent to 9:00 Brasília time.
+
+## Raw and unvalidated data
+Data from the automatic stations are raw and do not undergo a consistency validation process.
+
+# Limitations
+* The microdata table made available by DB includes exclusively data from automatic stations.
+* Measurements refer to a single point in space. Extrapolating the data to larger areas should be done with weighting.
+
+# Inconsistencies
+No inconsistencies have been reported in this dataset yet.
+
+# Observations over time
+Each row represents a compilation of measurements taken by a meteorological station over a one-hour interval. The columns provided are aggregations of that period, allowing users to track the evolution of weather conditions over time at the stations.
+
+# Duplicate rows
+No duplicate rows have been reported in the tables of this dataset yet.
+
+# Crosswalks
+The microdata table can be linked to the station table through the `id_estação` column, enabling geolocation of the data. This makes it possible to cross the data externally with georeferenced tables or tables that have geolocation elements, such as a postal code column. In addition, the station table provides the municipality identifier, expanding the possibilities for crosswalks.
+
+# Downloading the data
+The microdata table is larger than 10GB. Depending on the computer's capacity, processing the data may overload the machine. We therefore recommend using queries in BigQuery to process the data in the cloud before downloading it. Filter by the partition column (year) and select only the relevant columns.
+
+# Collection instrument
+The data are collected by automatic meteorological stations (EMA). Data collection is carried out through sensors that measure the meteorological parameters to be observed. Measurements are taken at one-minute intervals and integrated over a one-hour period. The data collected by the EMAs are automatically sent to INMET headquarters in Brasília every hour.
+
+# Changes in collection
+These tables have been consistent since 2000; we have no record of changes to the collection method.
+
+# Updates
+The data are updated at the original source every hour. At Data Basis, we update this information monthly.
+
+# Treatments applied by DB:
+In this guide, the treatments are described in more accessible language. In addition, [the extraction and treatment code](https://github.com/basedosdados/pipelines/blob/main/pipelines/datasets/br_inmet_bdmep/flows.py) and the [modifications made in BigQuery](https://github.com/basedosdados/queries-basedosdados/blob/main/models/br_inmet_bdmep/br_inmet_bdmep__microdados.sql) are available in the GitHub repository for reference.
+The treatments applied to the microdata table were:
+* Renaming columns to conform to DB's style manual.
+* Replacing invalid codes ("-9999") with null values.
+* Adding the station identifier (id_estação) to the microdata table.
+* Adjusting the format of the date and time columns for compatibility with BigQuery.
+
+# Supporting materials
+* [Technical note on the operation of INMET's meteorological station network](http://www.cemtec.ms.gov.br/wp-content/uploads/2019/02/Nota_Tecnica-Rede_estacoes_INMET.pdf) 
+* [INMET notice - find out how to access meteorological data](https://portal.inmet.gov.br/noticias/saiba-como-acessar-os-dados-meteorol%C3%B3gicos-dispon%C3%ADveis-no-site-do-inmet?utm_source=chatgpt.com)

--- a/next/content/userGuide/en/br-me-caged.md
+++ b/next/content/userGuide/en/br-me-caged.md
@@ -121,7 +121,7 @@ The data are anonymized and contain no CNPJs or CPFs. To obtain identified data,
 
 # Processing done by DB:
 
-In this guide, the processing steps are described in more accessible language. In addition, the [extraction and processing code](https://github.com/basedosdados/queries-basedosdados-dev/blob/main/models/br_me_caged/code/crawler_caged.py) and the [modifications made in BigQuery](https://github.com/basedosdados/queries-basedosdados/tree/main/models/br_me_caged) are available in the GitHub repository for reference.
+In this guide, the processing steps are described in more accessible language. In addition, the [extraction and processing code](https://github.com/basedosdados/pipelines/blob/main/models/br_me_caged/code/crawler_caged.py) and the [modifications made in BigQuery](https://github.com/basedosdados/pipelines/tree/main/models/br_me_caged) are available in the GitHub repository for reference.
 The processing steps performed were:
 
 - Renaming columns to conform to the style manual;

--- a/next/content/userGuide/en/br-me-caged.md
+++ b/next/content/userGuide/en/br-me-caged.md
@@ -1,0 +1,137 @@
+---
+title: CAGED Usage Guide
+description: >-
+  Usage guide for the Cadastro Geral de Empregados e Desempregados (CAGED). This material contains information on the most important variables, frequently asked questions, and usage examples for the dataset.
+date:
+  created: "2024-11-28T18:18:06.419Z"
+thumbnail:
+categories: [guia-de-uso]
+authors:
+  - name: Laura Amaral
+    role: Text
+---
+
+# Introduction
+
+> This guide contains detailed information about the data. For questions about accessing or using the platform, see our [Frequently Asked Questions page](/faq).
+
+This dataset has five microdata tables, split between two from the old CAGED and three from the new CAGED. The methodologies of the old and new models are not compatible, which affects time-series analyses.
+
+- **Old Microdata:** Each row represents an admission or dismissal record up to December 2019. The columns describe the characteristics of the employee, the type of employment relationship, and the company.
+- **Old Adjustment Microdata:** Complements the Old Microdata table with adjustments to monthly admissions and dismissals, including cancellations and late-filed movements.
+- **Movement Microdata:** Each row represents an admission or dismissal record from January 2020 onward. The columns describe the characteristics of the employee, the type of employment relationship, and the company.
+- **Excluded Movement Microdata:** Complements the Movement Microdata table with cancellations of admissions or dismissals. These cancellations affect the CAGED balance in the opposite direction of the original event.
+- **Late-Filed Movement Microdata:** Complements the Movement Microdata table by recording events filed outside the regular period.
+
+# Considerations for analysis
+
+## Movement balance
+
+Job growth or reduction within a group can be determined by summing the `saldo_movimentacao` column. Check this column to see whether a row represents an admission or a dismissal.
+
+## Exclusions and late-filed movements
+
+Beyond regular movements, it is important to consider the Excluded Movement Microdata and Late-Filed Movement Microdata tables to obtain a more accurate balance. Cancellations affect the balance in the opposite direction of the original event, while late-filed movements include events recorded after the regular period.
+
+## Example of adjusting the balance with late-filed and excluded movements
+
+As an example of how to carry out the adjustment procedure, the following query can be used:
+
+```sql
+with tabelas_unidas as (
+select *, 0 as indicador_exclusao from `basedosdados.br_me_caged.microdados_movimentacao`
+union all
+select * except (ano,mes), 0 as indicador_exclusao from `basedosdados.br_me_caged.microdados_movimentacao_fora_prazo`
+union all
+select * except (ano,mes, ano_declaracao_movimentacao, mes_declaracao_movimentacao, indicador_exclusao), 1 as indicador_exclusao from `basedosdados.br_me_caged.microdados_movimentacao_excluida`),
+
+tabela_ajustada as (
+select *,
+case
+  when saldo_movimentacao = 1 then 'admissão'
+  when saldo_movimentacao = -1 then 'desligamento'
+end as admissao_desligamento,
+case
+  when indicador_exclusao = 0 then saldo_movimentacao
+  when indicador_exclusao = 1 then -saldo_movimentacao
+end as saldo_movimentacao_ajustado
+from tabelas_unidas)
+
+select
+ano,
+mes,
+sum(if(admissao_desligamento = 'admissão', saldo_movimentacao_ajustado, 0)) as qte_admissoes,
+sum(if(admissao_desligamento = 'desligamento', saldo_movimentacao_ajustado, 0))as qte_desligamentos,
+sum(saldo_movimentacao_ajustado) as saldo,
+from tabela_ajustada
+where sigla_uf='SP'
+group by 1, 2
+order by ano, mes
+```
+
+# Limitations
+
+The data are limited to workers with a formal employment relationship, and do not include information on informal or self-employed workers.
+
+# Inconsistencies
+
+## `salario_mensal` column
+
+Values outside the expected range have been identified, such as salaries in the range of millions of reais for sectors that generally do not pay such high amounts. This may be due to recording errors or outliers.
+
+## Unidentified municipalities and federative units
+
+In all tables, there are cases where the _uf_ column (sigla_uf, in DB) is filled with value 99 and the _municipio_ variable (id_municipio, in DB) is filled with value 99999.
+
+## CAGED jobs panel
+
+The [CAGED](https://app.powerbi.com/view?r=eyJrIjoiNWI5NWI0ODEtYmZiYy00Mjg3LTkzNWUtY2UyYjIwMDE1YWI2IiwidCI6IjNlYzkyOTY5LTVhNTEtNGYxOC04YWM5LWVmOThmYmFmYTk3OCJ9&pageName=ReportSectionb52b07ec3b5f3ac6c749) jobs panel is the validation reference for the adjustments that should be made using the microdados_movimentacao_fora_prazo and microdados_movimentacao_excluida tables.
+
+# Observations over time
+
+Each row represents a hiring or a dismissal. Because the data are de-identified, it is not possible to track individuals or companies over time. What is possible is to track the growth or decline of formally employed workers in a given sector (`cnae`), occupation (`cbo`), or other combinations of the available columns. It is also important to note that the CAGED methodology changed at the start of 2020, so time-series analyses should be conducted either up to 2019 or from 2020 onward, not across both periods.
+
+# Duplicate rows
+
+No duplicate rows have been found in this dataset.
+
+# Crosswalks
+
+The data are anonymized and contain no CNPJs or CPFs. This limits crosswalks with other datasets that have CNPJs, but columns such as `cnae` and `id_municipio` can be used to build useful crosswalks.
+
+# Downloading the data
+
+The microdata total more than 20 GB. To avoid overloading your computer, we recommend using queries in BigQuery to process the data in the cloud before downloading them. Filter by partition columns (such as year and state) and select only the relevant columns.
+
+# Collection instrument
+
+The New CAGED compiles formal employment data from systems such as eSocial, CAGED, and Empregador Web. The administrative records go through processing before being made available to the public.
+
+# Changes in collection
+
+In 2020, CAGED underwent a redesign, automating information collection and expanding coverage. However, this resulted in incompatibility with earlier historical series. For more information about these changes, see the [supporting materials](https://basedosdados.org/dataset/562b56a3-0b01-4735-a049-eeac5681f056?tab=userGuide#tratamentos-feitos-pela-bd).
+
+# Updates
+
+The microdata are updated with a one-month lag. The update schedule can be found on the [MTE website](https://www.gov.br/trabalho-e-emprego/pt-br/assuntos/estatisticas-trabalho/o-pdet/calendario-de-divulgacao-do-novo-caged).
+
+# Identified data
+
+The data are anonymized and contain no CNPJs or CPFs. To obtain identified data, a request must be submitted to the MTE. The process can be lengthy and there is no guarantee of approval.
+
+# Processing done by DB:
+
+In this guide, the processing steps are described in more accessible language. In addition, the [extraction and processing code](https://github.com/basedosdados/queries-basedosdados-dev/blob/main/models/br_me_caged/code/crawler_caged.py) and the [modifications made in BigQuery](https://github.com/basedosdados/queries-basedosdados/tree/main/models/br_me_caged) are available in the GitHub repository for reference.
+The processing steps performed were:
+
+- Renaming columns to conform to the style manual;
+- Creating the `ano` and `mes` columns;
+- Creating the ano_competencia_movimentacao and mes_competencia_movimentacao columns in the microdados_movimentacao_fora_prazo and microdados_movimentacao_excluida tables
+- Creating the ano_declaracao_movimentacao and mes_declaracao_movimentacao columns in the microdados_movimentacao_excluida table
+- Standardizing the federative unit columns to the UF abbreviation format;
+- Removing the columns: `valorsalariofixo`, `unidadesalariocodigo`
+
+# Supporting materials
+
+- [G1 report on changes to CAGED](https://g1.globo.com/economia/noticia/2021/04/28/serie-historica-do-emprego-formal-nao-pode-ser-comparada-com-novo-caged-dizem-analistas.ghtml): G1 report gathering experts' considerations on the changes to CAGED
+- [MTE note explaining the main changes in the New CAGED](https://www.gov.br/trabalho-e-emprego/pt-br/assuntos/estatisticas-trabalho/o-pdet/o-que-e-o-novo-caged): MTE note explaining the main changes that occurred in the New CAGED

--- a/next/content/userGuide/en/br-me-cnpj.md
+++ b/next/content/userGuide/en/br-me-cnpj.md
@@ -1,0 +1,101 @@
+---
+title: CNPJ data usage guide
+description: >-
+  Usage guide for the CNPJ data. This material contains information on the most important variables, frequently asked questions, and usage examples for the RAIS dataset
+date:
+  created: "2024-11-28T18:18:06.419Z"
+thumbnail: 
+categories: [guia-de-uso]
+authors:
+  - name: Laura Amaral
+    role: Text
+---
+
+# Introduction
+
+> This guide contains detailed information about the data. For questions about accessing or using the platform, see our [Frequently Asked Questions page](/faq).
+
+This dataset has four microdata tables:  
+- **Companies:** Each row represents a company and its attributes. The columns describe attributes such as legal nature and type of ownership structure. 
+- **Partners:** Each row represents a partner of a company. The columns describe the partner's characteristics and qualify their relationship with the company.
+- **Establishments:** Each row represents an operating establishment of a company. The columns detail information on location, economic activity, and contact information.
+- **Simples:** Each row represents a company and indicates whether the company is enrolled in Simples Nacional or MEI.  
+
+The table that links all of them is the Companies table. A company can have several partners, several establishments, and can be classified as Simples Nacional or MEI. 
+
+The Companies, Partners, and Establishments tables are released as snapshots. For each date, there is a portrait of the National Registry of Legal Entities (CNPJs) and their attributes.
+
+# Considerations for analysis
+## Difference between establishments and companies
+A company can have several establishments. The `cnpj_basico` column refers to the company, and the `cnpj` column refers to the establishment. As a result, the company's `cnpj_basico` value repeats in proportion to the number of establishments in the Establishments table. Some information from the Companies table, such as legal nature, can be assigned to establishments. To do so, the company table must be merged with its establishments.
+
+## Filtering active CNPJs
+To filter only active CNPJs, use the `situacao_cadastral` column.
+
+# Limitations
+Data are available only from 2021-11-23 onward. Records prior to that date cannot be accessed. However, the database is cumulative and does not exclude records. It only updates the registration status and attributes of the CNPJs. Thus, even without being able to track changes before 2021-11-23, it is possible to look up every CNPJ ever opened in Brazil.
+
+# Inconsistencies
+No inconsistencies have been reported in this dataset so far.
+
+# Observations over time
+The data are released as snapshots. For each date, there is a portrait of the CNPJs and their attributes. With the exception of the Simples table, the date column reports the date on which the data were extracted. Data prior to 2021-11-23 are presented with the status as of that date.
+
+# Duplicate rows
+In most files released by the Receita Federal, there are only a few dozen duplicate rows in the data. These duplications come from the original source and represent less than 0.1% of the total, which normally does not affect analyses.
+
+However, on two specific dates, the Receita Federal files contain a significant number of duplicate rows:
+  - Partners table on 2024-09-18: 4,625,789 duplicate rows were found
+  - Establishments table on 2024-10-16: 8,100,851 duplicate rows were found
+These duplicate rows were not removed from the tables. During integrity testing, it was found that the number of unique CNPJs was lower than that recorded on previous dates. This indicates that the duplications may have replaced CNPJs that should be present in the tables.
+
+# Crosswalks
+The tables can be merged using the `cnpj_básico` and `data` columns. It is necessary to understand the unique keys of each table to avoid duplications.
+
+# Downloading the data
+The microdata total more than 300 GB. To avoid overloading your computer, we recommend using queries in BigQuery to process the data in the cloud before downloading them. Filter by partition columns (such as year and state) and select only the relevant columns.
+
+# Collection instrument
+The current collection instrument is the Basic Entry Document (Documento Básico de Entrada, DBE), used by the Receita Federal to register, amend, or close a legal entity's registration.
+  
+# Changes in collection
+There have been no changes to the collection methodology from 2021 up to the time this guide was prepared (2025-01-08).
+
+# Updates
+The data are updated after the 15th of each month. Our platform runs automatic daily checks for updates.
+
+# Identified data
+The partners' CPF data are made available in anonymized form. The identified database cannot be obtained. 
+
+# Processing done by DB:
+In this guide, the processing steps are described in more accessible language. In addition, the [processing code](https://github.com/basedosdados/pipelines/blob/main/pipelines/datasets/br_me_cnpj/tasks.py#L50C1-L50C74) and the [modifications made in BigQuery](https://github.com/basedosdados/queries-basedosdados/tree/main/models/br_me_cnpj) are available in the GitHub repository for reference.
+
+## Companies table
+- Replacement of ',' with '.' in the `capital_social` column
+- Left-padding with zeros (0) to a maximum length of 8 digits in the `cnpj_basico` column
+- Left-padding with zeros (0) to a maximum length of 4 digits in the `natureza_juridica` column
+
+## Partners table
+- Conversion of the `data_entrada_sociedade` column to the year-month-day standard (%Y-%m-%d)
+- Left-padding with zeros (0) to a maximum length of 8 digits in the `cnpj_basico` column
+- Replacement of the value that identifies null CPF values from "***000000***" to ""
+
+## Establishments table
+- Left-padding with zeros (0) to a maximum length of 8 digits in the `cnpj_basico` column
+- Left-padding with zeros (0) to a maximum length of 4 digits in the `cnpj_ordem` column
+- Left-padding with zeros (0) to a maximum length of 2 digits in the `cnpj_dv` column
+- Creation of the `cnp` column by joining the values of the `cnpj_basico`, `cnpj_ordem`, and `cnpj_dv` columns
+- Creation of the 7-digit IBGE `id_municipio` column from the `id_municipio_rf` column (Receita Federal municipality ID)
+- Conversion of the `data_situacao_cadastral`, `data_situacao_especial`, and `data_inicio_atividade` columns to the year-month-day standard (%Y-%m-%d)
+
+## Simples table
+- Replacement of N with 0 and S with 1 in the `opcao_simples` column
+- Replacement of N with 0 and S with 1 in the `opcao_mei` column
+- Left-padding with zeros (0) to a maximum length of 8 digits in the `cnpj_basico` column
+- Conversion of the `data_opcao_simples`, `data_exclusao_simples`, `data_opcao_mei`, and `data_exclusao_mei` columns to the year-month-day standard (%Y-%m-%d)
+
+
+
+# Supporting materials
+* [Confidentiality assessment of the information contained in the Open Data of the National Registry of Legal Entities (CNPJ)](https://www.gov.br/receitafederal/dados/nota-cocad-rfb-86-2024.pdf/)
+* [DB tutorial on how to access and analyze CNPJ data using SQL, Python, or R](https://www.youtube.com/watch?v=WQruVEizTlc&t=1782s)

--- a/next/content/userGuide/en/br-me-cnpj.md
+++ b/next/content/userGuide/en/br-me-cnpj.md
@@ -68,7 +68,7 @@ The data are updated after the 15th of each month. Our platform runs automatic d
 The partners' CPF data are made available in anonymized form. The identified database cannot be obtained. 
 
 # Processing done by DB:
-In this guide, the processing steps are described in more accessible language. In addition, the [processing code](https://github.com/basedosdados/pipelines/blob/main/pipelines/datasets/br_me_cnpj/tasks.py#L50C1-L50C74) and the [modifications made in BigQuery](https://github.com/basedosdados/queries-basedosdados/tree/main/models/br_me_cnpj) are available in the GitHub repository for reference.
+In this guide, the processing steps are described in more accessible language. In addition, the [processing code](https://github.com/basedosdados/pipelines/blob/main/pipelines/datasets/br_me_cnpj/tasks.py#L50C1-L50C74) and the [modifications made in BigQuery](https://github.com/basedosdados/pipelines/tree/main/models/br_me_cnpj) are available in the GitHub repository for reference.
 
 ## Companies table
 - Replacement of ',' with '.' in the `capital_social` column

--- a/next/content/userGuide/en/br-me-rais.md
+++ b/next/content/userGuide/en/br-me-rais.md
@@ -70,7 +70,7 @@ The data have a partial and a complete update. The partial update occurs in Sept
 The data are anonymized and do not contain CNPJs or CPFs. To obtain identified RAIS data, you must submit a request to the MTE. The process can be lengthy, and there is no guarantee of approval.
 
 # Processing performed by DB
-In this guide, the processing steps are described in more accessible language. In addition, the [processing code](https://github.com/basedosdados/queries-basedosdados/tree/main/models/br_me_rais/code) and the [modifications made in BigQuery](https://github.com/basedosdados/queries-basedosdados/tree/main/models/br_me_rais) are available in the GitHub repository for reference. 
+In this guide, the processing steps are described in more accessible language. In addition, the [processing code](https://github.com/basedosdados/pipelines/tree/main/models/br_me_rais/code) and the [modifications made in BigQuery](https://github.com/basedosdados/pipelines/tree/main/models/br_me_rais) are available in the GitHub repository for reference. 
 The processing steps performed were: 
 * Standardizing the columns that identify municipalities to the IBGE Municipality ID format (7 digits);
 * Standardizing the columns that identify Federative Units to the state abbreviation (UF) standard;

--- a/next/content/userGuide/en/br-me-rais.md
+++ b/next/content/userGuide/en/br-me-rais.md
@@ -1,0 +1,85 @@
+---
+title: RAIS Usage Guide
+description: >-
+  Usage guide for the Relação Anual de Informações Sociais (RAIS). This material contains information about the most important variables, frequently asked questions, and usage examples for the RAIS dataset 
+date:
+  created: "2024-11-28T18:18:06.419Z"
+thumbnail: 
+categories: [guia-de-uso]
+authors:
+  - name: Laura Amaral
+    role: Text
+---
+
+# Introduction
+
+> This guide contains detailed information about the data. For questions about accessing or using the platform, see our [Frequently Asked Questions page](/faq).
+
+This dataset has two microdata tables: 
+- **Establishment Microdata:** Each row represents an establishment in a specific year. The columns show details about the company and its employees.
+- **Employment Record Microdata:** Each row represents an employment record in a specific year. The columns show information about the employment record, the employee, and the hiring company.
+
+# Considerations for analysis
+## Employment records and data filtering
+The employment record table shows all employment records registered by a company during the year. If an employee is dismissed and another is hired in the same year for the same position, both will have an employment record. To count active employees in a sector or region, use the `vinculo_ativo_3112` column.
+
+## Address information
+RAIS does not contain information about employees' home addresses. The `id_municipio` column refers to the company's municipality, and the `id_municipio_trabalho` column refers to the municipality where the employee works, when different.
+
+## Partial and complete data
+RAIS is released twice a year. Between the partial release (September) and the complete release (early the following year), the most recent year in the series always shows fewer records. For example, in November 2025, the year 2024 shows about 46 million employment records, while 2022 and 2023 have more than 50 million. This does not mean the number of employment records fell — it only means the 2024 data had not yet been fully released.
+
+# Limitations
+The data are limited to workers with a formal employment record and do not include informal or self-employed workers. The public data are anonymized.
+
+# Inconsistencies
+## `quantidade_vinculos_ativos` and `tamanho_estabelecimento` columns
+There are discrepancies between the `quantidade_vinculos_ativos` and `tamanho_estabelecimento` columns. The first shows the total number of employment records, while the second classifies the establishment by number of employment records. In some cases, the number of employment records does not match the establishment size category.
+
+## Employment records in RAIS and CAGED
+RAIS registers employment records annually, while CAGED registers hiring and dismissal movements throughout the year. In theory, adding or subtracting CAGED's movements to RAIS's total employment records should yield the following year's total, but this does not happen. Because the two systems operate independently, the discrepancies may result from errors accumulated in each one.
+
+## `id_municipio_trabalho` column
+The `id_municipio_trabalho` column is populated only between 2005-2011 and 2017-2021. The reason is unknown.  
+
+## Outdated data
+Sometimes RAIS data are updated outside the expected calendar, and our team does not always find out. If you are confident that you are running the correct queries, contact us with the query and the discrepancy relative to the official site, so that we can assess the situation and correct it if necessary.  
+
+# Observations over time
+Each year, the dataset is updated, so that an establishment or employment record appears in every year it was active. Because the data are anonymized, it is not possible to track individual employment records or companies over time, but it is possible to analyze the number of formally registered employees in different sectors or locations.
+
+# Duplicate rows
+No duplicate rows were found in this dataset. However, the Employment Record Microdata table includes all employment records for a company, so if an employee was dismissed and another hired in the same year, there will be two rows for the same position.
+
+# Merging with other datasets
+The data are anonymized and do not contain CNPJs or CPFs. This limits merges with other datasets, but columns such as `cnae` and `cep` can be used for that purpose.
+
+# Downloading the data
+The microdata total more than 350 GB. To avoid overloading your computer, we recommend using BigQuery queries to process the data in the cloud before downloading it. Filter by the partition columns (such as `ano` and `sigla_uf`) and select only the relevant columns.
+
+# Collection instrument
+The current collection instrument is a form that employers must fill out about their employees.
+
+# Changes in data collection
+Some columns have been added or removed over time. Starting in 2022, eSocial group 3 companies were no longer required to report RAIS through the usual program. Comparing that year's results with results from previous years is therefore not recommended.
+
+# Updates
+The data have a partial and a complete update. The partial update occurs in September of the collection year, and the complete update occurs by the beginning of the year following the collection year. This means that data for reference year 2023, collected in 2024, became partially available in September 2024, and the complete version was released by early 2025. Updates can sometimes occur outside the expected calendar. If you notice that the data are outdated, contact our team.
+
+# Identified data
+The data are anonymized and do not contain CNPJs or CPFs. To obtain identified RAIS data, you must submit a request to the MTE. The process can be lengthy, and there is no guarantee of approval.
+
+# Processing performed by DB
+In this guide, the processing steps are described in more accessible language. In addition, the [processing code](https://github.com/basedosdados/queries-basedosdados/tree/main/models/br_me_rais/code) and the [modifications made in BigQuery](https://github.com/basedosdados/queries-basedosdados/tree/main/models/br_me_rais) are available in the GitHub repository for reference. 
+The processing steps performed were: 
+* Standardizing the columns that identify municipalities to the IBGE Municipality ID format (7 digits);
+* Standardizing the columns that identify Federative Units to the state abbreviation (UF) standard;
+* Replacing invalid codes (such as "9999" or "000") with null values in the `bairros`, `cbo`, `cnae`, and `ano` columns;
+* Standardizing the codes in the `tipo_estabelecimento` column to ensure consistency across different years.
+
+# Supporting materials
+* [Guidance manual for employers on how to fill out the form fields](http://www.rais.gov.br/sitio/rais_ftp/ManualRAIS2023.pdf)
+* [Detailed information about RAIS on the MTE website](http://www.rais.gov.br/sitio/sobre.jsf)
+* [MTE dashboard with consolidated figures for the complete RAIS](https://app.powerbi.com/view?r=eyJrIjoiZmJmMDVhODctMTEwOS00YTVhLWJhNzItOWE3NmVlMWEwMTUxIiwidCI6IjNlYzkyOTY5LTVhNTEtNGYxOC04YWM5LWVmOThmYmFmYTk3OCJ9)
+* [MTE dashboard with consolidated figures for the partial RAIS](https://app.powerbi.com/view?r=eyJrIjoiNjk3M2IwZDYtOGQzMS00YmE1LWE3M2MtZWRjODA4NTk3YTQ2IiwidCI6IjNlYzkyOTY5LTVhNTEtNGYxOC04YWM5LWVmOThmYmFmYTk3OCJ9)
+* [Dardo System: the system we use to validate the tables made available](https://bi.mte.gov.br/bgcaged/)

--- a/next/content/userGuide/en/br-tse-eleicoes.md
+++ b/next/content/userGuide/en/br-tse-eleicoes.md
@@ -1,0 +1,133 @@
+---
+title: Brazilian Elections Usage Guide
+description: >-
+  Usage guide for Brazilian Elections data. This material contains information on the most important variables, frequently asked questions, and usage examples for the dataset.
+date:
+  created: "2024-11-28T18:18:06.419Z"
+thumbnail: 
+categories: [guia-de-uso]
+authors:
+  - name: Laura Amaral
+    role: Text
+---
+
+# Introduction
+
+> This guide contains detailed information about the data. For questions about accessing or using the platform, see our [Frequently Asked Questions page](/faq).
+
+With more than 20 tables, this dataset can seem complex at first glance. To make it easier, we organized the information into thematic groups and detail the content of each table.
+
+## Candidates
+- **`candidato`**: Microdata table. Each row represents a candidacy in an election. The columns contain information about the candidate and their candidacy.
+- **`bens_candidato`**: Microdata table. Each row represents an asset declared by a candidate in an election. If the candidate runs in more than one election, repeated items may appear. The columns describe the item and its value.
+- **`despesas_candidato`**: Microdata table. Each row represents an expense receipt of a candidate in an election. The columns describe the expense details.
+- **`receitas_candidato`**: Microdata table. Each row represents a campaign revenue item of a candidate in an election. The columns provide information about the revenue, such as donor data and tax details.
+- **`resultados_candidato`, `resultados_candidato_municipio`, `resultados_candidato_municipio_zona`, `resultados_candidato_secao`**: Aggregated tables with a similar structure. Each row represents the result of a candidate in an election. The difference lies in the aggregation level: election total, by municipality, by zone, or by polling section. The columns show the total votes, position details, and whether the candidate was elected.
+
+## Parties
+- **`partidos`**: Microdata table. Each row represents a party within an electoral scope in an election. The columns indicate the party's status and any coalitions or federations formed for each position.
+- **`receitas_comite` and `receitas_orgao_partidario`**: Microdata tables with a similar structure. Each row represents a campaign revenue item. The difference lies in the entity that received the revenue: committee or party body. The columns provide information about the revenue, such as donor data and tax details.
+- **`resultados_partido_municipio`, `resultados_partido_municipio_zona`, `resultados_partido_secao`**: Aggregated tables with a similar structure. Each row represents the result of a party for a given position in an election. The difference lies in the aggregation level: by municipality, by zone, or by polling section. The columns show the total votes, separating nominal votes and party-list votes.
+
+## General information about the elections
+- **`vagas`**: Aggregated table. Each row represents a position in an electoral unit in an election. The columns indicate the total number of seats for that position.
+- **`perfil_eleitorado_local_votacao`, `perfil_eleitorado_municipio_zona`, `perfil_eleitorado_secao`**: Aggregated tables with a similar structure. Each row represents a stratum of voters' sociodemographic profile (gender, age, marital status, education). The difference lies in the aggregation level: by municipality, by zone, or by polling section. The columns indicate the sociodemographic profile, biometric registration status, and the total number of voters.
+- **`detalhes_votacao_municipio`, `detalhes_votacao_municipio_zona`, `detalhes_votacao_secao`**: Aggregated tables with a similar structure. Each row represents voting details in an election. The difference lies in the aggregation level: by municipality, by zone, or by polling section. The columns indicate the total number of abstentions and votes by type.
+- **`local_secao`**: Microdata table. Each row represents a polling section in a given year. This is the only table not provided by the TSE; it was created by an external organization. The columns include estimates of the geographic location point of each polling section.
+
+# Considerations for analysis
+## Transfers between candidates in the revenue table
+Candidates can transfer funds to one another, which causes the same revenue item to appear more than once.
+
+## id_municipio column
+Some records have the `id_municipio nulo` column, because the TSE registers municipalities abroad that do not have an IBGE code. In these cases, only the `id_municipio_tse` column is filled in.
+
+## Candidate status
+Candidacies can be rejected by the electoral courts. To filter only candidates who actually ran in an election, use the filter `situacao = 'deferida'`.
+
+## Campaign finance reporting
+The data are entered manually, which can generate inconsistencies, missing values, or duplicates, especially during campaign periods.
+
+## Proportion of valid votes for the Senate
+In years when the Senate election involves two seats, the proportion of valid votes in the `detalhes_votacao_municipio`, `detalhes_votacao_municipio_zona`, and `detalhes_votacao_secao` tables can exceed 100%.
+This occurs because, in those years, each voter can vote for two different candidates, and the TSE counts each vote individually as a valid vote for the position. As a result, the same voter appears twice in the count, which raises the proportion of valid votes above 100%.
+
+## Supplementary elections
+There can be more than one elected mayor, governor, or president within the same term (for example, 2020–2024). This occurs when the electoral courts annul more than 50% of valid votes and call a supplementary election to elect a new representative. For analysis, use the `tipo_eleição` column to distinguish ordinary and supplementary elections within the same electoral cycle.
+
+## ano column
+The ano column indicates the year of the electoral cycle originally scheduled (e.g., 2020), even if the election actually took place later. For example, the `data_eleicao` column may show a date in 2022, while the `ano` column remains at 2020.
+
+# Limitations
+The TSE tables do not include information on elections for the conselho tutelar (municipal children and adolescent guardianship council).
+
+# Inconsistencies
+Beyond the expected pattern in years with two Senate seats, we identified a few dozen rows in the `detalhes_votacao_secao` table where the proportion of valid votes exceeds 100% with no known cause. This set of cases is very small relative to the total number of rows in the table, and to date we have not found an explanation for it. We recommend treating these records as residual and analyzing them with caution if they have a direct impact on your application.
+
+# Observations over time
+
+- To track candidates over the years, you can use the `titulo_eleitoral` column. This identifier tracks individuals consistently, overcoming the limitation of other associated IDs that change between elections. It identifies candidates in 99.5% of cases. However, it is worth noting that null values or two different identifiers for the same candidate can occur in some cases.
+
+- To track parties, you need to account for name changes and mergers over time.
+
+# Duplicate rows
+Duplicate rows are removed during DB's processing.
+
+# Cross-referencing
+Pay attention to the columns that uniquely identify entities and tables:
+- **Candidacies**: To cross-reference information from the same election, the `ano`, `tipo_eleicao`, and `sequencial_candidato` columns form a unique key for data from 2010 onward. For earlier periods, you can use the `titulo_eleitor`, `ano`, and `tipo_eleicao` columns. This combination is unique in 99.5% of cases, but it is not fully precise, since some candidacies have an empty `titulo_eleitor` column.
+- **People:** The same person can have several candidacies registered over the years. To identify a person, we recommend using the `titulo_eleitor` column.
+- **Zones**: To cross-reference information from the same year, the `ano`, `id_municipio_tse`, and `zona` columns form a unique key. Zones can change between years and have unique identifiers only within a municipality.
+- **Polling sections**: To cross-reference information from the same year, the `ano`, `id_municipio_tse`, `zona`, and `seção` columns form a unique key. Polling sections can change between years and have unique identifiers only within a municipality and a zone.
+- **Parties**: They are identified by the `sigla_partido` and `numero_partido` columns.
+
+# Downloading the data
+Some tables in this dataset are larger than 1GB, while others are smaller. To avoid overloading your computer, check the size of the tables you are interested in. If they are too large, we recommend using queries in BigQuery to process the data in the cloud before downloading it. Filter by the partition columns (such as year and state, UF) and select only the relevant columns.
+
+# Collection instrument
+## Sistema de Candidaturas (CAND)
+System used to register candidacies, where parties and coalitions enter candidates' personal data, party affiliation information, criminal record certificates, and other required documentation.
+
+## Sistema de Prestação de Contas Eleitorais (SPCE)
+System used to register all campaign revenues and expenses. The SPCE ensures that information is reported in a standardized format and within the deadlines set by the electoral courts.
+
+## Election results
+After voting closes, each electronic voting machine generates a Boletim de Urna (polling machine report) with the results tallied at that polling section. The data from these reports are sent to the Regional Electoral Courts (TREs) and then to the TSE for the release of final results.
+
+## Voter profile
+During voter registration and registry updates, voters provide personal data such as name, date of birth, gender, education, and address. Electoral registry offices record this information in the Cadastro Nacional de Eleitores (National Voter Registry).
+
+# Changes in collection
+The electoral system has undergone several changes over the years, which affected the data collected. See the main changes below:
+- **1997**: Addition of gender information;
+- **1998**: Disclosure of candidates' CPF (individual taxpayer ID);
+- **2014**: Addition of information on race or color;
+- **2016**: Ban on donations from CNPJs (companies);
+- **2022**: Collection of data on transgender identity;
+- **2024**: Discontinuation of the disclosure of candidates' CPF.
+
+# Updates
+Most of the data is updated once per regular election (every two years). Revenue and expense data are updated daily during election campaigns.
+
+# Processing done by DB:
+In this guide, the processing steps are described in more accessible language. In addition, the [processing code](code-notebook) and the [modifications made in BigQuery](queries-dir) are available in the GitHub repository for reference.
+The processing steps performed were:
+- Removal of accents and conversion of text to lowercase.
+- Removal of duplicate records considering the full set of columns.
+- Invalid values, such as "-9999" or "#NULO", were converted to nulls.
+- Adjustment of the columns that identify municipalities to the IBGE Municipality ID format (7 digits).
+- Inconsistent dates in the `data_nascimento` column (ages below 18 or above 120 years) were replaced with null values.
+- Standardization of the `tipo_eleicao` column, changing "eleições municipais" to "eleição ordinária".
+- Standardization of the `nacionalidade` column, changing "brasileira nata" to "brasileira".
+
+# Supporting materials
+* [TSE open data website with files available for download](https://dadosabertos.tse.jus.br/dataset/)
+* [Electoral Statistics Panel with a wide range of filters and simplified analyses](https://sig.tse.jus.br/ords/dwapr/seai/r/sig-eleicao/home?session=17112009236550)
+* [Panel for looking up information on candidacies and campaign finance](https://divulgacandcontas.tse.jus.br/divulga/#/home)
+* [Siga o Dinheiro (Follow the Money): Panel developed by DB to understand where campaign money comes from and where it is being spent](https://www.sigaodinheiro.org/)
+* [DB's Electoral Data Analysis Course](https://info.basedosdados.org/bd-edu-eleicoes)
+* [TSE news article about supplementary elections](https://www.tse.jus.br/comunicacao/noticias/2025/Fevereiro/voce-sabe-o-que-e-uma-eleicao-suplementar)
+
+[code-pipeline]: https://github.com/basedosdados/pipelines/tree/main/pipelines/utils/crawler_tse_eleicoes
+[code-notebook]: https://github.com/basedosdados/queries-basedosdados/blob/main/models/br_tse_eleicoes/code/%5Bdbt%5Dbr_tse_eleicoes.ipynb
+[queries-dir]: https://github.com/basedosdados/queries-basedosdados/tree/main/models/br_tse_eleicoes

--- a/next/content/userGuide/en/br-tse-eleicoes.md
+++ b/next/content/userGuide/en/br-tse-eleicoes.md
@@ -129,5 +129,5 @@ The processing steps performed were:
 * [TSE news article about supplementary elections](https://www.tse.jus.br/comunicacao/noticias/2025/Fevereiro/voce-sabe-o-que-e-uma-eleicao-suplementar)
 
 [code-pipeline]: https://github.com/basedosdados/pipelines/tree/main/pipelines/utils/crawler_tse_eleicoes
-[code-notebook]: https://github.com/basedosdados/queries-basedosdados/blob/main/models/br_tse_eleicoes/code/%5Bdbt%5Dbr_tse_eleicoes.ipynb
-[queries-dir]: https://github.com/basedosdados/queries-basedosdados/tree/main/models/br_tse_eleicoes
+[code-notebook]: https://github.com/basedosdados/pipelines/blob/main/models/br_tse_eleicoes/code/%5Bdbt%5Dbr_tse_eleicoes.ipynb
+[queries-dir]: https://github.com/basedosdados/pipelines/tree/main/models/br_tse_eleicoes

--- a/next/content/userGuide/en/br_me_comex.md
+++ b/next/content/userGuide/en/br_me_comex.md
@@ -1,0 +1,97 @@
+---
+title: Comex Stat Usage Guide
+description: >-
+  Usage guide for the Foreign Trade Statistics in Open Data (Comex Stat). This material contains information on the most important variables, frequently asked questions, and usage examples for the Comex Stat dataset
+date:
+  created: "2025-10-25T18:18:06.419Z"
+thumbnail: 
+categories: [guia-de-uso]
+authors:
+  - name: Thais Filipi
+    role: Text
+---
+
+# Introduction
+
+> This guide contains detailed information about the data. For questions about accessing or using the platform, see our [Frequently Asked Questions page](/faq).
+
+This dataset has four microdata tables:
+- **Municipality Export:** Each row represents the aggregation of export records by year, month, product category (SH4), destination country, state, and municipality of the exporting company.
+- **Municipality Import:** Each row represents the aggregation of import records by year, month, product category (SH4), country of origin of the imported good, state, and municipality of the importing company.
+- **NCM Export:** Each row represents the aggregation of export records by year, month, mode of transport, customs office, country, product category (NCM), and the state in which the exported good was produced.
+- **NCM Import:** Each row represents the aggregation of import records by year, month, mode of transport, customs office, country, product category (NCM), and the destination state of the import.
+
+# Considerations for analysis
+## Product categories
+- The Harmonized System (HS) is an international system for classifying and coding goods, usually with 6-digit codes. It has several levels of detail. The first two digits refer to the chapter, the next two to the heading, and the last two to the subheading of the good. In the ```municipio_exportacao``` and ```municipio_importacao``` tables, the classification column is SH4, meaning we only have the heading-level aggregation of the good. This code is translated through [DB's World Directories](https://basedosdados.org/dataset/afc7c3a1-8691-4f3b-8566-bdce90f1100d?table=2399179d-0e74-4f1b-a940-7e418cafa02f), which has 6 digits.
+-  The Mercosur Common Nomenclature (NCM) is an extension of the HS. Of the eight digits that make up the NCM, the first six come from the Harmonized System, while the last two correspond to specific sections within MERCOSUR. Translate via [World Directories](https://basedosdados.org/dataset/afc7c3a1-8691-4f3b-8566-bdce90f1100d?table=3027c0d8-d17b-443f-a295-1de6ff65d5cc).
+- Each product is associated with a unit of measurement (```id_unidade```) that defines how the values should be interpreted (for example, net kilogram, unit, or net metric ton). The ```id_unidade``` column in the ```ncm_exportação``` and ```ncm_importacao``` tables can be translated via [World Directories](https://basedosdados.org/dataset/afc7c3a1-8691-4f3b-8566-bdce90f1100d?table=3027c0d8-d17b-443f-a295-1de6ff65d5cc).
+
+## ```id_municipio``` and ```sigla_uf``` data
+- In ```municipio_exportacao``` and ```municipio_importacao```, the municipality column refers to the registered tax address of the company responsible for the export or import — not the place where the exported good was produced or the destination of the import. The ```sigla_uf``` in these tables corresponds to the value of ```id_municipio```.
+- In ```ncm_exportacao``` and ```ncm_importacao```, the state column refers to the place of production of the good (export) or the destination of the import, regardless of the location of the headquarters of the company that carried out the export or import.
+
+# Correcting null state and municipality values
+Null values of ```id_municipio``` and ```sigla_uf``` are correctly fixed and filled in only after the annual data correction by the responsible secretariat.
+
+## ```id_pais``` data in the import tables
+Imports consider the origin of the good, not the country of the company that made the sale. In most cases, the home country of the company selling the good is the same country where the good is manufactured. However, there are cases where this does not happen.
+
+## FOB value
+```valor_fob_dolar``` refers only to the value of the good. Freight and import insurance costs are detailed in ```valor_frete``` and ```valor_seguro```.
+
+## URFs and route
+The Federal Revenue Customs Clearance Units (URFs) should not be confused with a specific route, such as ports, since some ports have more than one customs facility.
+
+# Limitations
+Records are not identified by the companies or individuals involved in exporting or importing goods, which limits the possible analyses (such as by CNAE or company size, for example).
+
+# Inconsistencies
+Discrepancies appear when comparing data between countries. In Brazil's bilateral trade, it is common to find discrepancies between the figures published by each partner.
+
+# Observations over time
+Trade balance trends can be tracked at the different observation levels of the tables, both month by month and by year. Aggregating the consolidated monthly data yields the annual foreign trade results.
+
+# Duplicate rows
+No information at this time.
+
+# Cross-referencing
+The data are anonymized and do not contain CNPJ or CPF information for import and export agents. This limits cross-referencing with other datasets, but the ```id_pais```, ```sigla_uf```, and ```id_municipio``` columns can be used.
+
+# Downloading the data
+The total tables amount to about 9 GB, so it is recommended to follow good data processing practices as much as possible. To avoid overloading your computer, we recommend using BigQuery queries to process the data in the cloud before downloading it. Filter by the partition columns (such as ```ano```, ```mes```, ```sigla_uf```, and ```sigla_pais_iso3```) and select only the relevant columns.
+
+# Collection instrument
+Foreign trade statistics are produced from administrative record data, submitted via declaration by the parties involved in export and import operations – companies, customs brokers, financial institutions, carriers, freight forwarders, individuals, etc. – in the official [Siscomex](https://www.gov.br/siscomex/pt-br) and [Single Siscomex Portal](https://portalunico.siscomex.gov.br/portal/) systems, which manage Brazilian foreign trade.
+
+# Changes in data collection
+- **Changes to the collection system in 2018**
+	- Starting in 2018, the export data entry tool changed from NOVOEX to the Single Portal. In the new system, cases of early shipment without an invoice may go unrecorded for state ("Undeclared State"). Only after the invoice is issued can the state information be corrected, which causes null values for this field to be overrepresented in the most recent months. See the Comex Usage Manual for more details.
+- **Methodology change regarding the reference date of imported and exported goods in 2018** 
+	- Starting in 2018, the reference date for export data became the date on which the cargo is considered fully exported (CCE Date) – from 1997 to 2017 it was the Customs Clearance date.
+
+# Updates
+Comex data is updated in the first business days of each month. Although the responsible secretariat publishes weekly bulletins, these should be disregarded once the consolidated monthly version is published. Data Basis has a scheduled pipeline that fetches and updates the data daily. If you notice the data is out of date, contact our team.
+
+# Identified data
+The data are anonymized and do not contain CNPJ or CPF information. The administrative and customs records that feed Comex Stat serve evidentiary, oversight, and legal validity purposes, under the responsibility of the competent agencies.
+
+# Processing done by DB
+In this guide, the processing steps are described in more accessible language. In addition, the [processing code](https://github.com/basedosdados/pipelines/tree/main/pipelines/datasets/br_me_comex_stat) and the [modifications made in BigQuery](https://github.com/basedosdados/pipelines/tree/main/models/br_me_comex_stat) are available in the GitHub repository for reference.
+The processing steps performed were: 
+* Correction of specific municipal codes in states with historical inconsistencies (SP, MS, GO, and DF), ensuring alignment with the IBGE standard (7 digits);
+* Standardization of column names according to [DB's Style Manual](https://basedosdados.org/docs/style_data);
+* Conversion of the ```mes``` column to integer type (int64)
+* Replacement of invalid codes (such as "ND" or "9300000") with null values in the ```sigla_uf``` and ```id_municipio``` columns;
+* Standardization of codes in specific columns:
+	* ```id_ncm``` (8 digits, string format);
+	- ```id_sh4``` (4 digits, string format);
+	- ```id_pais``` converted to the ISO3 code (```sigla_pais_iso3```) in the tables where this applies
+
+# Supporting materials
+- [Manual for using Brazilian foreign trade statistical data](https://balanca.economia.gov.br/balanca/manual/Manual.pdf).
+- [Manuals and Methodological Notes](https://www.gov.br/mdic/pt-br/assuntos/comercio-exterior/estatisticas/manuais-e-notas-metodologicas) on the website of the Ministry of Development, Industry, Trade, and Services.
+- [Totals for validation](https://www.gov.br/mdic/pt-br/assuntos/comercio-exterior/estatisticas/base-de-dados-bruta) of the data in Foreign Trade Statistics in Open Data
+- Analyses done by DB with Comex Stat ([soybeans](https://github.com/basedosdados/analises/blob/main/redes_sociais/br_comex_stat_municipio_exportacao_20230626.ipynb) and [coffee](https://github.com/basedosdados/analises/blob/main/redes_sociais/br_me_comex_stat_20251006.sql)).
+
+

--- a/next/content/userGuide/en/mundo-transfermarkt-competicoes.md
+++ b/next/content/userGuide/en/mundo-transfermarkt-competicoes.md
@@ -1,0 +1,67 @@
+---
+title: Usage Guide for Football Championships Data
+description: >-
+  Usage guide for Football Championships data. This material contains information about the most important variables, frequently asked questions, and examples of how to use the dataset.
+date:
+  created: "2024-11-28T18:18:06.419Z"
+thumbnail: 
+categories: [guia-de-uso]
+authors:
+  - name: Laura Amaral
+    role: Text
+---
+
+# Introduction
+
+> This guide contains detailed information about the data. For questions about accessing or using the platform, see our [Frequently Asked Questions page](/faq).
+
+This dataset has two microdata tables:  
+- **Brasileirão Série A:** Each row represents a match. The columns provide information on match characteristics, results, and game statistics 
+- **Copa do Brasil:** Each row represents a match. The columns provide information on match characteristics, results, and game statistics 
+
+# Considerations for analysis
+## Data sources and compilation
+The tables present information compiled by Transfermarkt. To understand how these statistics were produced and structured, it is necessary to review the compilation methods.
+
+# Limitations
+* The tables contain the information available on the Transfermarkt website that our team selected to include. If you find that some information that would be useful for your analysis is not available in this dataset but is available on the Transfermarkt website, please get in touch so we can find out! 
+
+# Inconsistencies
+No inconsistencies have been reported so far
+
+# Observations over time
+Each row represents a game, so it is possible to track a team's evolution over the course of a season, or even over the years.
+
+# Duplicate rows
+No evidence of duplicate rows has been found in this dataset's tables so far
+
+# Joins
+The copa_brasil and brasileirao_serie_a tables can be joined using the time_mandante and time_visitante columns. In addition, these tables do not have many joins with other tables in the datalake. It is possible to use time-related information (year and date) in some cases.
+
+# Data download
+These tables are small, so it is possible to download the data directly from the platform
+
+
+# Responsible institution
+Transfermarkt.com
+
+# Collection instrument
+Transfermarkt obtains detailed information about football matches through a combination of sources:
+* Data Team: A dedicated team of more than 50 football enthusiasts from various parts of the world conducts detailed research and constantly updates the information
+* Community Contributions: Registered users can propose corrections and updates.
+* Official Sources and Partners: The site also uses data from official sources, such as leagues, federations, and clubs, in addition to partners specialized in sports statistics.
+
+# Changes in collection
+The data collected has changed considerably over time. Between 2003 and 2006, the data recorded were basic, such as dates, stadiums, rounds, and scores. Information about referees, attendance, coaches, and game statistics was completely absent.
+Starting in 2007, data recording began to expand, with the inclusion of referees and, gradually, coaches and team standings. Attendance data began to appear consistently in 2012, while financial and demographic statistics, such as team values and average ages, became more detailed between 2013 and 2016.
+From 2017 onward, the dataset reached a high level of completeness, covering detailed statistics such as shots, corner kicks, saves, and offsides. However, in 2024, a slight decline was observed in some columns, such as maximum attendance and game statistics, although the dataset remains significantly more complete than in the early years. 
+
+# Updates
+The data are updated at the official source on an ongoing basis; since not all of the data collection is automated, there is no fixed schedule. At DB, we update the data for the latest round weekly
+
+# Processing performed by DB:
+DB performs a web scraping process on the Transfermarkt website. Our standard practice is not to make changes to the collected data. If you would like to review how our web scraping is done, the code is here: https://github.com/basedosdados/pipelines/blob/main/pipelines/datasets/mundo_transfermarkt_competicoes/utils.py#L371 . The complete pipeline code (including other steps beyond extraction, such as checking for updates, uploading the data to BigQuery, materialization via dbt, and running data quality tests) is here: https://github.com/basedosdados/pipelines/blob/main/pipelines/datasets/mundo_transfermarkt_competicoes/flows.py
+
+# Supporting materials
+* [Transfermarkt FAQ](https://www.transfermarkt.com/intern/faq) 
+* [Transfermarkt data entry process](https://www.transfermarkt.us/intern/datenpflegeGuide)

--- a/next/content/userGuide/en/user_guide_model.md
+++ b/next/content/userGuide/en/user_guide_model.md
@@ -89,7 +89,7 @@ The partners' CPF data are made available in anonymized form. The identified dat
 
 # Processing done by DB:
 <!-- Here we describe the processing steps in more direct language, so that even users without programming knowledge know what processing was done. It is still necessary to leave links for anyone who wants to verify the process. If needed, the processing steps can be split across tables-->
-In this guide, the processing steps are described in more accessible language. In addition, the [processing code](https://github.com/basedosdados/pipelines/blob/main/pipelines/datasets/br_me_cnpj/tasks.py#L50C1-L50C74) and the [modifications made in BigQuery](https://github.com/basedosdados/queries-basedosdados/tree/main/models/br_me_cnpj) are available in the GitHub repository for reference.
+In this guide, the processing steps are described in more accessible language. In addition, the [processing code](https://github.com/basedosdados/pipelines/blob/main/pipelines/datasets/br_me_cnpj/tasks.py#L50C1-L50C74) and the [modifications made in BigQuery](https://github.com/basedosdados/pipelines/tree/main/models/br_me_cnpj) are available in the GitHub repository for reference.
 
 ## Companies table
 - Replacement of ',' with '.' in the `capital_social` column

--- a/next/content/userGuide/en/user_guide_model.md
+++ b/next/content/userGuide/en/user_guide_model.md
@@ -1,0 +1,122 @@
+---
+title: Usage Guide Template
+description: >-
+  This template serves as a reference for usage guides. It should describe the standards agreed on with the team. If you think a standard is worth including, feel free to add it here and we will evaluate it.
+date:
+  created: "2024-11-28T18:18:06.419Z"
+thumbnail: 
+categories: [guia-de-uso]
+authors:
+  - name: Laura Amaral
+    role: Text
+---
+<!-- In this template, we keep the text from the CNPJ guide so it can be used as an example
+
+General standards:
+- Always use the terms "dataset" and "table." Avoid using the words "base" and "data" on their own, to keep clear which element is being referenced.  
+- Prioritize direct, concise language. We recommend using ChatGPT to review the text and make it more objective.
+ -->
+
+
+# Introduction
+<!-- Every guide starts with this short notice so new users can find their way around.-->
+> This guide contains detailed information about the data. For questions about accessing or using the platform, see our [Frequently Asked Questions page](/faq).
+
+<!-- In the introduction, we describe the tables that make up the dataset.
+This description must necessarily include: 
+  - Whether the table contains microdata or aggregated data 
+  - An explanation of what each row of the table represents
+  - A summary of the columns
+If there is any information that is key to understanding the dataset, it can also be added here. But be careful not to add too much information — the rest of the guide is there to describe the dataset in more detail.  
+   -->
+This dataset has four microdata tables:  
+- **Companies:** Each row represents a company and its attributes. The columns describe attributes such as legal nature and type of ownership structure.  
+- **Partners:** Each row represents a partner of a company. The columns describe some characteristics of the partner and qualify their relationship with the company.
+- **Establishments:** Each row represents an operating establishment of a company. The columns detail information on location, economic activity, and contact information.
+- **Simples:** Each row represents a company and indicates whether the company is enrolled in Simples Nacional or MEI.  
+
+The table that links all of them is the Companies table. A company can have several partners, several establishments, and can be classified as Simples Nacional or MEI. 
+
+The Companies, Partners, and Establishments tables are released as snapshots. For each date, there is a portrait of the National Registry of Legal Entities (CNPJs) and their attributes.
+
+# Considerations for analysis
+<!-- Here we include, as topics, various considerations for analysis — this is the most open-ended category of the guide. We try to include frequently asked questions, usage tips, and common points of confusion -->
+## Difference between establishments and companies
+A company can have several establishments. The `cnpj_basico` column refers to the company, and the `cnpj` column refers to the establishment. As a result, the company's `cnpj_basico` value repeats in proportion to the number of establishments in the Establishments table. Some information from the Companies table, such as legal nature, can be assigned to establishments. To do so, the company table must be merged with its establishments.
+
+## Filtering active CNPJs
+To filter only active CNPJs, use the `situacao_cadastral` column.
+
+# Limitations
+<!-- Unlike the considerations section, this space is specifically for limitations imposed by the dataset made available. It can be a methodological limitation or one imposed by the time coverage -->
+Data are available only from 2021-11-23 onward. Records prior to that date cannot be accessed. However, the database is cumulative and does not exclude records. It only updates the registration status and attributes of the CNPJs. Thus, even without being able to track changes before 2021-11-23, it is possible to look up every CNPJ ever opened in Brazil.
+
+# Inconsistencies
+<!-- Here we include information on inconsistencies we have already found in the database. It is useful to include an explanation of the source of the inconsistencies-->
+We don't have any reported inconsistencies yet
+
+# Observations over time
+<!-- The purpose of this topic is to explain how to track observations over time and to provide a tip or extra information on this topic -->
+The data are released as snapshots. For each date, there is a portrait of the CNPJs and their attributes. With the exception of the Simples table, the date column reports the date on which the data were extracted. Data prior to 2021-11-23 are presented with the status as of that date.
+
+# Duplicate rows
+<!-- This topic is meant to state explicitly whether there are duplicate rows. It is useful to include information on why this happens and how to work around it-->
+There are a few dozen duplicate rows in the dataset. These duplications come from the original source and represent less than 0.1% of the data, which generally does not affect analyses.
+
+# Crosswalks
+<!-- Here we cover the particularities of merging the tables in the dataset. This can include internal crosswalks, within the dataset itself, and external crosswalks, with datasets outside this one -->
+The tables can be merged using the `cnpj_básico` and `data` columns. It is necessary to understand the unique keys of each table to avoid duplications.
+
+# Downloading the data
+<!-- Here we note whether or not direct download of the data is possible. We start the topic by noting the size of the tables and then explaining how to avoid overloads. The goal is to alert people who are not familiar with very large datasets that direct download is sometimes not possible and filters must be applied -->
+The microdata total more than 300 GB. To avoid overloading your computer, we recommend using queries in BigQuery to process the data in the cloud before downloading them. Filter by partition columns (such as year and state) and select only the relevant columns.
+
+# Collection instrument
+<!-- This topic describes what the data collection instrument is like. This matters because it provides more context for the data and helps identify possible biases and limitations not listed earlier -->
+The current collection instrument is the Basic Entry Document (Documento Básico de Entrada, DBE), used by the Receita Federal to register, amend, or close a legal entity's registration.
+  
+# Changes in collection
+<!-- The goal here is to alert users to any changes in the data over the time series, which matters a great deal for analyses to be carried out with quality -->
+There have been no changes to the collection methodology from 2021 up to the time this guide was prepared (2025-01-08).
+
+# Updates
+<!-- Here we explain how updates are made at the original source, whether at a specific time of year or month, and whether there is a set schedule. This topic matters so users know when to expect the data to be updated-->
+The data are updated after the 15th of each month. Our platform runs automatic daily checks for updates.
+
+# Identified data
+<!-- The goal of this topic is to tell users whether identified data exist or whether the data are anonymized. Many users are interested in de-anonymized data, but few datasets have this information -->
+The partners' CPF data are made available in anonymized form. The identified database cannot be obtained. 
+
+# Processing done by DB:
+<!-- Here we describe the processing steps in more direct language, so that even users without programming knowledge know what processing was done. It is still necessary to leave links for anyone who wants to verify the process. If needed, the processing steps can be split across tables-->
+In this guide, the processing steps are described in more accessible language. In addition, the [processing code](https://github.com/basedosdados/pipelines/blob/main/pipelines/datasets/br_me_cnpj/tasks.py#L50C1-L50C74) and the [modifications made in BigQuery](https://github.com/basedosdados/queries-basedosdados/tree/main/models/br_me_cnpj) are available in the GitHub repository for reference.
+
+## Companies table
+- Replacement of ',' with '.' in the `capital_social` column
+- Left-padding with zeros (0) to a maximum length of 8 digits in the `cnpj_basico` column
+- Left-padding with zeros (0) to a maximum length of 4 digits in the `natureza_juridica` column
+
+## Partners table
+- Conversion of the `data_entrada_sociedade` column to the year-month-day standard (%Y-%m-%d)
+- Left-padding with zeros (0) to a maximum length of 8 digits in the `cnpj_basico` column
+- Replacement of the value that identifies null CPF values from "***000000***" to ""
+
+## Establishments table
+- Left-padding with zeros (0) to a maximum length of 8 digits in the `cnpj_basico` column
+- Left-padding with zeros (0) to a maximum length of 4 digits in the `cnpj_ordem` column
+- Left-padding with zeros (0) to a maximum length of 2 digits in the `cnpj_dv` column
+- Creation of the `cnp` column by joining the values of the `cnpj_basico`, `cnpj_ordem`, and `cnpj_dv` columns
+- Creation of the 7-digit IBGE `id_municipio` column from the `id_municipio_rf` column (Receita Federal municipality ID)
+- Conversion of the `data_situacao_cadastral`, `data_situacao_especial`, and `data_inicio_atividade` columns to the year-month-day standard (%Y-%m-%d)
+
+## Simples table
+- Replacement of N with 0 and S with 1 in the `opcao_simples` column
+- Replacement of N with 0 and S with 1 in the `opcao_mei` column
+- Left-padding with zeros (0) to a maximum length of 8 digits in the `cnpj_basico` column
+- Conversion of the `data_opcao_simples`, `data_exclusao_simples`, `data_opcao_mei`, and `data_exclusao_mei` columns to the year-month-day standard (%Y-%m-%d)
+
+
+# Supporting materials
+<!-- Last, we include supporting materials, so users can consult information directly from the original sources or supplement their understanding of the dataset -->
+* [Confidentiality assessment of the information contained in the Open Data of the National Registry of Legal Entities (CNPJ)](https://www.gov.br/receitafederal/dados/nota-cocad-rfb-86-2024.pdf/)
+* [DB tutorial on how to access and analyze CNPJ data using SQL, Python, or R](https://www.youtube.com/watch?v=WQruVEizTlc&t=1782s)

--- a/next/content/userGuide/es/br-ibge-censo-2022.md
+++ b/next/content/userGuide/es/br-ibge-censo-2022.md
@@ -1,0 +1,62 @@
+---
+title: Guía de uso del conjunto del Censo 2022
+description: >-
+  Guía de uso de la Relación Anual de Informaciones Sociales (RAIS). Este material contiene información sobre las variables más importantes, preguntas frecuentes y ejemplos de uso del conjunto de la RAIS 
+date:
+  created: "2024-11-28T18:18:06.419Z"
+thumbnail: 
+categories: [guia-de-uso]
+authors:
+  - name: Laura Amaral
+    role: Texto
+---
+
+# Introducción
+
+> Esta guía contiene información detallada sobre los datos. Para dudas sobre el acceso o el uso de la plataforma, consulta nuestra [página de Preguntas Frecuentes](/faq).
+
+Esta base posee 2 tablas con microdatos: 
+- **Microdatos de Establecimientos:** Cada fila representa un establecimiento en un año determinado. Las columnas describen características de la empresa y sus empleados.
+- **Microdatos de Vínculos:** Cada fila representa un vínculo laboral en un año determinado. Las columnas describen características del tipo de vínculo, del empleado y de la empresa contratante.
+
+# Consideraciones para los análisis
+## Vínculos y filtrado de datos
+La tabla de Vínculos incluye todos los vínculos registrados por una empresa durante el año. Por lo tanto, si un empleado fue despedido y otro fue contratado en el mismo año, ambos tendrán una fila para el mismo puesto en la empresa. Si el objetivo es evaluar el total de empleados activos en un sector o región, es necesario utilizar la columna `vinculo_ativo_3112` para filtrar únicamente los vínculos que están activos en la fecha indicada.
+
+# Limitaciones
+* Los datos disponibles se limitan a los trabajadores con vínculo laboral formal, y no incluyen información sobre trabajadores informales o autónomos.
+* Los datos públicos están anonimizados.
+
+# Inconsistencias
+## Columnas quantidade_vinculos_ativos y tamanho_estabelecimento
+Las columnas `quantidade_vinculos_ativos` y `tamanho_estabelecimento` de la tabla de establecimientos presentan información discrepante entre sí. La primera tiene un valor entero que representa el total de vínculos de ese establecimiento, y la segunda es una categoría definida por el total de vínculos. Sin embargo, encontramos varios casos en los que la cantidad de vínculos no está dentro del rango definido por el tamaño del establecimiento. Aún no se sabe por qué ocurre esta inconsistencia.
+
+# Observaciones a lo largo del tiempo
+En estas tablas no es posible dar seguimiento a las variables a lo largo del tiempo; para realizar comparaciones entre años es necesario agregar los microdatos disponibles en el conjunto de microdatos del Censo.
+
+# Filas duplicadas
+Hasta el momento no se han encontrado indicios de filas duplicadas en las tablas de este conjunto.
+
+# Cruces
+Las tablas del censo pueden cruzarse con otras utilizando los recortes geográficos; contamos con información geolocalizada a nivel de sector censal. El cruce con otras bases que tengan información de municipios también es posible.
+
+# Descarga de los datos
+La mayor parte de las tablas del censo no son muy grandes; algunas se pueden descargar directamente desde nuestra plataforma, mientras que otras deben descargarse vía Python o R.
+
+# Instrumento de recolección
+La recolección de la información se realizó, en general, mediante entrevista presencial (entrevista directa, cara a cara, con los residentes del domicilio). Además de esta modalidad tradicional, para el Censo Demográfico 2022 se abrió la posibilidad de recolección por Internet. El censista podía ofrecer esta alternativa a pedido del residente, cuando hubiera restricciones de acceso a áreas específicas (por ejemplo, en condominios cerrados), o cuando surgiera cualquier otra dificultad para realizar la recolección en la modalidad de entrevista presencial. También hubo un aumento en la recolección entre los Pueblos y Comunidades Tradicionales, donde se relevó, por primera vez, a las comunidades quilombolas.
+
+# Cambios en la recolección
+Como los datos de este conjunto se refieren únicamente a 2022, la metodología de recolección es la misma para todo el conjunto.
+
+# Actualizaciones
+Los datos del censo 2022 no tienen actualizaciones, pero el IBGE pone a disposición nuevos conjuntos de datos con frecuencia. Los próximos conjuntos están programados según el [calendario](https://censo2022.ibge.gov.br/panorama/calendario.html?localidade=BR).
+
+# Tratamientos realizados por BD
+El tratamiento de las tablas es mínimo: 
+* Inclusión del id_municipio.
+* Unión de la información de domicilios, población, área, tasa de alfabetización, edad mediana, índice de envejecimiento, población indígena y población quilombola en una única tabla de municipio.
+* Creación de las columnas `idade_anos` y `grupo_idade` para facilitar operaciones numéricas en las tablas que contienen información de edad.
+
+# Materiales de apoyo
+* [Notas técnicas sobre el censo 2022](https://www.ibge.gov.br/estatisticas/sociais/trabalho/22827-censo-demografico-2022.html?=&t=notas-tecnicas): Información relevante sobre cómo se realizó cada parte de la investigación, muy importante para obtener contexto y útil como inspiración para análisis.

--- a/next/content/userGuide/es/br-inep-censo-escolar.md
+++ b/next/content/userGuide/es/br-inep-censo-escolar.md
@@ -1,0 +1,72 @@
+---
+title: Guía de uso de datos del Censo Escolar
+description: >-
+  Guía de uso de datos de Campeonatos de Fútbol. Este material contiene información sobre las variables más importantes, preguntas frecuentes y ejemplos de uso del conjunto.
+date:
+  created: "2024-11-28T18:18:06.419Z"
+thumbnail: 
+categories: [guia-de-uso]
+authors:
+  - name: Laura Amaral
+    role: Texto
+---
+
+# Introducción
+
+> Esta guía contiene información detallada sobre los datos. Para dudas sobre el acceso o el uso de la plataforma, consulta nuestra [página de Preguntas Frecuentes](/faq).
+
+Este conjunto tiene cuatro tablas de microdatos:  
+- **Escuelas:** Única tabla puesta a disposición por el INEP a partir de 2021, cada fila representa una escuela. Las columnas incluyen características de la escuela, como la infraestructura física disponible, el equipo pedagógico, la infraestructura pedagógica, rasgos del período lectivo, e información agregada sobre matrículas, docentes y clases.
+- **Clases:** Tabla puesta a disposición a partir de solicitudes presentadas mediante pedidos LAI (Ley de Acceso a la Información). Cada fila representa una clase activa en el año escolar, las columnas contienen información sobre las asignaturas cursadas por la clase, el horario de inicio de las clases, el número de alumnos de la clase y el nivel de enseñanza.
+- **Matrículas:** Mantenida para consulta histórica, pero no se actualiza desde 2021. Cada fila representa una matrícula, las columnas incluyen variables sociodemográficas, actividades que realiza el alumno y la forma de transporte para llegar a la escuela.
+- **Docentes:** Mantenida para consulta histórica, pero no se actualiza desde 2021. Cada fila representa la asignación de un docente a una clase en una escuela durante un año, las columnas contienen características sociodemográficas, información sobre su formación y detalles de la actividad del docente en la escuela.
+
+# Consideraciones para los análisis
+## Selección de variables
+No ponemos a disposición todas las variables que aparecen en el Censo. Seleccionamos las variables que aparecieron 8 o más veces entre 2009 y 2020, además de otras variables que consideramos cruciales por ser identificadores importantes. Esto significa que, si una variable solo aparece en 2 años en la fuente original, por ejemplo, no fue incluida en nuestras tablas.
+
+## Información de raza y color
+La información de raza y color en el Censo Escolar es completada por la escuela, pero muchos registros quedan en blanco. Esto puede causar distorsiones en los análisis sobre este tema realizados con esta base.
+
+Sabemos esto porque la prueba SAEB también recoge la raza de los alumnos, pero de forma diferente: son los propios estudiantes quienes la informan. Los datos del Censo Escolar y del SAEB terminan siendo bastante diferentes debido a estas diferentes metodologías.
+
+# Limitaciones
+* Los datos están disponibles a partir de 2009, ya que fue cuando la encuesta pasó a tener un formato más uniforme. Esto facilita la comparación entre los años y garantiza una mayor compatibilidad.
+
+# Inconsistencias
+Aún no se han reportado inconsistencias en este conjunto de datos.
+
+# Observaciones a lo largo del tiempo
+Los alumnos y docentes tienen información anonimizada, por lo que no es posible dar seguimiento a estas entidades a lo largo de los años en las tablas de matrículas y docentes. Las escuelas, en cambio, son identificables y pueden ser seguidas a lo largo de los años.
+También cabe señalar que las tablas de matrículas y docentes dejaron de estar disponibles en 2020.
+
+# Filas duplicadas
+Aún no se han encontrado indicios de filas duplicadas en las tablas de este conjunto.
+
+# Cruces
+Dentro del propio conjunto es posible cruzar las tablas utilizando las claves id_escola, id_turma y ano. 
+Además, estas tablas pueden complementarse con información de otros conjuntos del INEP:  
+1. **Indicadores Escolares del INEP**: Los Indicadores Escolares del INEP presentan una serie de mediciones sobre la calidad de la enseñanza en diferentes niveles de agregación, permitiendo análisis más detallados del contexto educativo en escuelas, municipios y estados.  
+2. **Sinopsis Estadísticas de la Educación Básica**: Las Sinopsis Estadísticas de la Educación Básica presentan información del Censo Escolar de manera agregada y simplificada, facilitando análisis rápidos y comparaciones entre diferentes niveles de enseñanza y regiones.  
+3. **Índice de Desarrollo de la Educación Básica (Ideb)**: El dataset br_inep_ideb pone a disposición tablas que identifican las notas de los alumnos en evaluaciones de la calidad de la enseñanza, como las pruebas del SAEB, además de información sobre tasas de rendimiento, como aprobación, reprobación y abandono, y el desempeño de las escuelas en el IDEB. Junto con las tablas del Censo, se puede evaluar, por ejemplo, cómo se desempeñan en esas pruebas las escuelas con más profesores con maestría en relación con escuelas con profesores que no tienen posgrado.
+
+# Descarga de los datos
+Estas tablas son demasiado grandes para la descarga directa; es muy importante seleccionar columnas y aplicar filtros temporales o geográficos antes de descargar los datos.
+
+Los microdatos suman más de 300 GB. Para evitar sobrecargar tu computadora, recomendamos usar queries en BigQuery para procesar los datos en la nube antes de descargarlos. Filtra por las columnas de partición (como ano y UF) y selecciona solo las columnas relevantes.
+
+# Instrumento de recolección
+Los datos del Censo Escolar se recolectan en dos etapas. En el primer semestre, las escuelas completan cinco formularios (escuelas, directivos, clases, alumnos y personal en el aula) con información de todas las instituciones de educación básica y profesional. Al final del año lectivo, la segunda etapa registra la situación de los alumnos, indicando si fueron aprobados, reprobados, transferidos, dejaron de asistir o fallecieron.
+
+# Cambios en la recolección
+El principal cambio a lo largo de los años fue la sustitución de las tablas de matrículas, docentes y directivos escolares por una única tabla de escuelas con datos agregados. A partir de 2021, esta nueva tabla incluyó 123 nuevas variables, permitiendo el acceso a cierta información sobre matrículas, docentes y directivos escolares de forma resumida.
+
+# Actualizaciones
+Los datos se actualizan anualmente, a comienzos del año siguiente a la recolección de datos.
+
+# Tratamientos realizados por BD:
+
+
+# Materiales de apoyo
+[Sitio del INEP sobre el Censo Escolar](https://www.gov.br/inep/pt-br/areas-de-atuacao/pesquisas-estatisticas-e-indicadores/censo-escolar): Documentos e instrucciones sobre el Censo Escolar, útil para comprender mejor el contexto y obtener materiales complementarios como los formularios que se completan, fechas de divulgación y recolección, entre otra información. 
+[Nota de BD sobre el cambio en la divulgación de los datos del Censo Escolar](https://basedosdados.org/blog/nota-sobre-divulgacao-dos-dados-do-inep): Nota que expone la posición de BD sobre el cambio ocurrido en 2021

--- a/next/content/userGuide/es/br-inmet-bdmep.md
+++ b/next/content/userGuide/es/br-inmet-bdmep.md
@@ -62,7 +62,7 @@ Estas tablas son consistentes desde el año 2000; no tenemos registro de cambios
 La actualización de los datos en la fuente original es cada hora. En Base de los Datos actualizamos esta información mensualmente.
 
 # Tratamientos realizados por BD:
-En esta guía, los tratamientos se describen en un lenguaje más accesible. De manera complementaria, [los códigos de extracción y tratamiento](https://github.com/basedosdados/pipelines/blob/main/pipelines/datasets/br_inmet_bdmep/flows.py) y las [modificaciones realizadas en BigQuery](https://github.com/basedosdados/queries-basedosdados/blob/main/models/br_inmet_bdmep/br_inmet_bdmep__microdados.sql) están disponibles en el repositorio de GitHub para su consulta.
+En esta guía, los tratamientos se describen en un lenguaje más accesible. De manera complementaria, [los códigos de extracción y tratamiento](https://github.com/basedosdados/pipelines/blob/main/pipelines/datasets/br_inmet_bdmep/flows.py) y las [modificaciones realizadas en BigQuery](https://github.com/basedosdados/pipelines/blob/main/models/br_inmet_bdmep/br_inmet_bdmep__microdados.sql) están disponibles en el repositorio de GitHub para su consulta.
 Los tratamientos realizados en la tabla de microdatos fueron:
 * Renombramiento de las columnas para adecuarlas al manual de estilo de BD.
 * Sustitución de códigos inválidos ("-9999") por valores nulos.

--- a/next/content/userGuide/es/br-inmet-bdmep.md
+++ b/next/content/userGuide/es/br-inmet-bdmep.md
@@ -1,0 +1,74 @@
+---
+title: Guía de uso del BDMEP
+description: >-
+  Guía de uso de los Datos Meteorológicos BDMEP. Este material contiene información sobre las variables más importantes, preguntas frecuentes y ejemplos de uso del conjunto
+date:
+  created: "2024-11-28T18:18:06.419Z"
+thumbnail: 
+categories: [guia-de-uso]
+authors:
+  - name: Laura Amaral
+    role: Texto
+---
+
+# Introducción
+
+> Esta guía contiene información detallada sobre los datos. Para dudas sobre el acceso o el uso de la plataforma, consulta nuestra [página de Preguntas Frecuentes](/faq).
+
+Este conjunto tiene dos tablas de microdatos:  
+- **Microdatos:** Cada fila representa una colección de mediciones de una estación en un horario. Las columnas contienen información sobre la precipitación, la presión, la radiación, la temperatura, la humedad y el viento.  
+- **Estación:** Cada fila representa una estación meteorológica. Las columnas contienen información geográfica de esa estación.
+
+# Consideraciones para los análisis
+
+## Forma de cálculo
+Antes de realizar operaciones con los datos del BDMEP, es crucial entender cómo fue calculada cada medida. Algunas columnas presentan valores promedio, mientras que otras contienen valores máximos o mínimos. La elección de la variable adecuada dependerá de las necesidades específicas del análisis.
+
+## Filas vacías, fallas y datos inexistentes
+Los datos del INMET-BDMEP tienen fallas, como filas vacías debido a problemas en los sensores y en la comunicación de las estaciones meteorológicas. Estas fallas pueden identificarse porque todas las columnas de valores están nulas. Es importante considerar estas fallas al realizar análisis.
+
+## Conversión de horario
+Toda la información de horario está en UTC. Para convertirla al horario oficial de Brasília, es necesario restar 3 horas. Por ejemplo, 12:00 UTC equivale a las 9:00 en horario de Brasília.
+
+## Datos brutos y no validados
+Los datos de las estaciones automáticas son brutos y no pasan por un proceso de validación de consistencia.
+
+# Limitaciones
+* La tabla de microdatos disponibilizada por BD incluye exclusivamente datos de estaciones automáticas.
+* Las mediciones corresponden a un único punto en el espacio. La extrapolación de los datos a áreas mayores debe realizarse con ponderaciones.
+
+# Inconsistencias
+Aún no se han reportado inconsistencias en este conjunto de datos.
+
+# Observaciones a lo largo del tiempo
+Cada fila representa una compilación de medidas realizada por una estación meteorológica en un intervalo de una hora. Las columnas disponibilizadas son agregaciones de ese período, lo que permite seguir la evolución de las condiciones climáticas a lo largo del tiempo en las estaciones.
+
+# Filas duplicadas
+Aún no se han reportado filas duplicadas en las tablas de este conjunto.
+
+# Cruces
+La tabla de microdatos puede asociarse con la tabla de estaciones mediante la columna `id_estação`, lo que permite la geolocalización de los datos. Esto posibilita cruces externos con tablas georreferenciadas o que posean elementos de geolocalización, como la columna de código postal. Además, la tabla de estaciones ofrece la identificación del municipio, ampliando las posibilidades de cruces.
+
+# Descarga de los datos
+La tabla de microdatos tiene más de 10GB. Dependiendo de la capacidad de la computadora, el procesamiento de los datos puede sobrecargar la máquina. Por eso, recomendamos usar queries en BigQuery para procesar los datos en la nube antes de descargarlos. Filtra por la columna de partición (año) y selecciona solo las columnas relevantes.
+
+# Instrumento de recolección
+Los datos son recolectados por estaciones meteorológicas automáticas (EMA). La recolección de datos se realiza mediante sensores para la medición de los parámetros meteorológicos a observar. Las medidas se toman en intervalos de minuto a minuto y se integran en el período de una hora. Los datos recolectados por las EMA son enviados automáticamente a la sede del INMET en Brasília, cada hora.
+
+# Cambios en la recolección
+Estas tablas son consistentes desde el año 2000; no tenemos registro de cambios en la forma de recolección.
+
+# Actualizaciones
+La actualización de los datos en la fuente original es cada hora. En Base de los Datos actualizamos esta información mensualmente.
+
+# Tratamientos realizados por BD:
+En esta guía, los tratamientos se describen en un lenguaje más accesible. De manera complementaria, [los códigos de extracción y tratamiento](https://github.com/basedosdados/pipelines/blob/main/pipelines/datasets/br_inmet_bdmep/flows.py) y las [modificaciones realizadas en BigQuery](https://github.com/basedosdados/queries-basedosdados/blob/main/models/br_inmet_bdmep/br_inmet_bdmep__microdados.sql) están disponibles en el repositorio de GitHub para su consulta.
+Los tratamientos realizados en la tabla de microdatos fueron:
+* Renombramiento de las columnas para adecuarlas al manual de estilo de BD.
+* Sustitución de códigos inválidos ("-9999") por valores nulos.
+* Inclusión del identificador de la estación (id_estação) en la tabla de microdatos.
+* Ajuste del formato de las columnas de fecha y hora para compatibilidad con BigQuery.
+
+# Materiales de apoyo
+* [Nota técnica sobre el funcionamiento de la red de estaciones meteorológicas del INMET](http://www.cemtec.ms.gov.br/wp-content/uploads/2019/02/Nota_Tecnica-Rede_estacoes_INMET.pdf) 
+* [Nota del INMET - conoce cómo acceder a los datos meteorológicos](https://portal.inmet.gov.br/noticias/saiba-como-acessar-os-dados-meteorol%C3%B3gicos-dispon%C3%ADveis-no-site-do-inmet?utm_source=chatgpt.com)

--- a/next/content/userGuide/es/br-me-caged.md
+++ b/next/content/userGuide/es/br-me-caged.md
@@ -121,7 +121,7 @@ Los datos están anonimizados y no contienen CNPJ ni CPF. Para obtener datos ide
 
 # Tratamientos realizados por BD:
 
-En esta guía, los tratamientos se describen en un lenguaje más accesible. De manera complementaria, [los códigos de extracción y tratamiento](https://github.com/basedosdados/queries-basedosdados-dev/blob/main/models/br_me_caged/code/crawler_caged.py) y las [modificaciones realizadas en BigQuery](https://github.com/basedosdados/queries-basedosdados/tree/main/models/br_me_caged) están disponibles en el repositorio de GitHub para consulta.
+En esta guía, los tratamientos se describen en un lenguaje más accesible. De manera complementaria, [los códigos de extracción y tratamiento](https://github.com/basedosdados/pipelines/blob/main/models/br_me_caged/code/crawler_caged.py) y las [modificaciones realizadas en BigQuery](https://github.com/basedosdados/pipelines/tree/main/models/br_me_caged) están disponibles en el repositorio de GitHub para consulta.
 Los tratamientos realizados fueron:
 
 - Cambio de nombre de las columnas para adecuarlas al manual de estilo;

--- a/next/content/userGuide/es/br-me-caged.md
+++ b/next/content/userGuide/es/br-me-caged.md
@@ -1,0 +1,137 @@
+---
+title: Guía de uso del CAGED
+description: >-
+  Guía de uso del Cadastro Geral de Empregados e Desempregados (CAGED). Este material contiene información sobre las variables más importantes, preguntas frecuentes y ejemplos de uso del conjunto.
+date:
+  created: "2024-11-28T18:18:06.419Z"
+thumbnail:
+categories: [guia-de-uso]
+authors:
+  - name: Laura Amaral
+    role: Texto
+---
+
+# Introducción
+
+> Esta guía contiene información detallada sobre los datos. Para dudas sobre el acceso o el uso de la plataforma, consulta nuestra [página de Preguntas Frecuentes](/faq).
+
+Este conjunto de datos posee cinco tablas de microdatos, divididas entre dos del antiguo CAGED y tres del nuevo CAGED. Las metodologías del modelo antiguo y del nuevo no son compatibles, lo que afecta los análisis temporales.
+
+- **Microdatos Antiguos:** Cada fila representa un registro de admisión o despido hasta diciembre de 2019. Las columnas describen las características del empleado, del tipo de vínculo laboral y de la empresa.
+- **Microdatos Antiguos de Ajustes:** Complementa la tabla Microdatos Antiguos con ajustes de admisiones y despidos mensuales, incluyendo cancelaciones y movimientos fuera de plazo.
+- **Microdatos de Movimientos:** Cada fila representa un registro de admisión o despido a partir de enero de 2020. Las columnas describen las características del empleado, del tipo de vínculo laboral y de la empresa.
+- **Microdatos de Movimientos Excluidos:** Complementa la tabla Microdatos de Movimientos con cancelaciones de admisiones o despidos. Estas cancelaciones afectan el saldo del CAGED en sentido inverso al del evento original.
+- **Microdatos de Movimientos Fuera de Plazo:** Complementa la tabla Microdatos de Movimientos registrando eventos fuera del período regular.
+
+# Consideraciones para los análisis
+
+## Saldo de movimientos
+
+El crecimiento o la reducción de empleos en un grupo puede determinarse mediante la suma de la columna `saldo_movimentacao`. Verifica en esa columna si la fila representa una admisión o un despido.
+
+## Exclusiones y movimientos fuera de plazo
+
+Además de los movimientos regulares, es importante considerar las tablas Microdatos de Movimientos Excluidos y Microdatos de Movimientos Fuera de Plazo para obtener un saldo más preciso. Las cancelaciones afectan el saldo en sentido inverso al del evento original, mientras que los movimientos fuera de plazo incluyen eventos registrados después del período regular.
+
+## Ejemplo de ajuste del saldo con los movimientos fuera de plazo y los movimientos excluidos
+
+Como ejemplo de cómo realizar el procedimiento de ajuste, puede utilizarse la siguiente _query_:
+
+```sql
+with tabelas_unidas as (
+select *, 0 as indicador_exclusao from `basedosdados.br_me_caged.microdados_movimentacao`
+union all
+select * except (ano,mes), 0 as indicador_exclusao from `basedosdados.br_me_caged.microdados_movimentacao_fora_prazo`
+union all
+select * except (ano,mes, ano_declaracao_movimentacao, mes_declaracao_movimentacao, indicador_exclusao), 1 as indicador_exclusao from `basedosdados.br_me_caged.microdados_movimentacao_excluida`),
+
+tabela_ajustada as (
+select *,
+case
+  when saldo_movimentacao = 1 then 'admissão'
+  when saldo_movimentacao = -1 then 'desligamento'
+end as admissao_desligamento,
+case
+  when indicador_exclusao = 0 then saldo_movimentacao
+  when indicador_exclusao = 1 then -saldo_movimentacao
+end as saldo_movimentacao_ajustado
+from tabelas_unidas)
+
+select
+ano,
+mes,
+sum(if(admissao_desligamento = 'admissão', saldo_movimentacao_ajustado, 0)) as qte_admissoes,
+sum(if(admissao_desligamento = 'desligamento', saldo_movimentacao_ajustado, 0))as qte_desligamentos,
+sum(saldo_movimentacao_ajustado) as saldo,
+from tabela_ajustada
+where sigla_uf='SP'
+group by 1, 2
+order by ano, mes
+```
+
+# Limitaciones
+
+Los datos se limitan a trabajadores con vínculo laboral formal, y no incluyen información sobre trabajadores informales o autónomos.
+
+# Inconsistencias
+
+## Columna `salario_mensal`
+
+Se identificaron valores fuera de lo esperado, como salarios en el rango de millones de reales para sectores que generalmente no pagan montos tan elevados. Esto puede deberse a errores de registro o a valores atípicos.
+
+## Municipios y unidades federativas no identificados
+
+En todas las tablas existen casos en los que la columna _uf_ (sigla_uf, en BD) tiene el valor 99 y la variable _municipio_ (id_municipio, en BD) tiene el valor 99999.
+
+## Panel de empleos del CAGED
+
+El panel de empleos del [CAGED](https://app.powerbi.com/view?r=eyJrIjoiNWI5NWI0ODEtYmZiYy00Mjg3LTkzNWUtY2UyYjIwMDE1YWI2IiwidCI6IjNlYzkyOTY5LTVhNTEtNGYxOC04YWM5LWVmOThmYmFmYTk3OCJ9&pageName=ReportSectionb52b07ec3b5f3ac6c749) es la referencia de validación de los ajustes que deben realizarse con las tablas microdados_movimentacao_fora_prazo y microdados_movimentacao_excluida.
+
+# Observaciones a lo largo del tiempo
+
+Cada fila representa una contratación o un despido. Como los datos están desidentificados, no es posible seguir a individuos o empresas a lo largo del tiempo. Lo que sí es posible es seguir el crecimiento o la caída de trabajadores con contrato formal en un determinado sector (`cnae`), ocupación (`cbo`) u otras combinaciones de las columnas disponibles. Además, es importante tener en cuenta que la metodología del CAGED cambió a comienzos de 2020, por lo que los análisis temporales deben realizarse hasta 2019 o a partir de 2020.
+
+# Filas duplicadas
+
+No se encontraron filas duplicadas en este conjunto de datos.
+
+# Cruces
+
+Los datos están anonimizados y no contienen CNPJ ni CPF. Esto limita los cruces con otros conjuntos que sí poseen CNPJ, pero es posible usar columnas como `cnae` e `id_municipio` para realizar cruces interesantes.
+
+# Descarga de los datos
+
+Los microdatos suman más de 20 GB. Para evitar sobrecargar tu computadora, recomendamos usar queries en BigQuery para procesar los datos en la nube antes de descargarlos. Filtra por las columnas de partición (como año y UF) y selecciona solo las columnas relevantes.
+
+# Instrumento de recolección
+
+El Nuevo CAGED compila datos del empleo formal a partir de sistemas como eSocial, CAGED y Empregador Web. Los registros administrativos pasan por un procesamiento antes de ponerse a disposición del público.
+
+# Cambios en la recolección
+
+En 2020, el CAGED pasó por una reformulación, que automatizó la recolección de información y amplió la cobertura. Sin embargo, esto generó una incompatibilidad con las series históricas anteriores. Para más información sobre estas modificaciones, consulta los [materiales de apoyo](https://basedosdados.org/dataset/562b56a3-0b01-4735-a049-eeac5681f056?tab=userGuide#tratamentos-feitos-pela-bd).
+
+# Actualizaciones
+
+Los microdatos se actualizan con un mes de rezago. El calendario de actualizaciones puede consultarse en el [sitio del MTE](https://www.gov.br/trabalho-e-emprego/pt-br/assuntos/estatisticas-trabalho/o-pdet/calendario-de-divulgacao-do-novo-caged).
+
+# Datos identificados
+
+Los datos están anonimizados y no contienen CNPJ ni CPF. Para obtener datos identificados es necesario solicitarlos al MTE. El proceso puede ser demorado y no hay garantía de aprobación.
+
+# Tratamientos realizados por BD:
+
+En esta guía, los tratamientos se describen en un lenguaje más accesible. De manera complementaria, [los códigos de extracción y tratamiento](https://github.com/basedosdados/queries-basedosdados-dev/blob/main/models/br_me_caged/code/crawler_caged.py) y las [modificaciones realizadas en BigQuery](https://github.com/basedosdados/queries-basedosdados/tree/main/models/br_me_caged) están disponibles en el repositorio de GitHub para consulta.
+Los tratamientos realizados fueron:
+
+- Cambio de nombre de las columnas para adecuarlas al manual de estilo;
+- Creación de las columnas `ano` y `mes`;
+- Creación de las columnas ano_competencia_movimentacao y mes_competencia_movimentacao en las tablas microdados_movimentacao_fora_prazo y microdados_movimentacao_excluida
+- Creación de las columnas ano_declaracao_movimentacao y mes_declaracao_movimentacao en la tabla microdados_movimentacao_excluida
+- Adecuación de las columnas de unidades federativas al estándar de sigla UF;
+- Eliminación de las columnas: `valorsalariofixo`, `unidadesalariocodigo`
+
+# Materiales de apoyo
+
+- [Reportaje de G1 sobre los cambios en el CAGED](https://g1.globo.com/economia/noticia/2021/04/28/serie-historica-do-emprego-formal-nao-pode-ser-comparada-com-novo-caged-dizem-analistas.ghtml): Reportaje de G1 que recoge las consideraciones de especialistas sobre los cambios del CAGED
+- [Nota del MTE que explica los principales cambios en el Nuevo CAGED](https://www.gov.br/trabalho-e-emprego/pt-br/assuntos/estatisticas-trabalho/o-pdet/o-que-e-o-novo-caged): Nota del MTE que explica los principales cambios ocurridos en el Nuevo CAGED

--- a/next/content/userGuide/es/br-me-cnpj.md
+++ b/next/content/userGuide/es/br-me-cnpj.md
@@ -1,0 +1,101 @@
+---
+title: Guía de uso de los datos de CNPJ
+description: >-
+  Guía de uso de los datos de CNPJ. Este material contiene información sobre las variables más importantes, preguntas frecuentes y ejemplos de uso del conjunto de la RAIS 
+date:
+  created: "2024-11-28T18:18:06.419Z"
+thumbnail: 
+categories: [guia-de-uso]
+authors:
+  - name: Laura Amaral
+    role: Texto
+---
+
+# Introducción
+
+> Esta guía contiene información detallada sobre los datos. Para dudas sobre el acceso o el uso de la plataforma, consulta nuestra [página de Preguntas Frecuentes](/faq).
+
+Este conjunto posee cuatro tablas de microdatos:  
+- **Empresas:** Cada fila representa una empresa y sus atributos. Las columnas describen sus atributos, como la naturaleza jurídica y el tipo de estructura societaria. 
+- **Socios:** Cada fila representa un socio de una empresa. Las columnas describen las características del socio y califican su relación con la empresa.
+- **Establecimientos:** Cada fila representa un establecimiento de operación de una empresa. Las columnas detallan información sobre ubicación, actividad económica e información de contacto.
+- **Simples:** Cada fila representa una empresa e indica si la empresa está en el Simples Nacional o el MEI.  
+
+La tabla que relaciona a todas ellas es la tabla Empresas. Una empresa puede tener varios socios, varios establecimientos y puede estar clasificada como Simples Nacional o MEI. 
+
+Las tablas Empresas, Socios y Establecimientos se publican en formato de fotografías. Para cada fecha, se tiene un retrato del Registro Nacional de Personas Jurídicas (CNPJ) y sus atributos.
+
+# Consideraciones para los análisis
+## Diferencia entre establecimientos y empresas
+Una empresa puede tener varios establecimientos. La columna `cnpj_basico` se refiere a la empresa, y la columna `cnpj` se refiere al establecimiento. Por lo tanto, el `cnpj_basico` de la empresa se repite en proporción al número de establecimientos en la tabla Establecimientos. Parte de la información de la tabla Empresas, como la naturaleza jurídica, puede asignarse a los establecimientos. Para ello, es necesario cruzar los datos de la tabla de empresas con los de sus establecimientos.
+
+## Filtrado de CNPJ activos
+Para filtrar solo los CNPJ activos, usa la columna `situacao_cadastral`.
+
+# Limitaciones
+Los datos están disponibles solo a partir del 23-11-2021. No es posible acceder a los registros anteriores a esa fecha. Sin embargo, la base es acumulativa y no excluye registros. Solo actualiza la situación registral y los atributos de los CNPJ. Así, aunque no se puedan seguir los cambios anteriores al 23-11-2021, es posible consultar todos los CNPJ que alguna vez se abrieron en Brasil.
+
+# Inconsistencias
+Hasta el momento no se han reportado inconsistencias en este conjunto de datos.
+
+# Observaciones a lo largo del tiempo
+Los datos se publican en formato de fotografías. Para cada fecha, se tiene un retrato de los CNPJ y sus atributos. Con excepción de la tabla Simples, la columna de fecha indica la fecha en que se extrajeron los datos. Los datos anteriores al 23-11-2021 se presentan con el estado correspondiente a esa fecha.
+
+# Filas duplicadas
+En la mayoría de los archivos publicados por la Receita Federal, hay solo algunas decenas de filas duplicadas en los datos. Estas duplicaciones provienen de la fuente original y representan menos del 0,1% del total, lo que normalmente no afecta los análisis.
+
+Sin embargo, en dos fechas específicas, los archivos de la Receita Federal contienen un número significativo de filas duplicadas:
+  - Tabla Socios en la fecha 2024-09-18: se encontraron 4.625.789 filas duplicadas
+  - Tabla Establecimientos en la fecha 2024-10-16: se encontraron 8.100.851 filas duplicadas
+Estas filas duplicadas no fueron eliminadas de las tablas. Durante las pruebas de integridad, se observó que el número de CNPJ únicos fue menor que el registrado en fechas anteriores. Esto indica que las duplicaciones podrían haber sustituido CNPJ que deberían estar presentes en las tablas.
+
+# Cruces
+Las tablas pueden cruzarse usando las columnas `cnpj_básico` y `data`. Es necesario entender las claves únicas de cada tabla para evitar duplicaciones.
+
+# Descarga de los datos
+Los microdatos suman más de 300 GB. Para evitar sobrecargar tu computadora, recomendamos usar queries en BigQuery para procesar los datos en la nube antes de descargarlos. Filtra por las columnas de partición (como año y UF) y selecciona solo las columnas relevantes.
+
+# Instrumento de recolección
+El instrumento de recolección actual es el Documento Básico de Entrada (DBE), utilizado por la Receita Federal para registrar, modificar o dar de baja el registro de una persona jurídica.
+  
+# Cambios en la recolección
+No hubo cambios en la metodología de recolección desde 2021 hasta el momento de elaboración de esta guía (08-01-2025).
+
+# Actualizaciones
+Los datos se actualizan después del día 15 de cada mes. Nuestra plataforma realiza verificaciones automáticas diarias para detectar actualizaciones.
+
+# Datos identificados
+Los datos de CPF de los socios se ponen a disposición de forma anonimizada. No es posible obtener la base identificada. 
+
+# Tratamientos realizados por BD:
+En esta guía, los tratamientos se describen en un lenguaje más accesible. De manera complementaria, los [códigos de tratamiento](https://github.com/basedosdados/pipelines/blob/main/pipelines/datasets/br_me_cnpj/tasks.py#L50C1-L50C74) y las [modificaciones realizadas en BigQuery](https://github.com/basedosdados/queries-basedosdados/tree/main/models/br_me_cnpj) están disponibles en el repositorio de GitHub para consulta.
+
+## Tabla Empresas
+- Sustitución de ',' por '.' en la columna `capital_social`
+- Relleno con ceros (0) a la izquierda hasta una longitud máxima de 8 dígitos en la columna `cnpj_basico`
+- Relleno con ceros (0) a la izquierda hasta una longitud máxima de 4 dígitos en la columna `natureza_juridica`
+
+## Tabla Socios
+- Adecuación de la columna `data_entrada_sociedade` al estándar año-mes-día (%Y-%m-%d)
+- Relleno con ceros (0) a la izquierda hasta una longitud máxima de 8 dígitos en la columna `cnpj_basico`
+- Sustitución del valor que identifica valores nulos de CPF de "***000000***" por ""
+
+## Tabla Establecimientos
+- Relleno con ceros (0) a la izquierda hasta una longitud máxima de 8 dígitos en la columna `cnpj_basico`
+- Relleno con ceros (0) a la izquierda hasta una longitud máxima de 4 dígitos en la columna `cnpj_ordem`
+- Relleno con ceros (0) a la izquierda hasta una longitud máxima de 2 dígitos en la columna `cnpj_dv`
+- Creación de la columna `cnp` mediante la unión de los valores de las columnas `cnpj_basico`, `cnpj_ordem` y `cnpj_dv`
+- Creación de la columna `id_municipio` de 7 dígitos del IBGE a partir de la columna `id_municipio_rf` (ID de municipio de la Receita Federal)
+- Adecuación de las columnas `data_situacao_cadastral`, `data_situacao_especial` y `data_inicio_atividade` al estándar año-mes-día (%Y-%m-%d)
+
+## Tabla Simples
+- Sustitución de los valores N por 0 y S por 1 en la columna `opcao_simples`
+- Sustitución de los valores N por 0 y S por 1 en la columna `opcao_mei`
+- Relleno con ceros (0) a la izquierda hasta una longitud máxima de 8 dígitos en la columna `cnpj_basico`
+- Adecuación de las columnas `data_opcao_simples`, `data_exclusao_simples`, `data_opcao_mei` y `data_exclusao_mei` al estándar año-mes-día (%Y-%m-%d)
+
+
+
+# Materiales de apoyo
+* [Evaluación de confidencialidad de la información contenida en los Datos Abiertos del Registro Nacional de Personas Jurídicas (CNPJ)](https://www.gov.br/receitafederal/dados/nota-cocad-rfb-86-2024.pdf/)
+* [Tutorial de BD sobre cómo acceder y analizar datos de CNPJ usando SQL, Python o R](https://www.youtube.com/watch?v=WQruVEizTlc&t=1782s)

--- a/next/content/userGuide/es/br-me-cnpj.md
+++ b/next/content/userGuide/es/br-me-cnpj.md
@@ -68,7 +68,7 @@ Los datos se actualizan después del día 15 de cada mes. Nuestra plataforma rea
 Los datos de CPF de los socios se ponen a disposición de forma anonimizada. No es posible obtener la base identificada. 
 
 # Tratamientos realizados por BD:
-En esta guía, los tratamientos se describen en un lenguaje más accesible. De manera complementaria, los [códigos de tratamiento](https://github.com/basedosdados/pipelines/blob/main/pipelines/datasets/br_me_cnpj/tasks.py#L50C1-L50C74) y las [modificaciones realizadas en BigQuery](https://github.com/basedosdados/queries-basedosdados/tree/main/models/br_me_cnpj) están disponibles en el repositorio de GitHub para consulta.
+En esta guía, los tratamientos se describen en un lenguaje más accesible. De manera complementaria, los [códigos de tratamiento](https://github.com/basedosdados/pipelines/blob/main/pipelines/datasets/br_me_cnpj/tasks.py#L50C1-L50C74) y las [modificaciones realizadas en BigQuery](https://github.com/basedosdados/pipelines/tree/main/models/br_me_cnpj) están disponibles en el repositorio de GitHub para consulta.
 
 ## Tabla Empresas
 - Sustitución de ',' por '.' en la columna `capital_social`

--- a/next/content/userGuide/es/br-me-rais.md
+++ b/next/content/userGuide/es/br-me-rais.md
@@ -1,0 +1,85 @@
+---
+title: Guía de uso de la RAIS
+description: >-
+  Guía de uso de la Relação Anual de Informações Sociais (RAIS). Este material contiene información sobre las variables más importantes, preguntas frecuentes y ejemplos de uso del conjunto de datos de la RAIS 
+date:
+  created: "2024-11-28T18:18:06.419Z"
+thumbnail: 
+categories: [guia-de-uso]
+authors:
+  - name: Laura Amaral
+    role: Texto
+---
+
+# Introducción
+
+> Esta guía contiene información detallada sobre los datos. Si tiene dudas sobre el acceso o el uso de la plataforma, consulte nuestra [página de Preguntas Frecuentes](/faq).
+
+Este conjunto de datos tiene dos tablas de microdatos: 
+- **Microdatos de Establecimientos:** Cada fila representa un establecimiento en un año específico. Las columnas muestran detalles sobre la empresa y sus empleados.
+- **Microdatos de Vínculos:** Cada fila representa un vínculo laboral en un año específico. Las columnas muestran información sobre el vínculo, el empleado y la empresa contratante.
+
+# Consideraciones para los análisis
+## Vínculos y filtrado de datos
+La tabla de vínculos muestra todos los vínculos registrados por una empresa durante el año. Si un empleado es despedido y otro es contratado en el mismo año, ambos tendrán un registro de vínculo para el mismo puesto. Para contar los empleados activos en un sector o región, use la columna `vinculo_ativo_3112`.
+
+## Información de dirección
+La RAIS no contiene información sobre la dirección de los empleados. La columna `id_municipio` se refiere al municipio de la empresa, y la columna `id_municipio_trabalho` se refiere al municipio donde el trabajador presta servicios, cuando es diferente.
+
+## Datos parciales y datos completos
+La RAIS se publica dos veces al año. Entre la publicación parcial (septiembre) y la completa (inicio del año siguiente), el último año de la serie siempre muestra menos registros. Por ejemplo, en noviembre de 2025, el año 2024 muestra alrededor de 46 millones de vínculos, mientras que 2022 y 2023 tienen más de 50 millones. Esto no significa que el número de vínculos haya caído: solo significa que los datos de 2024 aún no se habían publicado en su totalidad.
+
+# Limitaciones
+Los datos se limitan a trabajadores con vínculo formal y no incluyen trabajadores informales ni autónomos. Los datos públicos están anonimizados.
+
+# Inconsistencias
+## Columnas `quantidade_vinculos_ativos` y `tamanho_estabelecimento`
+Existen discrepancias entre las columnas `quantidade_vinculos_ativos` y `tamanho_estabelecimento`. La primera muestra el total de vínculos, mientras que la segunda clasifica el establecimiento por número de vínculos. En algunos casos, la cantidad de vínculos no corresponde a la categoría de tamaño del establecimiento.
+
+## Vínculos laborales en la RAIS y en el CAGED
+La RAIS registra vínculos laborales anualmente y el CAGED registra los movimientos durante el año. En teoría, sumando o restando los movimientos del CAGED al total de vínculos de la RAIS, sería posible calcular el total del año siguiente, pero eso no ocurre. Como los sistemas operan de forma independiente, las divergencias pueden deberse a errores acumulados en cada uno.
+
+## Columna id_municipio_trabalho
+La columna `id_municipio_trabalho` está completa solo entre 2005-2011 y 2017-2021. Se desconoce el motivo.  
+
+## Datos desactualizados
+A veces, los datos de la RAIS se actualizan fuera del calendario previsto y nuestro equipo no siempre se entera. Si tiene la certeza de que está haciendo las consultas correctas, contáctenos enviando la consulta y la diferencia respecto al sitio oficial, para que podamos evaluar la situación y, si es necesario, corregirla.  
+
+# Observaciones a lo largo del tiempo
+Cada año, el conjunto de datos se actualiza, de modo que un establecimiento o vínculo aparece en todos los años en que estuvo activo. Como los datos están anonimizados, no es posible seguir la evolución de vínculos o empresas a lo largo del tiempo, pero sí es posible analizar el número de empleados registrados formalmente en diferentes sectores o localidades.
+
+# Filas duplicadas
+No se encontraron filas duplicadas en este conjunto de datos. Sin embargo, la tabla de Microdatos de Vínculos incluye todos los vínculos de una empresa, por lo que, si un empleado fue despedido y otro contratado en el mismo año, habrá dos filas para el mismo puesto.
+
+# Cruces con otros conjuntos de datos
+Los datos están anonimizados y no contienen CNPJ ni CPF. Esto limita los cruces con otros conjuntos de datos, pero es posible usar columnas como `cnae` y `cep` para ese fin.
+
+# Descarga de los datos
+Los microdatos suman más de 350 GB. Para evitar sobrecargar su computadora, recomendamos usar consultas en BigQuery para procesar los datos en la nube antes de descargarlos. Filtre por las columnas de partición (como `ano` y `sigla_uf`) y seleccione solo las columnas relevantes.
+
+# Instrumento de recolección
+El instrumento de recolección actual es un formulario que los empleadores deben completar sobre sus empleados.
+
+# Cambios en la recolección
+Algunas columnas se han agregado o eliminado a lo largo del tiempo. A partir de 2022, las empresas del grupo 3 del eSocial dejaron de estar obligadas a declarar la RAIS por su programa habitual. Por eso, no se recomienda comparar los resultados de ese año con los de años anteriores.
+
+# Actualizaciones
+Los datos tienen una actualización parcial y una completa. La actualización parcial ocurre en septiembre del año de recolección, y la completa ocurre hasta el inicio del año siguiente al año de recolección. Esto significa que los datos correspondientes a 2023, recolectados en 2024, estuvieron parcialmente disponibles en septiembre de 2024, y la versión completa se publicó hasta comienzos de 2025. A veces, la actualización puede ocurrir fuera del calendario previsto. Si nota que los datos están desactualizados, contacte a nuestro equipo.
+
+# Datos identificados
+Los datos están anonimizados y no contienen CNPJ ni CPF. Para obtener datos identificados de la RAIS, es necesario solicitarlos al MTE. El proceso puede ser lento y no hay garantía de aprobación.
+
+# Tratamientos realizados por BD
+En esta guía, los tratamientos se describen en un lenguaje más accesible. De manera complementaria, los [códigos de tratamiento](https://github.com/basedosdados/queries-basedosdados/tree/main/models/br_me_rais/code) y las [modificaciones realizadas en BigQuery](https://github.com/basedosdados/queries-basedosdados/tree/main/models/br_me_rais) están disponibles en el repositorio de GitHub para consulta. 
+Los tratamientos realizados fueron: 
+* Adecuación de las columnas que identifican municipios al formato ID Municipio IBGE (7 dígitos);
+* Adecuación de las columnas que identifican Unidades Federativas al estándar de sigla UF;
+* Sustitución de códigos inválidos (como "9999" o "000") por valores nulos en las columnas `bairros`, `cbo`, `cnae` y `ano`;
+* Estandarización de los códigos en la columna `tipo_estabelecimento` para garantizar consistencia entre diferentes años.
+
+# Materiales de apoyo
+* [Manual de orientación para los empleadores sobre cómo completar los campos del formulario](http://www.rais.gov.br/sitio/rais_ftp/ManualRAIS2023.pdf)
+* [Información detallada sobre la RAIS en el sitio del MTE](http://www.rais.gov.br/sitio/sobre.jsf)
+* [Panel del MTE con cifras consolidadas de la RAIS completa](https://app.powerbi.com/view?r=eyJrIjoiZmJmMDVhODctMTEwOS00YTVhLWJhNzItOWE3NmVlMWEwMTUxIiwidCI6IjNlYzkyOTY5LTVhNTEtNGYxOC04YWM5LWVmOThmYmFmYTk3OCJ9)
+* [Panel del MTE con cifras consolidadas de la RAIS parcial](https://app.powerbi.com/view?r=eyJrIjoiNjk3M2IwZDYtOGQzMS00YmE1LWE3M2MtZWRjODA4NTk3YTQ2IiwidCI6IjNlYzkyOTY5LTVhNTEtNGYxOC04YWM5LWVmOThmYmFmYTk3OCJ9)
+* [Sistema Dardo: sistema que utilizamos para la validación de las tablas publicadas](https://bi.mte.gov.br/bgcaged/)

--- a/next/content/userGuide/es/br-me-rais.md
+++ b/next/content/userGuide/es/br-me-rais.md
@@ -70,7 +70,7 @@ Los datos tienen una actualización parcial y una completa. La actualización pa
 Los datos están anonimizados y no contienen CNPJ ni CPF. Para obtener datos identificados de la RAIS, es necesario solicitarlos al MTE. El proceso puede ser lento y no hay garantía de aprobación.
 
 # Tratamientos realizados por BD
-En esta guía, los tratamientos se describen en un lenguaje más accesible. De manera complementaria, los [códigos de tratamiento](https://github.com/basedosdados/queries-basedosdados/tree/main/models/br_me_rais/code) y las [modificaciones realizadas en BigQuery](https://github.com/basedosdados/queries-basedosdados/tree/main/models/br_me_rais) están disponibles en el repositorio de GitHub para consulta. 
+En esta guía, los tratamientos se describen en un lenguaje más accesible. De manera complementaria, los [códigos de tratamiento](https://github.com/basedosdados/pipelines/tree/main/models/br_me_rais/code) y las [modificaciones realizadas en BigQuery](https://github.com/basedosdados/pipelines/tree/main/models/br_me_rais) están disponibles en el repositorio de GitHub para consulta. 
 Los tratamientos realizados fueron: 
 * Adecuación de las columnas que identifican municipios al formato ID Municipio IBGE (7 dígitos);
 * Adecuación de las columnas que identifican Unidades Federativas al estándar de sigla UF;

--- a/next/content/userGuide/es/br-tse-eleicoes.md
+++ b/next/content/userGuide/es/br-tse-eleicoes.md
@@ -129,5 +129,5 @@ Los tratamientos realizados fueron:
 * [Noticia del TSE sobre las elecciones suplementarias](https://www.tse.jus.br/comunicacao/noticias/2025/Fevereiro/voce-sabe-o-que-e-uma-eleicao-suplementar)
 
 [code-pipeline]: https://github.com/basedosdados/pipelines/tree/main/pipelines/utils/crawler_tse_eleicoes
-[code-notebook]: https://github.com/basedosdados/queries-basedosdados/blob/main/models/br_tse_eleicoes/code/%5Bdbt%5Dbr_tse_eleicoes.ipynb
-[queries-dir]: https://github.com/basedosdados/queries-basedosdados/tree/main/models/br_tse_eleicoes
+[code-notebook]: https://github.com/basedosdados/pipelines/blob/main/models/br_tse_eleicoes/code/%5Bdbt%5Dbr_tse_eleicoes.ipynb
+[queries-dir]: https://github.com/basedosdados/pipelines/tree/main/models/br_tse_eleicoes

--- a/next/content/userGuide/es/br-tse-eleicoes.md
+++ b/next/content/userGuide/es/br-tse-eleicoes.md
@@ -1,0 +1,133 @@
+---
+title: Guía de uso de las Elecciones Brasileñas
+description: >-
+  Guía de uso de los datos de Elecciones Brasileñas. Este material contiene información sobre las variables más importantes, preguntas frecuentes y ejemplos de uso del conjunto.
+date:
+  created: "2024-11-28T18:18:06.419Z"
+thumbnail: 
+categories: [guia-de-uso]
+authors:
+  - name: Laura Amaral
+    role: Texto
+---
+
+# Introducción
+
+> Esta guía contiene información detallada sobre los datos. Para dudas sobre el acceso o el uso de la plataforma, consulte nuestra [página de Preguntas Frecuentes](/faq).
+
+Al tener más de 20 tablas, este conjunto puede parecer complejo a primera vista. Para facilitarlo, organizamos la información en grupos temáticos y detallamos el contenido de cada tabla.
+
+## Candidatos
+- **`candidato`**: Tabla de microdatos. Cada fila representa una candidatura en una elección. Las columnas contienen información sobre el candidato y su candidatura.
+- **`bens_candidato`**: Tabla de microdatos. Cada fila representa un bien declarado por un candidato en una elección. Si el candidato participa en más de una elección, pueden aparecer bienes repetidos. Las columnas describen el bien y su valor.
+- **`despesas_candidato`**: Tabla de microdatos. Cada fila representa un comprobante de gasto de un candidato en una elección. Las columnas describen los detalles del gasto.
+- **`receitas_candidato`**: Tabla de microdatos. Cada fila representa un ingreso de campaña de un candidato en una elección. Las columnas incluyen información sobre el ingreso, como los datos del donante y detalles fiscales.
+- **`resultados_candidato`, `resultados_candidato_municipio`, `resultados_candidato_municipio_zona`, `resultados_candidato_secao`**: Tablas agregadas con estructura similar. Cada fila representa el resultado de un candidato en una elección. La diferencia está en el nivel de agregación: total de la elección, por municipio, por zona o por sección. Las columnas muestran el total de votos, detalles del cargo y si el candidato fue electo.
+
+## Partidos
+- **`partidos`**: Tabla de microdatos. Cada fila representa un partido en un recorte electoral en una elección. Las columnas indican la situación del partido y las coaliciones o federaciones formadas para cada cargo.
+- **`receitas_comite` y `receitas_orgao_partidario`**: Tablas de microdatos con estructura similar. Cada fila representa un ingreso de campaña. La diferencia está en la entidad que recibió el ingreso: comité u órgano partidario. Las columnas incluyen información sobre el ingreso, como los datos del donante y detalles fiscales.
+- **`resultados_partido_municipio`, `resultados_partido_municipio_zona`, `resultados_partido_secao`**: Tablas agregadas con estructura similar. Cada fila representa el resultado de un partido para un cargo determinado en una elección. La diferencia está en el nivel de agregación: por municipio, por zona o por sección. Las columnas muestran el total de votos, separando votos nominales y votos de leyenda (lista partidaria).
+
+## Información general sobre las elecciones
+- **`vagas`**: Tabla agregada. Cada fila representa un cargo en una unidad electoral en una elección. Las columnas indican el total de escaños disponibles para ese cargo.
+- **`perfil_eleitorado_local_votacao`, `perfil_eleitorado_municipio_zona`, `perfil_eleitorado_secao`**: Tablas agregadas con estructura similar. Cada fila representa un estrato del perfil sociodemográfico de los electores (género, edad, estado civil, nivel educativo). La diferencia está en el nivel de agregación: por municipio, por zona o por sección. Las columnas indican el perfil sociodemográfico, la situación respecto a la biometría y el total de electores.
+- **`detalhes_votacao_municipio`, `detalhes_votacao_municipio_zona`, `detalhes_votacao_secao`**: Tablas agregadas con estructura similar. Cada fila representa los detalles de la votación en una elección. La diferencia está en el nivel de agregación: por municipio, por zona o por sección. Las columnas indican el total de abstenciones y votos por tipo.
+- **`local_secao`**: Tabla de microdatos. Cada fila representa una sección electoral en un año. Esta es la única tabla que no fue publicada por el TSE; fue creada por una organización externa. Las columnas incluyen estimaciones del punto de ubicación geográfica de cada sección electoral.
+
+# Consideraciones para los análisis
+## Transferencias entre candidatos en la tabla de ingresos
+Los candidatos pueden transferirse fondos entre sí, lo que hace que un mismo ingreso aparezca más de una vez.
+
+## Columna id_municipio
+Algunos registros tienen la columna `id_municipio nulo`, ya que el TSE registra municipios en el exterior que no cuentan con código IBGE. En esos casos, solo la columna `id_municipio_tse` está completa.
+
+## Situación del candidato
+Las candidaturas pueden ser rechazadas por la justicia electoral. Para filtrar únicamente a los candidatos que efectivamente compitieron en una elección, use el filtro `situacao = 'deferida'`.
+
+## Rendición de cuentas
+Los datos se completan manualmente, lo que puede generar inconsistencias, valores ausentes o duplicados, especialmente durante los períodos de campaña.
+
+## Proporción de votos válidos para el Senado
+En los años en que la elección para el Senado involucra dos escaños, la proporción de votos válidos en las tablas `detalhes_votacao_municipio`, `detalhes_votacao_municipio_zona` y `detalhes_votacao_secao` puede superar el 100%.
+Esto ocurre porque, en esos años, cada elector puede votar por dos candidatos diferentes, y el TSE contabiliza cada voto individualmente como un voto válido para el cargo. Así, un mismo elector aparece dos veces en el conteo, lo que eleva la proporción de votos válidos por encima del 100%.
+
+## Elecciones suplementarias
+Puede haber más de un alcalde, gobernador o presidente electo dentro de un mismo mandato (por ejemplo, 2020–2024). Esto ocurre cuando la justicia electoral anula más del 50% de los votos válidos y convoca una elección suplementaria para elegir a un nuevo representante. Para el análisis, use la columna `tipo_eleição` para diferenciar elecciones ordinarias y suplementarias dentro de un mismo ciclo electoral.
+
+## Columna ano
+La columna ano indica el año del ciclo electoral originalmente previsto (ej.: 2020), aunque la elección haya ocurrido posteriormente. Por ejemplo, la columna `data_eleicao` puede indicar una fecha en 2022, mientras que la columna `ano` permanece con el valor 2020.
+
+# Limitaciones
+Las tablas del TSE no incluyen información sobre elecciones para el conselho tutelar (consejo tutelar de niños y adolescentes).
+
+# Inconsistencias
+Además del comportamiento esperado en los años con dos escaños para el Senado, identificamos que existen algunas decenas de filas en la tabla `detalhes_votacao_secao` en las que la proporción de votos válidos supera el 100% sin una causa conocida. Este conjunto de casos es muy pequeño en relación con el total de filas de la tabla y, hasta el momento, no hemos encontrado una explicación para lo ocurrido. Recomendamos tratar estos registros como residuales y analizarlos con cautela si tienen un impacto directo en su aplicación.
+
+# Observaciones a lo largo del tiempo
+
+- Para hacer seguimiento de los candidatos a lo largo de los años, puede usar la columna `titulo_eleitoral`. Este identificador rastrea a los individuos de forma consistente, superando la limitación de otros identificadores asociados que cambian entre elecciones. Identifica a los candidatos en el 99,5% de los casos. Sin embargo, cabe señalar que pueden existir valores nulos o dos identificadores diferentes para un mismo candidato en algunos casos.
+
+- Para hacer seguimiento de los partidos, es necesario considerar los cambios de nombre y las fusiones a lo largo del tiempo.
+
+# Filas duplicadas
+Las filas duplicadas se eliminan durante el tratamiento realizado por BD.
+
+# Cruces
+Preste atención a las columnas que identifican de manera única a las entidades y tablas:
+- **Candidaturas**: Para cruzar información de una misma elección, las columnas `ano`, `tipo_eleicao` y `sequencial_candidato` forman una clave única para los datos a partir de 2010. Para períodos anteriores, puede usar las columnas `titulo_eleitor`, `ano` y `tipo_eleicao`. Esta combinación es única en el 99,5% de los casos, pero no es totalmente precisa, ya que algunas candidaturas tienen la columna `titulo_eleitor` vacía.
+- **Personas:** Una misma persona puede tener varias candidaturas registradas a lo largo de los años. Para identificar a una persona, se recomienda usar la columna `titulo_eleitor`.
+- **Zonas**: Para cruzar información de un mismo año, las columnas `ano`, `id_municipio_tse` y `zona` forman una clave única. Las zonas pueden cambiar entre años y tienen identificadores únicos solo dentro de un municipio.
+- **Secciones**: Para cruzar información de un mismo año, las columnas `ano`, `id_municipio_tse`, `zona` y `seção` forman una clave única. Las secciones pueden cambiar entre años y tienen identificadores únicos solo dentro de un municipio y una zona.
+- **Partidos**: Se identifican por las columnas `sigla_partido` y `numero_partido`.
+
+# Descarga de los datos
+Algunas tablas de este conjunto tienen más de 1GB, mientras que otras son más pequeñas. Para evitar sobrecargar su computadora, verifique el tamaño de las tablas que le interesan. Si son muy grandes, recomendamos usar consultas en BigQuery para procesar los datos en la nube antes de descargarlos. Filtre por las columnas de partición (como año y estado, UF) y seleccione solo las columnas relevantes.
+
+# Instrumento de recolección
+## Sistema de Candidaturas (CAND)
+Sistema utilizado para registrar candidaturas, en el que los partidos y coaliciones ingresan datos personales, información sobre afiliación partidaria, certificados de antecedentes penales y demás documentación necesaria de los candidatos.
+
+## Sistema de Rendición de Cuentas Electorales (SPCE)
+Sistema utilizado para registrar todos los ingresos y gastos de campaña. El SPCE garantiza que la información se presente de forma estandarizada y dentro de los plazos establecidos por la justicia electoral.
+
+## Resultados electorales
+Al finalizar la votación, cada urna electrónica genera un Boletim de Urna (acta de resultados) con los resultados obtenidos en la sección electoral. Los datos de las actas se envían a los Tribunales Regionales Electorales (TRE) y, luego, al TSE para la divulgación de los resultados finales.
+
+## Perfil de los electores
+Durante el alistamiento electoral y la revisión del padrón, los electores proporcionan datos personales, como nombre, fecha de nacimiento, género, nivel educativo y dirección. Las oficinas electorales registran esta información en el Cadastro Nacional de Eleitores (Padrón Nacional de Electores).
+
+# Cambios en la recolección
+El sistema electoral ha pasado por varios cambios a lo largo de los años, lo que impactó los datos recolectados. A continuación, los principales cambios:
+- **1997**: Inclusión de información sobre género;
+- **1998**: Divulgación del CPF (identificación tributaria individual) de los candidatos;
+- **2014**: Inclusión de información sobre raza o color;
+- **2016**: Prohibición de donaciones de CNPJ (empresas);
+- **2022**: Recolección de datos sobre transgeneridad;
+- **2024**: Interrupción de la divulgación del CPF de los candidatos.
+
+# Actualizaciones
+La mayoría de los datos se actualiza una vez por cada elección regular (cada dos años). Los datos de ingresos y gastos se actualizan diariamente durante las campañas electorales.
+
+# Tratamientos realizados por BD:
+En esta guía, los tratamientos se describen en un lenguaje más accesible. De manera complementaria, los [códigos de tratamiento](code-notebook) y las [modificaciones realizadas en BigQuery](queries-dir) están disponibles en el repositorio de GitHub para su consulta.
+Los tratamientos realizados fueron:
+- Eliminación de acentos y conversión del texto a minúsculas.
+- Eliminación de registros duplicados considerando el conjunto completo de columnas.
+- Los valores inválidos, como "-9999" o "#NULO", se convirtieron en nulos.
+- Adecuación de las columnas que identifican municipios al formato ID Municipio IBGE (7 dígitos).
+- Las fechas inconsistentes en la columna `data_nascimento` (edades menores de 18 o mayores de 120 años) se sustituyeron por valores nulos.
+- Estandarización de la columna `tipo_eleicao`, cambiando "eleições municipais" por "eleição ordinária".
+- Estandarización de la columna `nacionalidade`, cambiando "brasileira nata" por "brasileira".
+
+# Materiales de apoyo
+* [Sitio de datos abiertos del TSE con archivos disponibles para descargar](https://dadosabertos.tse.jus.br/dataset/)
+* [Panel de Estadísticas Electorales con una amplia variedad de filtros y análisis simplificados](https://sig.tse.jus.br/ords/dwapr/seai/r/sig-eleicao/home?session=17112009236550)
+* [Panel de consulta de información sobre candidaturas y rendición de cuentas electorales](https://divulgacandcontas.tse.jus.br/divulga/#/home)
+* [Siga o Dinheiro (Sigue el Dinero): Panel desarrollado por BD para entender de dónde viene y en qué se está gastando el dinero de las campañas](https://www.sigaodinheiro.org/)
+* [Curso de Análisis de Datos Electorales de BD](https://info.basedosdados.org/bd-edu-eleicoes)
+* [Noticia del TSE sobre las elecciones suplementarias](https://www.tse.jus.br/comunicacao/noticias/2025/Fevereiro/voce-sabe-o-que-e-uma-eleicao-suplementar)
+
+[code-pipeline]: https://github.com/basedosdados/pipelines/tree/main/pipelines/utils/crawler_tse_eleicoes
+[code-notebook]: https://github.com/basedosdados/queries-basedosdados/blob/main/models/br_tse_eleicoes/code/%5Bdbt%5Dbr_tse_eleicoes.ipynb
+[queries-dir]: https://github.com/basedosdados/queries-basedosdados/tree/main/models/br_tse_eleicoes

--- a/next/content/userGuide/es/br_me_comex.md
+++ b/next/content/userGuide/es/br_me_comex.md
@@ -1,0 +1,97 @@
+---
+title: Guía de uso de Comex Stat
+description: >-
+  Guía de uso de las Estadísticas de Comercio Exterior en Datos Abiertos (Comex Stat). Este material contiene información sobre las variables más importantes, preguntas frecuentes y ejemplos de uso del conjunto de datos de Comex Stat
+date:
+  created: "2025-10-25T18:18:06.419Z"
+thumbnail: 
+categories: [guia-de-uso]
+authors:
+  - name: Thais Filipi
+    role: Texto
+---
+
+# Introducción
+
+> Esta guía contiene información detallada sobre los datos. Para dudas sobre el acceso o el uso de la plataforma, consulte nuestra [página de Preguntas Frecuentes](/faq).
+
+Este conjunto de datos tiene cuatro tablas de microdatos:
+- **Municipio Exportación:** Cada fila representa la agregación de los registros de exportación por año, mes, categoría del producto (SH4), país de destino, unidad federativa y municipio de la empresa exportadora.
+- **Municipio Importación:** Cada fila representa la agregación de los registros de importación por año, mes, categoría del producto (SH4), país de origen del bien importado, unidad federativa y municipio de la empresa importadora.
+- **NCM Exportación:** Cada fila representa la agregación de los registros de exportación por año, mes, medio de transporte, aduana, país, categoría del producto (NCM) y la unidad federativa en la que se produjo la mercancía exportada.
+- **NCM Importación:** Cada fila representa la agregación de los registros de importación por año, mes, medio de transporte, aduana, país, categoría del producto (NCM) y la unidad federativa de destino de la importación realizada.
+
+# Consideraciones para los análisis
+## Categorías de producto
+- El Sistema Armonizado (SA) es un sistema internacional de clasificación y codificación de mercancías, generalmente con códigos de 6 dígitos. Tiene varios niveles de detalle. Los dos primeros dígitos corresponden al capítulo, los dos siguientes a la partida y los dos últimos a la subpartida de la mercancía. En las tablas ```municipio_exportacao``` y ```municipio_importacao```, la columna de clasificación es SH4, lo que significa que solo tenemos la agregación a nivel de partida de la mercancía. La traducción de este código se realiza a través de los [Directorios Mundiales de BD](https://basedosdados.org/dataset/afc7c3a1-8691-4f3b-8566-bdce90f1100d?table=2399179d-0e74-4f1b-a940-7e418cafa02f), que tiene 6 dígitos.
+-  La Nomenclatura Común del Mercosur (NCM) es un desdoblamiento del SA. De los ocho dígitos que componen la NCM, los seis primeros están formados por el Sistema Armonizado, mientras que los dos últimos corresponden a secciones específicas en el ámbito del MERCOSUR. Traducir mediante los [Directorios Mundiales](https://basedosdados.org/dataset/afc7c3a1-8691-4f3b-8566-bdce90f1100d?table=3027c0d8-d17b-443f-a295-1de6ff65d5cc).
+- Cada producto está asociado a una unidad de medida (```id_unidade```) que define cómo deben interpretarse los valores (por ejemplo, kilogramo neto, unidad o tonelada métrica neta). Es posible traducir la columna ```id_unidade``` de las tablas ```ncm_exportação``` y ```ncm_importacao``` mediante los [Directorios Mundiales](https://basedosdados.org/dataset/afc7c3a1-8691-4f3b-8566-bdce90f1100d?table=3027c0d8-d17b-443f-a295-1de6ff65d5cc).
+
+## Datos de ```id_municipio``` y ```sigla_uf```
+- En ```municipio_exportacao``` y ```municipio_importacao```, la columna de municipio se refiere al domicilio fiscal de la empresa responsable de la exportación o importación, no al lugar donde se produjo la mercancía exportada ni al destino de la importación. La ```sigla_uf``` en estas tablas corresponde al valor de ```id_municipio```.
+- En ```ncm_exportacao``` y ```ncm_importacao```, la columna de UF se refiere al lugar de producción de la mercancía (exportación) o al destino de la importación, independientemente de la ubicación de la sede de la empresa que realizó la exportación o importación.
+
+# Corrección de valores nulos de UF y municipio
+Los valores nulos de ```id_municipio``` y ```sigla_uf``` se corrigen y completan correctamente solo después de la corrección anual de los datos por parte de la secretaría responsable.
+
+## Datos de ```id_pais``` en las tablas de importación
+La importación considera el origen de la mercancía, y no el país de la empresa que realizó la venta. En la mayoría de los casos, el país sede de la empresa que vende la mercancía es el mismo país donde se fabrica la mercancía. Sin embargo, hay casos en que esto no ocurre.
+
+## Valor FOB
+```valor_fob_dolar``` se refiere únicamente al valor de la mercancía. Los costos de flete y seguro de importación se detallan en ```valor_frete``` y ```valor_seguro```.
+
+## URFs y vía
+No se debe confundir las Unidades de la Receita Federal de Despacho (URFs) con una vía específica, como por ejemplo, los puertos, ya que algunos puertos tienen más de un recinto aduanero.
+
+# Limitaciones
+Los registros no están identificados por las empresas o personas físicas que participan en la exportación o importación de bienes, lo que limita las posibilidades de análisis (como por CNAE o tamaño de la empresa, por ejemplo).
+
+# Inconsistencias
+Aparecen divergencias en la comparación de datos entre países. En el intercambio bilateral de Brasil, es común identificar discrepancias entre las cifras publicadas por cada socio.
+
+# Observaciones a lo largo del tiempo
+Es posible seguir las tendencias de la balanza comercial en los diferentes niveles de observación de las tablas, tanto mes a mes como por año. La agregación de los datos mensuales consolidados permite obtener los resultados anuales del comercio exterior.
+
+# Filas duplicadas
+Sin información por el momento.
+
+# Cruces de datos
+Los datos están anonimizados y no contienen información de CNPJ o CPF de los agentes de importación y exportación. Esto limita los cruces con otros conjuntos de datos, pero es posible usar las columnas ```id_pais```, ```sigla_uf``` e ```id_municipio```.
+
+# Descarga de los datos
+El total de las tablas ocupa cerca de 9 GB, por lo que se recomienda seguir buenas prácticas de procesamiento de datos en la medida de lo posible. Para evitar sobrecargar su computadora, recomendamos usar consultas en BigQuery para procesar los datos en la nube antes de descargarlos. Filtre por las columnas de partición (como ```ano```, ```mes```, ```sigla_uf``` y ```sigla_pais_iso3```) y seleccione solo las columnas relevantes.
+
+# Instrumento de recolección
+Las estadísticas de comercio exterior se elaboran a partir de datos de registros administrativos, alimentados mediante declaración por las partes involucradas en las operaciones de exportación e importación –empresas, agentes de aduana, instituciones financieras, transportistas, agentes de carga, personas físicas, etc.– en los sistemas oficiales [Siscomex](https://www.gov.br/siscomex/pt-br) y [Portal Único de Siscomex](https://portalunico.siscomex.gov.br/portal/), que gestionan el comercio exterior brasileño.
+
+# Cambios en la recolección
+- **Cambios en el sistema de recolección en 2018**
+	- A partir de 2018, hubo un cambio en la herramienta de ingreso de los datos de exportación, del NOVOEX al Portal Único. En el nuevo sistema, los casos de embarque anticipado sin factura pueden quedar sin registro de UF ("UF No Declarada"). Solo después de la emisión de la factura es posible corregir la información de UF, lo que hace que los valores nulos de este campo estén sobredimensionados en los meses más recientes. Consulte el Manual de Uso de Comex para más detalles.
+- **Cambio de metodología sobre la fecha de referencia de bienes importados y exportados en 2018** 
+	- A partir de 2018, la fecha de referencia de los datos de exportación pasó a ser la fecha en que la carga se considera completamente exportada (Fecha de CCE); de 1997 a 2017 era la fecha de Despacho Aduanero.
+
+# Actualizaciones
+Los datos de Comex se actualizan en los primeros días hábiles de cada mes. Aunque la secretaría competente publica boletines semanales, estos deben desestimarse cuando se publica la versión mensual consolidada. En Base de los Datos hay una pipeline programada para buscar y actualizar los datos diariamente. Si nota que los datos están desactualizados, comuníquese con nuestro equipo.
+
+# Datos identificados
+Los datos están anonimizados y no contienen información de CNPJ o CPF. Los registros administrativos y aduaneros que alimentan Comex Stat tienen una finalidad probatoria, fiscalizadora y de validez jurídica, bajo la responsabilidad de los órganos competentes.
+
+# Tratamientos realizados por BD
+En esta guía, los tratamientos se describen en un lenguaje más accesible. De manera complementaria, los [códigos de tratamiento](https://github.com/basedosdados/pipelines/tree/main/pipelines/datasets/br_me_comex_stat) y las [modificaciones realizadas en BigQuery](https://github.com/basedosdados/pipelines/tree/main/models/br_me_comex_stat) están disponibles en el repositorio de GitHub para su consulta.
+Los tratamientos realizados fueron: 
+* Corrección de códigos municipales específicos en estados con inconsistencias históricas (SP, MS, GO y DF), garantizando la alineación con el estándar del IBGE (7 dígitos);
+* Estandarización de los nombres de las columnas según el [Manual de Estilo de BD](https://basedosdados.org/docs/style_data);
+* Conversión de la columna ```mes``` al tipo entero (int64)
+* Sustitución de códigos inválidos (como "ND" o "9300000") por valores nulos en las columnas ```sigla_uf``` e ```id_municipio```;
+* Estandarización de códigos en columnas específicas:
+	* ```id_ncm``` (8 dígitos, formato string);
+	- ```id_sh4``` (4 dígitos, formato string);
+	- ```id_pais``` convertido al código ISO3 (```sigla_pais_iso3```) en las tablas donde esto aplica
+
+# Materiales de apoyo
+- [Manual de utilización de los datos estadísticos del comercio exterior brasileño](https://balanca.economia.gov.br/balanca/manual/Manual.pdf).
+- [Manuales y Notas Metodológicas](https://www.gov.br/mdic/pt-br/assuntos/comercio-exterior/estatisticas/manuais-e-notas-metodologicas) en el sitio del Ministerio de Desarrollo, Industria, Comercio y Servicios.
+- [Totales para validación](https://www.gov.br/mdic/pt-br/assuntos/comercio-exterior/estatisticas/base-de-dados-bruta) de los datos en Estadísticas de Comercio Exterior en Datos Abiertos
+- Análisis realizados por BD con Comex Stat ([soja](https://github.com/basedosdados/analises/blob/main/redes_sociais/br_comex_stat_municipio_exportacao_20230626.ipynb) y [café](https://github.com/basedosdados/analises/blob/main/redes_sociais/br_me_comex_stat_20251006.sql)).
+
+

--- a/next/content/userGuide/es/mundo-transfermarkt-competicoes.md
+++ b/next/content/userGuide/es/mundo-transfermarkt-competicoes.md
@@ -1,0 +1,67 @@
+---
+title: Guía de uso de datos de Campeonatos de Fútbol
+description: >-
+  Guía de uso de datos de Campeonatos de Fútbol. Este material contiene información sobre las variables más importantes, preguntas frecuentes y ejemplos de uso del conjunto.
+date:
+  created: "2024-11-28T18:18:06.419Z"
+thumbnail: 
+categories: [guia-de-uso]
+authors:
+  - name: Laura Amaral
+    role: Texto
+---
+
+# Introducción
+
+> Esta guía contiene información detallada sobre los datos. Para dudas sobre el acceso o uso de la plataforma, consulte nuestra [página de Preguntas Frecuentes](/faq).
+
+Este conjunto cuenta con dos tablas de microdatos:  
+- **Brasileirão Série A:** Cada fila representa un partido. Las columnas incluyen información sobre las características del partido, los resultados y las estadísticas del juego 
+- **Copa do Brasil:** Cada fila representa un partido. Las columnas incluyen información sobre las características del partido, los resultados y las estadísticas del juego 
+
+# Consideraciones para los análisis
+## Fuentes y compilación de los datos
+Las tablas presentan información compilada por Transfermarkt. Para entender cómo se elaboraron y estructuraron estas estadísticas, es necesario revisar los métodos de compilación.
+
+# Limitaciones
+* Las tablas contienen la información disponible en el sitio de Transfermarkt que nuestro equipo seleccionó para incluir. Si considera que alguna información que sería muy útil para su análisis no está disponible en esta base, pero sí está disponible en el sitio de Transfermarkt, ¡por favor contáctenos para que lo sepamos! 
+
+# Inconsistencias
+Aún no se han reportado inconsistencias
+
+# Observaciones a lo largo del tiempo
+Cada fila representa un partido, por lo que es posible seguir la evolución de un equipo a lo largo de una temporada, o incluso a lo largo de los años.
+
+# Filas duplicadas
+Aún no se han encontrado indicios de filas duplicadas en las tablas de este conjunto
+
+# Cruces
+Las tablas copa_brasil y brasileirao_serie_a pueden cruzarse a través de las columnas time_mandante y time_visitante. Además, estas tablas no tienen muchos cruces con otras tablas del datalake. Es posible utilizar la información temporal (año y fecha) para algunos casos.
+
+# Descarga de los datos
+Estas tablas son pequeñas, por lo que es posible descargar los datos directamente desde la plataforma
+
+
+# Institución responsable
+Transfermarkt.com
+
+# Instrumento de recolección
+Transfermarkt obtiene información detallada sobre los partidos de fútbol mediante una combinación de fuentes:
+* Equipo de Datos: Un equipo dedicado de más de 50 entusiastas del fútbol de diversas partes del mundo realiza investigaciones detalladas y actualiza constantemente la información
+* Contribuciones de la Comunidad: Los usuarios registrados pueden proponer correcciones y actualizaciones.
+* Fuentes Oficiales y Socios: El sitio también utiliza datos de fuentes oficiales, como ligas, federaciones y clubes, además de socios especializados en estadísticas deportivas.
+
+# Cambios en la recolección
+Los datos recolectados cambiaron bastante a lo largo del tiempo. Entre 2003 y 2006, los datos registrados eran básicos, como fechas, estadios, jornadas y resultados. La información sobre árbitros, público, técnicos y estadísticas del juego estaba completamente ausente.
+A partir de 2007, el registro de datos comenzó a expandirse, con la inclusión de los árbitros y, gradualmente, de los técnicos y las posiciones de los equipos. Los datos de público comenzaron a aparecer de manera consistente en 2012, mientras que las estadísticas financieras y demográficas, como los valores de los equipos y las edades promedio, pasaron a ser más detalladas entre 2013 y 2016.
+A partir de 2017, la base alcanzó un alto nivel de completitud, cubriendo estadísticas detalladas, como tiros, tiros de esquina, atajadas y fueras de juego. Sin embargo, en 2024 se observó una leve disminución en algunas columnas, como público máximo y estadísticas del juego, aunque la base sigue siendo significativamente más completa que en los primeros años. 
+
+# Actualizaciones
+Los datos se actualizan en la fuente oficial de manera constante; como no todos los datos están automatizados, no existe un patrón fijo. En BD actualizamos los datos de la última jornada semanalmente
+
+# Tratamientos realizados por BD:
+BD realiza un proceso de web scraping en el sitio de Transfermarkt. Nuestro estándar es no realizar modificaciones en los datos recolectados. Si desea evaluar cómo se realiza nuestro web scraping, el código está aquí: https://github.com/basedosdados/pipelines/blob/main/pipelines/datasets/mundo_transfermarkt_competicoes/utils.py#L371 . El código completo del pipeline (con otras etapas además de la extracción, como la verificación de actualizaciones, la carga de los datos en BigQuery, la materialización vía dbt y la ejecución de pruebas de calidad de los datos) está aquí: https://github.com/basedosdados/pipelines/blob/main/pipelines/datasets/mundo_transfermarkt_competicoes/flows.py
+
+# Materiales de apoyo
+* [FAQ de Transfermarkt](https://www.transfermarkt.com/intern/faq) 
+* [Proceso de ingreso de datos de Transfermarkt](https://www.transfermarkt.us/intern/datenpflegeGuide)

--- a/next/content/userGuide/es/user_guide_model.md
+++ b/next/content/userGuide/es/user_guide_model.md
@@ -1,0 +1,122 @@
+---
+title: Plantilla de Guía de Uso
+description: >-
+  Esta plantilla sirve como referencia para las guías de uso. En ella deben describirse los estándares definidos con el equipo. Si te parece interesante incluir algún estándar, puedes agregarlo aquí y lo evaluaremos.  
+date:
+  created: "2024-11-28T18:18:06.419Z"
+thumbnail: 
+categories: [guia-de-uso]
+authors:
+  - name: Laura Amaral
+    role: Texto
+---
+<!-- En esta plantilla dejamos los textos de la guía del CNPJ para que sirvan de ejemplo
+
+Estándares generales:
+- Utilizar siempre los términos "conjunto" y "tabla". Debe evitarse el uso aislado de las palabras "base" y "datos" para garantizar claridad sobre el elemento al que se hace referencia.  
+- Priorizar un lenguaje directo y conciso. Se recomienda utilizar ChatGPT para revisar el texto y hacerlo más objetivo.
+ -->
+
+
+# Introducción
+<!-- Toda guía comienza con este breve aviso para que los usuarios nuevos puedan orientarse.-->
+> Esta guía contiene información detallada sobre los datos. Para dudas sobre el acceso o el uso de la plataforma, consulta nuestra [página de Preguntas Frecuentes](/faq).
+
+<!-- En la introducción describimos las tablas que componen el conjunto.
+Esta descripción debe incluir necesariamente: 
+  - Si la tabla contiene microdatos o datos agregados 
+  - Una explicación de lo que representa cada fila de la tabla
+  - Un resumen de las columnas
+Si hay alguna información clave para entender el conjunto, también puede agregarse aquí. Pero cuida no agregar demasiada información: el resto de la guía sirve para describir mejor el conjunto.  
+   -->
+Este conjunto posee cuatro tablas de microdatos:  
+- **Empresas:** Cada fila representa una empresa y sus atributos. Las columnas describen sus atributos, como la naturaleza jurídica y el tipo de estructura societaria.  
+- **Socios:** Cada fila representa un socio de una empresa. Las columnas describen algunas características del socio y califican su relación con la empresa.
+- **Establecimientos:** Cada fila representa un establecimiento de operación de una empresa. Las columnas detallan información sobre ubicación, actividad económica e información de contacto.
+- **Simples:** Cada fila representa una empresa e indica si la empresa está en el Simples Nacional o el MEI.  
+
+La tabla que relaciona a todas ellas es la tabla Empresas. Una empresa puede tener varios socios, varios establecimientos y puede estar clasificada como Simples Nacional o MEI. 
+
+Las tablas Empresas, Socios y Establecimientos se publican en formato de fotografías. Para cada fecha, se tiene un retrato del Registro Nacional de Personas Jurídicas (CNPJ) y sus atributos.
+
+# Consideraciones para los análisis
+<!-- Aquí incluimos, en distintos apartados, diversas consideraciones para los análisis; esta es la categoría más abierta de la guía. Intentamos incluir las preguntas frecuentes, consejos de uso y confusiones comunes -->
+## Diferencia entre establecimientos y empresas
+Una empresa puede tener varios establecimientos. La columna `cnpj_basico` se refiere a la empresa, y la columna `cnpj` se refiere al establecimiento. Por lo tanto, el `cnpj_basico` de la empresa se repite en proporción al número de establecimientos en la tabla Establecimientos. Parte de la información de la tabla Empresas, como la naturaleza jurídica, puede asignarse a los establecimientos. Para ello, es necesario cruzar los datos de la tabla de empresas con los de sus establecimientos.
+
+## Filtrado de CNPJ activos
+Para filtrar solo los CNPJ activos, usa la columna `situacao_cadastral`.
+
+# Limitaciones
+<!-- A diferencia del apartado de consideraciones, este espacio es específicamente para las limitaciones que impone el conjunto de datos disponible; puede ser una limitación metodológica o una limitación impuesta por la cobertura temporal -->
+Los datos están disponibles solo a partir del 23-11-2021. No es posible acceder a los registros anteriores a esa fecha. Sin embargo, la base es acumulativa y no excluye registros. Solo actualiza la situación registral y los atributos de los CNPJ. Así, aunque no se puedan seguir los cambios anteriores al 23-11-2021, es posible consultar todos los CNPJ que alguna vez se abrieron en Brasil.
+
+# Inconsistencias
+<!-- Aquí incluimos información sobre las inconsistencias que ya hemos encontrado en la base; es útil incluir la explicación del origen de las inconsistencias-->
+Todavía no tenemos inconsistencias reportadas
+
+# Observaciones a lo largo del tiempo
+<!-- El objetivo de este apartado es explicar cómo seguir las observaciones a lo largo del tiempo y aportar algún consejo o información adicional sobre el tema -->
+Los datos se publican en formato de fotografías. Para cada fecha, se tiene un retrato de los CNPJ y sus atributos. Con excepción de la tabla Simples, la columna de fecha indica la fecha en que se extrajeron los datos. Los datos anteriores al 23-11-2021 se presentan con el estado correspondiente a esa fecha.
+
+# Filas duplicadas
+<!-- Apartado desarrollado específicamente para indicar si existen filas duplicadas; es útil incluir información sobre por qué ocurre esto y cómo solucionarlo-->
+Hay algunas decenas de filas duplicadas en el conjunto de datos. Estas duplicaciones provienen de la fuente original y representan menos del 0,1% de los datos, lo que generalmente no afecta los análisis.
+
+# Cruces
+<!-- Aquí presentamos particularidades del cruce de las tablas del conjunto; puede incluir cruces internos, dentro del propio conjunto, y cruces externos, con bases fuera de este conjunto -->
+Las tablas pueden cruzarse usando las columnas `cnpj_básico` y `data`. Es necesario entender las claves únicas de cada tabla para evitar duplicaciones.
+
+# Descarga de los datos
+<!-- Aquí destacamos la posibilidad o no de descarga directa de los datos. Comenzamos el apartado señalando el tamaño de las tablas y luego indicando cómo evitar sobrecargas. El objetivo es advertir a quienes no conocen conjuntos muy grandes que a veces no es posible hacer una descarga directa y es necesario aplicar filtros  -->
+Los microdatos suman más de 300 GB. Para evitar sobrecargar tu computadora, recomendamos usar queries en BigQuery para procesar los datos en la nube antes de descargarlos. Filtra por las columnas de partición (como año y UF) y selecciona solo las columnas relevantes.
+
+# Instrumento de recolección
+<!-- Este apartado describe cómo es el instrumento de recolección de los datos. Esto importa porque aporta más contexto para los datos y permite identificar posibles sesgos y limitaciones que no listamos antes -->
+El instrumento de recolección actual es el Documento Básico de Entrada (DBE), utilizado por la Receita Federal para registrar, modificar o dar de baja el registro de una persona jurídica.
+  
+# Cambios en la recolección
+<!-- El objetivo aquí es advertir a los usuarios si hubo algún cambio en los datos a lo largo de la serie temporal; esto es muy importante para que los análisis se realicen con calidad -->
+No hubo cambios en la metodología de recolección desde 2021 hasta el momento de elaboración de esta guía (08-01-2025).
+
+# Actualizaciones
+<!-- Aquí explicamos cómo se realiza la actualización en la fuente original, si ocurre en alguna época específica del año o del mes y si existe algún calendario. Este apartado es importante para que los usuarios sepan cuándo esperar que se actualicen los datos-->
+Los datos se actualizan después del día 15 de cada mes. Nuestra plataforma realiza verificaciones automáticas diarias para detectar actualizaciones.
+
+# Datos identificados
+<!-- El objetivo de este apartado es orientar a los usuarios sobre si existen datos identificados o si los datos están anonimizados. Muchos usuarios están interesados en datos desanonimizados, pero pocas bases cuentan con esa información -->
+Los datos de CPF de los socios se ponen a disposición de forma anonimizada. No es posible obtener la base identificada. 
+
+# Tratamientos realizados por BD:
+<!-- Aquí describimos los tratamientos de manera más directa, para que incluso quien no sabe programar entienda cuáles fueron los tratamientos realizados. Aun así, es necesario dejar los enlaces para quienes quieran verificar el proceso. Si es necesario, los tratamientos pueden separarse en tablas-->
+En esta guía, los tratamientos se describen en un lenguaje más accesible. De manera complementaria, los [códigos de tratamiento](https://github.com/basedosdados/pipelines/blob/main/pipelines/datasets/br_me_cnpj/tasks.py#L50C1-L50C74) y las [modificaciones realizadas en BigQuery](https://github.com/basedosdados/queries-basedosdados/tree/main/models/br_me_cnpj) están disponibles en el repositorio de GitHub para consulta.
+
+## Tabla Empresas
+- Sustitución de ',' por '.' en la columna `capital_social`
+- Relleno con ceros (0) a la izquierda hasta una longitud máxima de 8 dígitos en la columna `cnpj_basico`
+- Relleno con ceros (0) a la izquierda hasta una longitud máxima de 4 dígitos en la columna `natureza_juridica`
+
+## Tabla Socios
+- Adecuación de la columna `data_entrada_sociedade` al estándar año-mes-día (%Y-%m-%d)
+- Relleno con ceros (0) a la izquierda hasta una longitud máxima de 8 dígitos en la columna `cnpj_basico`
+- Sustitución del valor que identifica valores nulos de CPF de "***000000***" por ""
+
+## Tabla Establecimientos
+- Relleno con ceros (0) a la izquierda hasta una longitud máxima de 8 dígitos en la columna `cnpj_basico`
+- Relleno con ceros (0) a la izquierda hasta una longitud máxima de 4 dígitos en la columna `cnpj_ordem`
+- Relleno con ceros (0) a la izquierda hasta una longitud máxima de 2 dígitos en la columna `cnpj_dv`
+- Creación de la columna `cnp` mediante la unión de los valores de las columnas `cnpj_basico`, `cnpj_ordem` y `cnpj_dv`
+- Creación de la columna `id_municipio` de 7 dígitos del IBGE a partir de la columna `id_municipio_rf` (ID de municipio de la Receita Federal)
+- Adecuación de las columnas `data_situacao_cadastral`, `data_situacao_especial` y `data_inicio_atividade` al estándar año-mes-día (%Y-%m-%d)
+
+## Tabla Simples
+- Sustitución de los valores N por 0 y S por 1 en la columna `opcao_simples`
+- Sustitución de los valores N por 0 y S por 1 en la columna `opcao_mei`
+- Relleno con ceros (0) a la izquierda hasta una longitud máxima de 8 dígitos en la columna `cnpj_basico`
+- Adecuación de las columnas `data_opcao_simples`, `data_exclusao_simples`, `data_opcao_mei` y `data_exclusao_mei` al estándar año-mes-día (%Y-%m-%d)
+
+
+# Materiales de apoyo
+<!-- Por último incluimos materiales de apoyo, para que el usuario pueda consultar información directamente desde las fuentes originales o complementar la comprensión de la base -->
+* [Evaluación de confidencialidad de la información contenida en los Datos Abiertos del Registro Nacional de Personas Jurídicas (CNPJ)](https://www.gov.br/receitafederal/dados/nota-cocad-rfb-86-2024.pdf/)
+* [Tutorial de BD sobre cómo acceder y analizar datos de CNPJ usando SQL, Python o R](https://www.youtube.com/watch?v=WQruVEizTlc&t=1782s)

--- a/next/content/userGuide/es/user_guide_model.md
+++ b/next/content/userGuide/es/user_guide_model.md
@@ -89,7 +89,7 @@ Los datos de CPF de los socios se ponen a disposición de forma anonimizada. No 
 
 # Tratamientos realizados por BD:
 <!-- Aquí describimos los tratamientos de manera más directa, para que incluso quien no sabe programar entienda cuáles fueron los tratamientos realizados. Aun así, es necesario dejar los enlaces para quienes quieran verificar el proceso. Si es necesario, los tratamientos pueden separarse en tablas-->
-En esta guía, los tratamientos se describen en un lenguaje más accesible. De manera complementaria, los [códigos de tratamiento](https://github.com/basedosdados/pipelines/blob/main/pipelines/datasets/br_me_cnpj/tasks.py#L50C1-L50C74) y las [modificaciones realizadas en BigQuery](https://github.com/basedosdados/queries-basedosdados/tree/main/models/br_me_cnpj) están disponibles en el repositorio de GitHub para consulta.
+En esta guía, los tratamientos se describen en un lenguaje más accesible. De manera complementaria, los [códigos de tratamiento](https://github.com/basedosdados/pipelines/blob/main/pipelines/datasets/br_me_cnpj/tasks.py#L50C1-L50C74) y las [modificaciones realizadas en BigQuery](https://github.com/basedosdados/pipelines/tree/main/models/br_me_cnpj) están disponibles en el repositorio de GitHub para consulta.
 
 ## Tabla Empresas
 - Sustitución de ',' por '.' en la columna `capital_social`

--- a/next/content/userGuide/pt/br-inmet-bdmep.md
+++ b/next/content/userGuide/pt/br-inmet-bdmep.md
@@ -62,7 +62,7 @@ Essas tabelas são consistentes desde 2000, não temos registro de alterações 
 A atualização dos dados na fonte original é a cada hora. Na Base dos Dados atualizamos essas informações mensalmente
 
 # Tratamentos feitos pela BD:
-Neste guia, os tratamentos são descritos em uma linguagem mais acessível. De maneira complementar, [os códigos de extração e tratamento](https://github.com/basedosdados/pipelines/blob/main/pipelines/datasets/br_inmet_bdmep/flows.py) e as [modificações feitas no BigQuery](https://github.com/basedosdados/queries-basedosdados/blob/main/models/br_inmet_bdmep/br_inmet_bdmep__microdados.sql) estão disponíveis no repositório do GitHub para consulta.
+Neste guia, os tratamentos são descritos em uma linguagem mais acessível. De maneira complementar, [os códigos de extração e tratamento](https://github.com/basedosdados/pipelines/blob/main/pipelines/datasets/br_inmet_bdmep/flows.py) e as [modificações feitas no BigQuery](https://github.com/basedosdados/pipelines/blob/main/models/br_inmet_bdmep/br_inmet_bdmep__microdados.sql) estão disponíveis no repositório do GitHub para consulta.
 Os tratamentos realizados na tabela de microdados foram:
 * Renomeação das colunas para adequação ao manual de estilo da BD.
 * Substituição de códigos inválidos (“-9999”) por valores nulos.

--- a/next/content/userGuide/pt/br-me-caged.md
+++ b/next/content/userGuide/pt/br-me-caged.md
@@ -121,7 +121,7 @@ Os dados são anonimizados, não contendo CNPJs nem CPFs. Para obter dados ident
 
 # Tratamentos feitos pela BD:
 
-Neste guia, os tratamentos são descritos em uma linguagem mais acessível. De maneira complementar, [os códigos de extração e tratamento](https://github.com/basedosdados/queries-basedosdados-dev/blob/main/models/br_me_caged/code/crawler_caged.py) e as [modificações feitas no BigQuery](https://github.com/basedosdados/queries-basedosdados/tree/main/models/br_me_caged) estão disponíveis no repositório do GitHub para consulta.
+Neste guia, os tratamentos são descritos em uma linguagem mais acessível. De maneira complementar, [os códigos de extração e tratamento](https://github.com/basedosdados/pipelines/blob/main/models/br_me_caged/code/crawler_caged.py) e as [modificações feitas no BigQuery](https://github.com/basedosdados/pipelines/tree/main/models/br_me_caged) estão disponíveis no repositório do GitHub para consulta.
 Os tratamentos realizados foram:
 
 - Renomeação das colunas para adequação ao manual de estilo;

--- a/next/content/userGuide/pt/br-me-cnpj.md
+++ b/next/content/userGuide/pt/br-me-cnpj.md
@@ -68,7 +68,7 @@ Os dados são atualizados após o dia 15 de cada mês. Nossa plataforma realiza 
 Os dados de CPF dos sócios são disponibilizados de maneira anonimizada. Não é possível obter a base identificada. 
 
 # Tratamentos feitos pela BD:
-Neste guia, os tratamentos são descritos em uma linguagem mais acessível. De maneira complementar, os [códigos de tratamento](https://github.com/basedosdados/pipelines/blob/main/pipelines/datasets/br_me_cnpj/tasks.py#L50C1-L50C74) e as [modificações feitas no BigQuery](https://github.com/basedosdados/queries-basedosdados/tree/main/models/br_me_cnpj) estão disponíveis no repositório do GitHub para consulta.
+Neste guia, os tratamentos são descritos em uma linguagem mais acessível. De maneira complementar, os [códigos de tratamento](https://github.com/basedosdados/pipelines/blob/main/pipelines/datasets/br_me_cnpj/tasks.py#L50C1-L50C74) e as [modificações feitas no BigQuery](https://github.com/basedosdados/pipelines/tree/main/models/br_me_cnpj) estão disponíveis no repositório do GitHub para consulta.
 
 ## Tabela Empresas
 - Troca de ',' por '.' na coluna `capital_social`

--- a/next/content/userGuide/pt/br-me-rais.md
+++ b/next/content/userGuide/pt/br-me-rais.md
@@ -70,7 +70,7 @@ Os dados têm atualização parcial e completa. A atualização parcial ocorre e
 Os dados são anonimizados, não contendo CNPJs nem CPFs. Para obter dados identificados da RAIS, é necessário solicitar ao MTE. O processo pode ser demorado e não há garantia de aprovação.
 
 # Tratamentos feitos pela BD
-Neste guia, os tratamentos são descritos em uma linguagem mais acessível. De maneira complementar, os [códigos de tratamento](https://github.com/basedosdados/queries-basedosdados/tree/main/models/br_me_rais/code) e as [modificações feitas no BigQuery](https://github.com/basedosdados/queries-basedosdados/tree/main/models/br_me_rais) estão disponíveis no repositório do GitHub para consulta. 
+Neste guia, os tratamentos são descritos em uma linguagem mais acessível. De maneira complementar, os [códigos de tratamento](https://github.com/basedosdados/pipelines/tree/main/models/br_me_rais/code) e as [modificações feitas no BigQuery](https://github.com/basedosdados/pipelines/tree/main/models/br_me_rais) estão disponíveis no repositório do GitHub para consulta. 
 Os tratamentos realizados foram: 
 * Adequação das colunas que identificam municípios ao formato ID Município IBGE (7 dígitos);
 * Adequação das colunas que identificam Unidades Federativas ao padrão de sigla UF;

--- a/next/content/userGuide/pt/br-tse-eleicoes.md
+++ b/next/content/userGuide/pt/br-tse-eleicoes.md
@@ -129,5 +129,5 @@ Os tratamentos realizados foram:
 * [Notícia do TSE sobre as eleições suplementares](https://www.tse.jus.br/comunicacao/noticias/2025/Fevereiro/voce-sabe-o-que-e-uma-eleicao-suplementar)
 
 [code-pipeline]: https://github.com/basedosdados/pipelines/tree/main/pipelines/utils/crawler_tse_eleicoes
-[code-notebook]: https://github.com/basedosdados/queries-basedosdados/blob/main/models/br_tse_eleicoes/code/%5Bdbt%5Dbr_tse_eleicoes.ipynb
-[queries-dir]: https://github.com/basedosdados/queries-basedosdados/tree/main/models/br_tse_eleicoes
+[code-notebook]: https://github.com/basedosdados/pipelines/blob/main/models/br_tse_eleicoes/code/%5Bdbt%5Dbr_tse_eleicoes.ipynb
+[queries-dir]: https://github.com/basedosdados/pipelines/tree/main/models/br_tse_eleicoes

--- a/next/content/userGuide/pt/user_guide_model.md
+++ b/next/content/userGuide/pt/user_guide_model.md
@@ -89,7 +89,7 @@ Os dados de CPF dos sócios são disponibilizados de maneira anonimizada. Não �
 
 # Tratamentos feitos pela BD:
 <!-- Aqui descrevemos os tratamentos de maneira mais direta, para que mesmo quem não sabe programação saiba quais foram os tratamentos feitos. Ainda é necessário deixar os links para quem queira fazer a verificação do processo . Se for necessário pode separar os tratamentos em tabelas-->
-Neste guia, os tratamentos são descritos em uma linguagem mais acessível. De maneira complementar, os [códigos de tratamento](https://github.com/basedosdados/pipelines/blob/main/pipelines/datasets/br_me_cnpj/tasks.py#L50C1-L50C74) e as [modificações feitas no BigQuery](https://github.com/basedosdados/queries-basedosdados/tree/main/models/br_me_cnpj) estão disponíveis no repositório do GitHub para consulta.
+Neste guia, os tratamentos são descritos em uma linguagem mais acessível. De maneira complementar, os [códigos de tratamento](https://github.com/basedosdados/pipelines/blob/main/pipelines/datasets/br_me_cnpj/tasks.py#L50C1-L50C74) e as [modificações feitas no BigQuery](https://github.com/basedosdados/pipelines/tree/main/models/br_me_cnpj) estão disponíveis no repositório do GitHub para consulta.
 
 ## Tabela Empresas
 - Troca de ',' por '.' na coluna `capital_social`

--- a/next/hooks/useChatbot.js
+++ b/next/hooks/useChatbot.js
@@ -395,7 +395,9 @@ export default function useChatbot(initialThreadId = null, options = {}) {
 
         const response = await axios.post(
           '/api/chatbot/threads',
-          { title }
+          // Send the site's active locale (pt/en/es, derived from the domain) so the
+          // chatbot backend persists the thread's language and answers accordingly.
+          { title, language: router.locale || 'pt' }
         )
 
         const newThreadId = response.data.id
@@ -413,7 +415,7 @@ export default function useChatbot(initialThreadId = null, options = {}) {
         throw err
       }
     },
-    [getAccessToken, handleAuthError, refetchThreads, onThreadCreated]
+    [getAccessToken, handleAuthError, refetchThreads, onThreadCreated, router]
   )
 
   const sendFeedback = useCallback(

--- a/next/pages/_app.js
+++ b/next/pages/_app.js
@@ -132,6 +132,25 @@ function MyApp({ Component, pageProps }) {
         }
         {/* <!-- End Google Tag Manager --> */}
         {/* FIM DA TAG DEVELOPMENT */}
+
+        {/* Meta Pixel Code */}
+        {local === "https://basedosdados.org" && (
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `!function(f,b,e,v,n,t,s)
+              {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+              n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+              if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+              n.queue=[];t=b.createElement(e);t.async=!0;
+              t.src=v;s=b.getElementsByTagName(e)[0];
+              s.parentNode.insertBefore(t,s)}(window, document,'script',
+              'https://connect.facebook.net/en_US/fbevents.js');
+              fbq('init', '773515071399019');
+              fbq('track', 'PageView');`,
+            }}
+          ></script>
+        )}
+        {/* End Meta Pixel Code */}
       </Head>
 
       <ChakraProvider>
@@ -165,6 +184,20 @@ function MyApp({ Component, pageProps }) {
       }
       {/* <!-- End Google Tag Manager (noscript) --> */}
       {/* FIM DA TAG DEVELOPMENT */}
+
+      {/* Meta Pixel Code (noscript) */}
+      {local === "https://basedosdados.org" && (
+        <noscript>
+          <img
+            height="1"
+            width="1"
+            style={{ display: "none" }}
+            src="https://www.facebook.com/tr?id=773515071399019&ev=PageView&noscript=1"
+            alt=""
+          />
+        </noscript>
+      )}
+      {/* End Meta Pixel Code (noscript) */}
 
     </QueryClientProvider >
   );

--- a/next/pages/about-us.js
+++ b/next/pages/about-us.js
@@ -165,6 +165,27 @@ function getTeamScore(slug) {
   }
 }
 
+// A career is "active" while it has no end date. A person is shown only if
+// they hold at least one active role, and only their active roles are listed.
+function isActiveCareer(careerNode) {
+  return !careerNode.endAt
+}
+
+function hasActiveRole(node) {
+  const careers = node?.careers?.edges || []
+  return careers.some((edge) => edge.node.role && isActiveCareer(edge.node))
+}
+
+// True when the person holds an active (not ended) career in the given team.
+// Used by the team filter so a person whose only tie to a team is an ended
+// role is not listed under that team.
+function hasActiveRoleInTeam(node, teamSlug) {
+  const careers = node?.careers?.edges || []
+  return careers.some(
+    (edge) => isActiveCareer(edge.node) && edge.node.team?.slug === teamSlug
+  )
+}
+
 const TeamBox = ({
   index,
   name,
@@ -183,6 +204,7 @@ const TeamBox = ({
   const role = () => {
     const roles = []
     careers.map((elm) => {
+      if (!isActiveCareer(elm.node)) return
       const roleData = elm.node.role
       if (!roleData) return
       const roleName = roleData[`name${capitalize(locale)}`]
@@ -365,13 +387,13 @@ export default function AboutUs() {
     const sortPeopleArray = array
 
     function compareByRole(a, b) {
-      const rolesA = a.node.careers.edges.map(edge => {
+      const rolesA = a.node.careers.edges.filter(edge => isActiveCareer(edge.node)).map(edge => {
         const roleData = edge.node.role
         if (!roleData) return ''
         return roleData.slug || ''
       }).filter(Boolean)
 
-      const rolesB = b.node.careers.edges.map(edge => {
+      const rolesB = b.node.careers.edges.filter(edge => isActiveCareer(edge.node)).map(edge => {
         const roleData = edge.node.role
         if (!roleData) return ''
         return roleData.slug || ''
@@ -406,7 +428,9 @@ export default function AboutUs() {
       })
     }
 
-    return removeDuplicates(data).filter(obj => obj.node.firstName !== "API User" && obj.node.firstName !== "Staging")
+    return removeDuplicates(data)
+      .filter(obj => obj.node.firstName !== "API User" && obj.node.firstName !== "Staging")
+      .filter(obj => hasActiveRole(obj.node))
   }
 
   const keyIcon = (url) => {
@@ -440,7 +464,8 @@ export default function AboutUs() {
         return setPeople(allPeople)
       }
       setIsLoading(true)
-      setPeople(sortPeople(result))
+      const activeInTeam = result.filter((obj) => hasActiveRoleInTeam(obj.node, elm))
+      setPeople(sortPeople(activeInTeam))
     }
   }
 

--- a/next/pages/about-us.js
+++ b/next/pages/about-us.js
@@ -12,6 +12,7 @@ import {
 } from "@chakra-ui/react";
 import Head from "next/head";
 import { useState, useEffect } from "react";
+import { getDiscordUrl } from "../utils";
 import { useDisclosure } from "@chakra-ui/hooks";
 import { MainPageTemplate } from "../components/templates/main";
 import { isMobileMod } from "../hooks/useCheckMobile.hook";
@@ -471,7 +472,7 @@ export default function AboutUs() {
         >
           <XIcon alt="twitter basedosdados" {...keyIcon("https://x.com/basedosdados")} borderTop="1px solid #0000001a"/>
           <BlueskyIcon alt="bluesky basedosdados" {...keyIcon("https://bsky.app/profile/basedosdados.bsky.social")}/>
-          <DiscordIcon alt="comunidade do discord basedosdados" {...keyIcon("https://discord.gg/huKWpsVYx4")}/>
+          <DiscordIcon alt="comunidade do discord basedosdados" {...keyIcon(getDiscordUrl(locale))}/>
           <GithubIcon alt="repositório github" {...keyIcon("https://github.com/basedosdados")}/>
           <LinkedinIcon alt="linkedin basedosdados" {...keyIcon("https://www.linkedin.com/company/base-dos-dados/mycompany/")}/>
         </Stack>

--- a/next/pages/api/datasets/getDataset.js
+++ b/next/pages/api/datasets/getDataset.js
@@ -27,6 +27,7 @@ export default async function getDataset(id, locale = 'pt') {
                 description
                 description${capitalize(locale)}
                 temporalCoverage
+                spatialCoverageName${capitalize(locale)}
                 status {
                   slug
                 }

--- a/next/pages/api/stripe/getPlans.js
+++ b/next/pages/api/stripe/getPlans.js
@@ -19,7 +19,6 @@ async function getPlans() {
                 productName
                 productSlug
                 interval
-                region
                 isActive
               }
             }

--- a/next/pages/api/stripe/getPlans.js
+++ b/next/pages/api/stripe/getPlans.js
@@ -14,6 +14,7 @@ async function getPlans() {
             edges {
               node {
                 _id
+                stripePriceId
                 amount
                 productName
                 productSlug

--- a/next/pages/api/stripe/getPlans.js
+++ b/next/pages/api/stripe/getPlans.js
@@ -19,6 +19,7 @@ async function getPlans() {
                 productName
                 productSlug
                 interval
+                region
                 isActive
               }
             }

--- a/next/pages/api/tables/getTableColumns.js
+++ b/next/pages/api/tables/getTableColumns.js
@@ -1,20 +1,48 @@
 import axios from "axios";
 import { validate as isUuid } from "uuid";
 
+const GRAPHQL_URL = `${process.env.NEXT_PUBLIC_API_URL}/api/v1/graphql`;
+
 async function getTableColumns(id) {
   const API_URL = `${process.env.NEXT_PUBLIC_API_URL}/tables/${id}/columns/`;
 
-  try {
-    const res = await axios({
-      url: API_URL,
-      method: "GET",
-    });
-    const data = res?.data;
-    return data;
-  } catch (error) {
-    console.error(error);
-    return "err";
-  }
+  const res = await axios({
+    url: API_URL,
+    method: "GET",
+  });
+  return res?.data;
+}
+
+// The REST endpoint above only exposes the Portuguese `description`/`observations`.
+// Fetch the localized fields from GraphQL so the columns table can render English and
+// Spanish descriptions on data-basis.org / basedelosdatos.org (the frontend reads
+// `description${Locale}` with a fallback to `description`).
+async function getLocalizedColumns(id) {
+  const res = await axios({
+    url: GRAPHQL_URL,
+    method: "POST",
+    data: {
+      query: `
+      query {
+        allColumn(table_Id: "${id}", first: 1000) {
+          edges {
+            node {
+              _id
+              name
+              descriptionPt
+              descriptionEn
+              descriptionEs
+              observationsPt
+              observationsEn
+              observationsEs
+            }
+          }
+        }
+      }
+      `,
+    },
+  });
+  return res?.data?.data?.allColumn?.edges?.map((edge) => edge.node) || [];
 }
 
 export default async function handler(req, res) {
@@ -24,9 +52,45 @@ export default async function handler(req, res) {
     return res.status(400).json({ error: "Invalid or missing ID", success: false });
   }
 
-  const result = await getTableColumns(id);
+  const [columnsResult, localizedResult] = await Promise.allSettled([
+    getTableColumns(id),
+    getLocalizedColumns(id),
+  ]);
 
-  if (result === "err") return res.status(500).json({ error: "err", success: false });
+  if (columnsResult.status !== "fulfilled" || !columnsResult.value) {
+    console.error(columnsResult.reason);
+    return res.status(500).json({ error: "err", success: false });
+  }
 
-  return res.status(200).json({ resource: result, success: true });
+  let resource = columnsResult.value;
+
+  // Enrich with localized descriptions/observations. If the GraphQL call fails, fall
+  // back to the REST payload (Portuguese only) rather than breaking the columns table.
+  if (localizedResult.status === "fulfilled" && Array.isArray(resource)) {
+    const localizedById = {};
+    const localizedByName = {};
+    localizedResult.value.forEach((node) => {
+      if (node?._id) localizedById[node._id] = node;
+      if (node?.name) localizedByName[node.name] = node;
+    });
+
+    resource = resource.map((column) => {
+      const localized = localizedById[column.id] || localizedByName[column.name];
+      if (!localized) return column;
+
+      return {
+        ...column,
+        descriptionPt: localized.descriptionPt ?? column.description,
+        descriptionEn: localized.descriptionEn,
+        descriptionEs: localized.descriptionEs,
+        observationsPt: localized.observationsPt ?? column.observations,
+        observationsEn: localized.observationsEn,
+        observationsEs: localized.observationsEs,
+      };
+    });
+  } else if (localizedResult.status === "rejected") {
+    console.error("Failed to fetch localized column fields:", localizedResult.reason);
+  }
+
+  return res.status(200).json({ resource, success: true });
 }

--- a/next/pages/chatbot.js
+++ b/next/pages/chatbot.js
@@ -279,15 +279,15 @@ function ChatbotContent() {
   return (
     <HStack width="100%" minHeight="100dvh" spacing={0} align="stretch">
       <Head>
-        <title>Chatbot - Basedosdados</title>
+        <title>{t("head.pageTitle")}</title>
         <meta
           property="og:title"
-          content="Chatbot - Basedosdados"
+          content={t("head.pageTitle")}
           key="ogtitle"
         />
         <meta
           property="og:description"
-          content="Chatbot - Basedosdados"
+          content={t("head.pageTitle")}
           key="ogdesc"
         />
       </Head>

--- a/next/pages/chatbot.js
+++ b/next/pages/chatbot.js
@@ -8,6 +8,8 @@ import {
 import { useState, useEffect, useRef, useCallback } from "react";
 import Head from "next/head";
 import { useRouter } from "next/router";
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import cookies from "js-cookie";
 import Sidebar from "../components/organisms/chatbot/Sidebar";
 import Search from "../components/organisms/chatbot/Search";
@@ -98,6 +100,7 @@ function ChatbotAccessGate({ children }) {
 
 function ChatbotContent() {
   const router = useRouter();
+  const { t } = useTranslation("chatbot");
   const { t: threadIdFromUrl } = router.query;
   const normalizedThreadId = Array.isArray(threadIdFromUrl)
     ? threadIdFromUrl[0]
@@ -225,7 +228,7 @@ function ChatbotContent() {
       <Box
         as="button"
         type="button"
-        aria-label="Abrir menu"
+        aria-label={t("ui.openMenu")}
         display="flex"
         alignItems="center"
         justifyContent="center"
@@ -245,7 +248,7 @@ function ChatbotContent() {
       <Box
         as="button"
         type="button"
-        aria-label="Nova conversa"
+        aria-label={t("ui.newChat")}
         display="flex"
         alignItems="center"
         justifyContent="center"
@@ -350,7 +353,7 @@ function ChatbotContent() {
                   lineHeight={{ base: "36px", md: "48px" }}
                   paddingX={{ base: "8px", md: 0 }}
                 >
-                  Olá,
+                  {t("ui.greetingPrefix")}
                   <Text
                     as="span"
                     textTransform="capitalize"
@@ -358,7 +361,7 @@ function ChatbotContent() {
                   >
                     {greetingFirstName
                       ? greetingFirstName
-                      : "Como posso ajudar você hoje?"}
+                      : t("ui.helpQuestion")}
                   </Text>
                 </Display>
                 <Box width="100%" flexShrink={0}>
@@ -401,6 +404,14 @@ function ChatbotContent() {
       </HStack>
     </HStack>
   );
+}
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ["common", "menu", "chatbot"])),
+    },
+  };
 }
 
 export default function Chatbot() {

--- a/next/pages/chatbot.js
+++ b/next/pages/chatbot.js
@@ -18,7 +18,7 @@ import OnboardingQuestions from "../components/organisms/chatbot/OnboardingQuest
 import Display from "../components/atoms/Text/Display";
 import SidebarIcon from "../public/img/icons/sidebarIcon";
 import CrossIcon from "../public/img/icons/crossIcon";
-import BDLogoImage from "../public/img/logos/bd_logo";
+import BrandLogo from "../components/organisms/chatbot/BrandLogo";
 import useChatbot from "../hooks/useChatbot";
 import { ChatbotProvider } from "../context/ChatbotContext";
 import { redirectToChatbotCheckout, clearClientSession } from "../utils";
@@ -243,7 +243,7 @@ function ChatbotContent() {
         <SidebarIcon width="20px" height="20px" />
       </Box>
 
-      <BDLogoImage widthImage="48px" heightImage="21px" />
+      <BrandLogo widthImage="48px" heightImage="21px" />
 
       <Box
         as="button"

--- a/next/pages/contact.js
+++ b/next/pages/contact.js
@@ -5,6 +5,7 @@ import {
 } from "@chakra-ui/react";
 import Head from "next/head";
 import { useEffect } from "react";
+import { getDiscordUrl } from "../utils";
 import { useTranslation } from 'next-i18next';
 import { useRouter } from 'next/router';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
@@ -126,7 +127,7 @@ export default function Contact({ pages }) {
               {t('questionsText')}
               <Link
                 display="inline"
-                href="https://discord.gg/huKWpsVYx4"
+                href={getDiscordUrl(locale)}
                 color="#0068C5"
                 _hover={{color: "#0057A4"}}
                 fontSize="16px"

--- a/next/pages/dataset/[dataset].js
+++ b/next/pages/dataset/[dataset].js
@@ -33,6 +33,7 @@ import {
   hasBDProSubscription,
   hasChatbotSubscription,
   trackNavigateToChatbotLp,
+  isBasedosdadosDomain,
 } from "../../utils";
 
 import { DataBaseIcon } from "../../public/img/icons/databaseIcon";
@@ -482,7 +483,7 @@ export default function DatasetPage ({ dataset, userGuide, hiddenDataset }) {
                 </BodyText>
               </GridItem>
 
-              {/* {locale !== 'pt' ?
+              {locale !== 'pt' &&
                 <GridItem colSpan={{ base: 5, lg: 3 }} marginBottom="8px">
                   <LabelText
                     typography="large"
@@ -501,9 +502,7 @@ export default function DatasetPage ({ dataset, userGuide, hiddenDataset }) {
                       : t('notProvided')}
                   </BodyText>
                 </GridItem>
-                :
-                <></>
-              } */}
+              }
             </Grid>
           </GridItem>
         </Grid>
@@ -538,7 +537,7 @@ export default function DatasetPage ({ dataset, userGuide, hiddenDataset }) {
             }}
           />
         )}
-        {!showSubscriptionBanner && abVariant && (
+        {isBasedosdadosDomain() && !showSubscriptionBanner && abVariant && (
           <ServiceHighlightABTest {...abTestContent[abVariant]} />
         )}
 

--- a/next/pages/dataset/[dataset].js
+++ b/next/pages/dataset/[dataset].js
@@ -474,7 +474,7 @@ export default function DatasetPage ({ dataset, userGuide, hiddenDataset }) {
                 </Link>
               </GridItem>
 
-              <GridItem colSpan={{ base: 5, lg: 2 }} marginBottom="8px">
+              <GridItem colSpan={{ base: 5, lg: 1 }} marginBottom="8px">
                 <LabelText typography="large" marginBottom="8px">
                   {t("temporalCoverage")}
                 </LabelText>
@@ -484,7 +484,7 @@ export default function DatasetPage ({ dataset, userGuide, hiddenDataset }) {
               </GridItem>
 
               {locale !== 'pt' &&
-                <GridItem colSpan={{ base: 5, lg: 3 }} marginBottom="8px">
+                <GridItem colSpan={{ base: 5, lg: 4 }} marginBottom="8px">
                   <LabelText
                     typography="large"
                     marginBottom="8px"

--- a/next/pages/docs/[slug].js
+++ b/next/pages/docs/[slug].js
@@ -152,7 +152,9 @@ function Toc({ allDocs, headings, slug, locale }) {
     'Docs',
     'APIs',
     translations[locale] || translations.default,
-    'Guia Central de Identidade Verbal'
+    // Verbal identity guide only exists in Portuguese; omit its (otherwise
+    // empty) header on other locales.
+    ...(locale === 'pt' ? ['Guia Central de Identidade Verbal'] : [])
   ]
 
   const groupedDocs = allDocs.reduce((acc, doc) => {

--- a/next/pages/faq.js
+++ b/next/pages/faq.js
@@ -86,7 +86,7 @@ export default function FAQ({ faqs }) {
     setQuestions(categorySelected ? filterByCategory(categorySelected) : allQuestions);
   }
 
-  const CategoryText = ({ category }) => {
+  const CategoryText = ({ category, label }) => {
     function handlerClick() {
       if(category === categorySelected) {
         setCategorySelected("")
@@ -109,7 +109,7 @@ export default function FAQ({ faqs }) {
         }}
         onClick={handlerClick}
       >
-        {category}
+        {label || category}
       </LabelText>
     )
   }
@@ -188,12 +188,12 @@ export default function FAQ({ faqs }) {
             position={{base: "relative", lg: "sticky"}}
             top={{base: "0", lg: "120px"}}
           >
-            <CategoryText category="Dados"/>
-            <CategoryText category="Planos Pagos"/>
-            <CategoryText category="BigQuery"/>
-            <CategoryText category="BD Lab"/>
-            <CategoryText category="BD Edu"/>
-            <CategoryText category="Institucional"/>
+            <CategoryText category="Dados" label={t('categories.data')}/>
+            <CategoryText category="Planos Pagos" label={t('categories.paidPlans')}/>
+            <CategoryText category="BigQuery" label={t('categories.bigQuery')}/>
+            <CategoryText category="BD Lab" label={t('categories.bdLab')}/>
+            <CategoryText category="BD Edu" label={t('categories.bdEdu')}/>
+            <CategoryText category="Institucional" label={t('categories.institutional')}/>
           </Box>
 
           <Stack

--- a/next/pages/prices.js
+++ b/next/pages/prices.js
@@ -599,7 +599,7 @@ export function SectionPrice({
                 plans?.[`bd_chatbot_${toggleAnual ? "year" : "month"}`]?.amount ??
                 (toggleAnual ? 326 : 30)
               }
-              region={plans?.[`bd_chatbot_${toggleAnual ? "year" : "month"}`]?.region}
+              region={plans?.[`bd_chatbot_${toggleAnual ? "year" : "month"}`] ? localeToRegion(locale) : "br"}
               anualPlan={toggleAnual}
               textResource={t("allFeaturesPlus", { plan: t("plans.free.title") })}
               resources={t("plans.chatbot.features", { returnObjects: true }).map(
@@ -638,7 +638,7 @@ export function SectionPrice({
             price={
               plans?.[`bd_pro_${toggleAnual ? "year" : "month"}`]?.amount || 444
             }
-            region={plans?.[`bd_pro_${toggleAnual ? "year" : "month"}`]?.region}
+            region={plans?.[`bd_pro_${toggleAnual ? "year" : "month"}`] ? localeToRegion(locale) : "br"}
             anualPlan={toggleAnual}
             textResource={t("allFeaturesPlus", { plan: t("plans.free.title") })}
             resources={t("plans.pro.features", { returnObjects: true }).map(

--- a/next/pages/prices.js
+++ b/next/pages/prices.js
@@ -636,7 +636,8 @@ export function SectionPrice({
             title={t("plans.pro.title")}
             subTitle={t("plans.pro.subtitle")}
             price={
-              plans?.[`bd_pro_${toggleAnual ? "year" : "month"}`]?.amount || 444
+              plans?.[`bd_pro_${toggleAnual ? "year" : "month"}`]?.amount ||
+              (toggleAnual ? 444 : 47)
             }
             region={plans?.[`bd_pro_${toggleAnual ? "year" : "month"}`] ? localeToRegion(locale) : "br"}
             anualPlan={toggleAnual}

--- a/next/pages/prices.js
+++ b/next/pages/prices.js
@@ -24,7 +24,7 @@ import BodyText from "../components/atoms/Text/BodyText";
 import CheckIcon from "../public/img/icons/checkIcon";
 import InfoIcon from '../public/img/icons/infoIcon';
 import { triggerGAEvent, triggerGAEventWithData } from "../utils";
-import { selectPlans } from "../constants/stripePlans";
+import { selectPlans, localeToRegion, regionCurrency, formatCurrency } from "../constants/stripePlans";
 
 export async function getStaticProps({ locale }) {
   const pagesProps = await withPages();
@@ -40,6 +40,7 @@ export const CardPrice = ({
   title,
   subTitle,
   price,
+  region,
   anualPlan = false,
   hidePrice = false,
   textResource,
@@ -48,6 +49,7 @@ export const CardPrice = ({
   locale,
   isBeta = false,
 }) => {
+  const { symbol: currencySymbol } = regionCurrency(region);
   const { t } = useTranslation('prices');
   const router = useRouter();
 
@@ -149,7 +151,7 @@ export const CardPrice = ({
                 alignItems="center"
               >
                 <Display textAlign="center">
-                  R$ {anualPlan ? Math.ceil(price / 12) : price}
+                  {currencySymbol} {anualPlan ? Math.ceil(price / 12) : price}
                 </Display>
                 <TitleText
                   typography="small"
@@ -170,9 +172,7 @@ export const CardPrice = ({
               >
                 {anualPlan &&
                   t("annualBillingMessage", {
-                    price: price.toLocaleString("pt-BR", {
-                      style: "currency",
-                      currency: "BRL",
+                    price: formatCurrency(price, region, {
                       minimumFractionDigits: 0,
                     }),
                   })}
@@ -366,7 +366,7 @@ export function SectionPrice({
         .then(res => res.json())
 
       if(result.success === true) {
-        setPlans(selectPlans(result.data))
+        setPlans(selectPlans(result.data, localeToRegion(locale)))
       }
     } catch (error) {
       console.error(error)
@@ -569,6 +569,7 @@ export function SectionPrice({
             title={t("plans.free.title")}
             subTitle={t("plans.free.subtitle")}
             price="0"
+            region={localeToRegion(locale)}
             textResource={t("features")}
             resources={t("plans.free.features", { returnObjects: true }).map(
               (feature, index) => ({
@@ -598,6 +599,7 @@ export function SectionPrice({
                 plans?.[`bd_chatbot_${toggleAnual ? "year" : "month"}`]?.amount ??
                 (toggleAnual ? 326 : 30)
               }
+              region={plans?.[`bd_chatbot_${toggleAnual ? "year" : "month"}`]?.region}
               anualPlan={toggleAnual}
               textResource={t("allFeaturesPlus", { plan: t("plans.free.title") })}
               resources={t("plans.chatbot.features", { returnObjects: true }).map(
@@ -636,6 +638,7 @@ export function SectionPrice({
             price={
               plans?.[`bd_pro_${toggleAnual ? "year" : "month"}`]?.amount || 444
             }
+            region={plans?.[`bd_pro_${toggleAnual ? "year" : "month"}`]?.region}
             anualPlan={toggleAnual}
             textResource={t("allFeaturesPlus", { plan: t("plans.free.title") })}
             resources={t("plans.pro.features", { returnObjects: true }).map(

--- a/next/pages/prices.js
+++ b/next/pages/prices.js
@@ -24,6 +24,7 @@ import BodyText from "../components/atoms/Text/BodyText";
 import CheckIcon from "../public/img/icons/checkIcon";
 import InfoIcon from '../public/img/icons/infoIcon';
 import { triggerGAEvent, triggerGAEventWithData } from "../utils";
+import { selectPlans } from "../constants/stripePlans";
 
 export async function getStaticProps({ locale }) {
   const pagesProps = await withPages();
@@ -365,39 +366,7 @@ export function SectionPrice({
         .then(res => res.json())
 
       if(result.success === true) {
-        function filterData(productName, interval, isActive, amount) {
-          let array = result.data
-
-          return array.filter(item => 
-            (productName ? item.node.productName === productName : true) &&
-            (interval ? item.node.interval === interval : true) &&
-            (amount ? item.node.amount === amount : true) &&
-            (isActive !== undefined ? item.node.isActive === isActive : true)
-          )
-        }
-
-        function filterChatbot(interval, amount) {
-          return result.data.filter((item) => {
-            const name = item.node.productName?.toLowerCase() || ""
-            const slug = item.node.productSlug?.toLowerCase() || ""
-            const isConsumerChatbot =
-              (name.includes("chatbot") || slug.includes("chatbot")) &&
-              !name.includes("empresas")
-            return isConsumerChatbot &&
-              item.node.interval === interval &&
-              item.node.amount === amount &&
-              item.node.isActive === true
-          })
-        }
-
-        const filteredPlans = {
-          bd_pro_month : filterData("BD Pro", "month", true, 47)[0].node,
-          bd_pro_year : filterData("BD Pro", "year", true, 444)[0].node,
-          bd_chatbot_month : filterChatbot("month", 30)[0]?.node,
-          bd_chatbot_year : filterChatbot("year", 326)[0]?.node,
-        }
-
-        setPlans(filteredPlans)
+        setPlans(selectPlans(result.data))
       }
     } catch (error) {
       console.error(error)

--- a/next/pages/search.js
+++ b/next/pages/search.js
@@ -154,6 +154,11 @@ function DatasetCard({ data, locale, index, page }) {
         themes={data?.themes}
         name={data?.name || t('noName')}
         temporalCoverageText={(data?.temporal_coverage && data.temporal_coverage[0]) || ""}
+        spatialCoverage={(data?.spatial_coverage || [])
+          .map(coverage => coverage.name)
+          .filter(Boolean)
+          .sort((a, b) => a.localeCompare(b, locale))
+          .join(', ')}
         organizations={data.organizations}
         tables={{
           id: data?.first_table_id,
@@ -237,6 +242,7 @@ export default function SearchDatasetPage() {
     return {
       themes: aggregations?.themes || [],
       organizations: aggregations?.organizations || [],
+      spatialCoverages: aggregations?.spatial_coverages || [],
       tags: aggregations?.tags || [],
       observationLevels: aggregations?.observation_levels || []
     }
@@ -697,6 +703,24 @@ export default function SearchDatasetPage() {
           />
 
           <Divider marginY="16px !important" borderColor="#DEDFE0"/>
+
+          {locale !== 'pt' && (
+            <>
+              <CheckboxFilterAccordion
+                isActive={validateActiveFilterAccordin("spatial_coverage")}
+                choices={memoizedFilters.spatialCoverages}
+                valueField="key"
+                displayField="name"
+                fieldName={t('spatialCoverage')}
+                valuesChecked={valuesCheckedFilter("spatial_coverage")}
+                onChange={(value) => handleSelectFilter(["spatial_coverage",`${value}`])}
+                isLoading={!isLoading}
+                facet="spatial_coverage"
+              />
+
+              <Divider marginY="16px !important" borderColor="#DEDFE0"/>
+            </>
+          )}
 
           <CheckboxFilterAccordion
             isActive={validateActiveFilterAccordin("organization")}

--- a/next/pages/user/login.js
+++ b/next/pages/user/login.js
@@ -105,7 +105,12 @@ export default function Login() {
   }
 
   const handleGoogleLogin = () => {
-    window.location.href = `${process.env.NEXT_PUBLIC_API_URL}/account/google/login/`;
+    // Tell the backend which domain to return to after Google OAuth, so a login
+    // started on data-basis.org (en) or basedelosdatos.org (es) comes back to
+    // the same domain instead of the pt default. The backend allowlists it.
+    const redirectOrigin =
+      typeof window !== "undefined" ? window.location.origin : "";
+    window.location.href = `${process.env.NEXT_PUBLIC_API_URL}/account/google/login/?redirect_origin=${encodeURIComponent(redirectOrigin)}`;
   };
 
   async function handleSubmit(event) {

--- a/next/pages/user/register.js
+++ b/next/pages/user/register.js
@@ -68,7 +68,12 @@ export default function Register() {
   const [isLoading, setIsLoading] = useState(false)
 
   const handleGoogleLogin = () => {
-    window.location.href = `${process.env.NEXT_PUBLIC_API_URL}/account/google/login/`;
+    // Tell the backend which domain to return to after Google OAuth, so a login
+    // started on data-basis.org (en) or basedelosdatos.org (es) comes back to
+    // the same domain instead of the pt default. The backend allowlists it.
+    const redirectOrigin =
+      typeof window !== "undefined" ? window.location.origin : "";
+    window.location.href = `${process.env.NEXT_PUBLIC_API_URL}/account/google/login/?redirect_origin=${encodeURIComponent(redirectOrigin)}`;
   };
 
   const handleInputChange = (e, field) => {

--- a/next/public/locales/en/bdpro.json
+++ b/next/public/locales/en/bdpro.json
@@ -1,7 +1,7 @@
 {
   "head": {
-    "pageTitle": "BD Pro - Data Basis",
-    "metaTitle": "BD Pro - Data Basis"
+    "pageTitle": "DB Pro - Data Basis",
+    "metaTitle": "DB Pro - Data Basis"
   },
   "hero": {
     "title": ["Public data,", "processed and always up-to-date"],
@@ -70,8 +70,8 @@
     "title": "Frequently Asked Questions - FAQ"
   },
   "banner": {
-    "title": "Discover BD Pro",
-    "description": "Subscribe to BD Pro to access the most updated version of these and other datasets, always in sync with the original source. Besides having constant access to integrated, quality data, your subscription helps Data Basis maintain and expand the largest public and free datalake in Brazil.",
+    "title": "Discover DB Pro",
+    "description": "Subscribe to DB Pro to access the most updated version of these and other datasets, always in sync with the original source. Besides having constant access to integrated, quality data, your subscription helps Data Basis maintain and expand the largest public and free datalake in Brazil.",
     "button": "Learn more and take a free test"
   }
 }

--- a/next/public/locales/en/blog.json
+++ b/next/public/locales/en/blog.json
@@ -8,6 +8,6 @@
   "all": "All",
   "noCategories": "No category",
   "noticedSomething": "Notice something wrong or have a suggestion?",
-  "contributeToBD": "Contribute to BD by editing this article via pull request on our GitHub.",
+  "contributeToBD": "Contribute to DB by editing this article via pull request on our GitHub.",
   "seeAll": "See all"
 }

--- a/next/public/locales/en/chatbot.json
+++ b/next/public/locales/en/chatbot.json
@@ -41,5 +41,95 @@
   "banner": {
     "title": "Create analyses in seconds with the power of AI and Base dos Dados' Datalake",
     "button": "Try the DB chatbot now"
+  },
+  "ui": {
+    "newChat": "New chat",
+    "openMenu": "Open menu",
+    "signOut": "Sign out",
+    "greetingPrefix": "Hello,",
+    "helpQuestion": "How can I help you today?",
+    "copy": "Copy",
+    "copied": "Copied!",
+    "copyResponse": "Copy response",
+    "goodResponse": "Good response",
+    "badResponse": "Bad response",
+    "cancel": "Cancel",
+    "send": "Send",
+    "delete": "Delete",
+    "error": "Error",
+    "thinkingAria": "Thinking",
+    "suggestedQuestions": "Suggested Questions",
+    "search": {
+      "placeholder": "Ask a question...",
+      "disclaimer": "The chatbot can make mistakes. Consider verifying important information.",
+      "disclaimerPrivacy": "All information submitted here is recorded for analysis and product improvement."
+    },
+    "sidebar": {
+      "closeMenu": "Close menu",
+      "collapseMenu": "Collapse menu",
+      "expandMenu": "Expand menu"
+    },
+    "sources": {
+      "title": "Data Sources"
+    },
+    "feedback": {
+      "title": "Feedback",
+      "thanks": "Thank you for your feedback!",
+      "detailsLabel": "Add details: (optional)",
+      "positivePlaceholder": "What was satisfactory about the response?",
+      "negativePlaceholder": "What was unsatisfactory about the response?"
+    },
+    "download": {
+      "label": "Download results",
+      "csv": "Download CSV",
+      "preparing": "Preparing download...",
+      "started": "Download started",
+      "availableWhenDone": "Available once the response finishes",
+      "retry": "Download failed. Please try again.",
+      "errors": {
+        "expiredTitle": "Result expired",
+        "expiredDescription": "These results are no longer available for download.",
+        "tooLargeTitle": "Result too large",
+        "tooLargeDescription": "These results are too large to download in a single file.",
+        "unsupportedTitle": "Unsupported format",
+        "unsupportedDescription": "The requested format is not available for download.",
+        "notFoundTitle": "Result not found",
+        "notFoundDescription": "We couldn't find that result. It may have expired or belong to another conversation.",
+        "genericTitle": "Download failed",
+        "genericDescription": "The result could not be downloaded. Please try again."
+      }
+    },
+    "thinking": {
+      "request": "Request",
+      "result": "Result",
+      "additionalResult": "Additional result",
+      "tools": {
+        "search_datasets": { "running": "Searching datasets", "done": "Datasets found" },
+        "get_dataset_details": { "running": "Exploring dataset", "done": "Dataset explored" },
+        "get_table_details": { "running": "Exploring table structure", "done": "Table structure explored" },
+        "execute_bigquery_sql": { "running": "Querying BigQuery", "done": "BigQuery query completed" },
+        "decode_table_values": { "running": "Decoding table values", "done": "Table values decoded" },
+        "fallback": { "running": "Running tool", "done": "Tool executed" }
+      }
+    },
+    "thread": {
+      "historyTitle": "Conversations",
+      "deleteTitle": "Confirm conversation deletion",
+      "deleteConfirm": "Are you sure you want to delete this conversation? This action cannot be undone.",
+      "loadError": "Error loading history.",
+      "tryAgain": "Please try again."
+    },
+    "table": {
+      "seeMore": "see more",
+      "seeLess": "see less",
+      "showingRows": "Showing {{shown}} of {{total}} results"
+    },
+    "onboarding": {
+      "items": [
+        { "eyebrow": "Data", "question": "What was the evolution of the number of city halls won by each party in Brazil between 2012 and 2020, highlighting the 5 parties that grew the most in that period?" },
+        { "eyebrow": "Analyses", "question": "What is the average wage gap between men and women in the state of São Paulo over the last five years?" },
+        { "eyebrow": "Documents", "question": "I need a CSV that cross-references the average price of regular gasoline with the GDP of the 10 municipalities with the highest GDP in Brazil" }
+      ]
+    }
   }
 }

--- a/next/public/locales/en/chatbot.json
+++ b/next/public/locales/en/chatbot.json
@@ -1,7 +1,7 @@
 {
   "head": {
-    "pageTitle": "Chatbot LP - Data Basis",
-    "metaTitle": "Chatbot LP - Data Basis"
+    "pageTitle": "Chatbot - Data Basis",
+    "metaTitle": "Chatbot - Data Basis"
   },
   "hero": {
     "title": "Talk to a large collection of public data",

--- a/next/public/locales/en/chatbot.json
+++ b/next/public/locales/en/chatbot.json
@@ -5,7 +5,7 @@
   },
   "hero": {
     "title": "Talk to a large collection of public data",
-    "description": "Discover the AI tool that helps you create analyses in seconds and guides you through the entire BD public datalake",
+    "description": "Discover the AI tool that helps you create analyses in seconds and guides you through the entire DB public datalake",
     "button": "Try the Chatbot"
   },
   "why": {
@@ -40,6 +40,6 @@
   },
   "banner": {
     "title": "Create analyses in seconds with the power of AI and Base dos Dados' Datalake",
-    "button": "Try the BD chatbot now"
+    "button": "Try the DB chatbot now"
   }
 }

--- a/next/public/locales/en/chatbot.json
+++ b/next/public/locales/en/chatbot.json
@@ -4,7 +4,7 @@
     "metaTitle": "Chatbot LP - Data Basis"
   },
   "hero": {
-    "title": "Talk to the largest collection of public data in Brazil",
+    "title": "Talk to a large collection of public data",
     "description": "Discover the AI tool that helps you create analyses in seconds and guides you through the entire BD public datalake",
     "button": "Try the Chatbot"
   },
@@ -12,7 +12,7 @@
     "title": "Why will the Data Basis Chatbot revolutionize the way you work with data?",
     "items": [
       {
-        "title": "Access to Brazil's Largest Public Datalake",
+        "title": "Access to a Large Public Datalake",
         "content": "Browse terabytes of data across more than 740 tables on diverse topics (education, economy, health, labor market, demography, environment).",
         "highlightFeature": 0
       },

--- a/next/public/locales/en/dataset.json
+++ b/next/public/locales/en/dataset.json
@@ -27,7 +27,7 @@
     "informationRequests": "LAI requests",
     "resources": "Resources",
     "resourcesTooltip": "On our platform, you will find two types of data: processed tables and original sources. Processed tables are ready-to-analyze tables available via SQL, Python, R, and direct CSV file download. Original sources are links to external pages with useful information about the dataset.",
-    "temporalCoverageTooltip": "Access to most of the data provided by BD is free. The paid subscription plan grants access to high-frequency updated data. These may sometimes be a subset of a larger processed table or an entire processed table.",
+    "temporalCoverageTooltip": "Access to most of the data provided by DB is free. The paid subscription plan grants access to high-frequency updated data. These may sometimes be a subset of a larger processed table or an entire processed table.",
     "downloadDirectTooltip": "The free plan allows direct download of processed tables up to 100 MB. The paid plan allows direct download of processed tables up to 1 GB. This limit does not apply to access via SQL, Python, or R.",
     "observationLevelTooltip": "The observation level indicates what each row in the table represents. It is as if the combination of the columns that make up the observation level were a primary key. This information is useful because it indicates the smallest possible granularity of analysis with that data. For example, a table with a state-level observation allows an analysis at the country level (as it is broader than a state) but not at the municipality level (which would be a more specific breakdown).",
     "downloadDirect": "Direct download",

--- a/next/public/locales/en/dataset.json
+++ b/next/public/locales/en/dataset.json
@@ -164,7 +164,7 @@
         "disableNotification": "Disable notifications",
         "tooltipEnableNotification": "Receive email notifications when this table is updated.",
         "tooltipDisableNotification": "Stop receiving email notifications for this table.",
-        "tooltipUpgradeRequired": "Subscribe to BD Pro to unlock this feature, click here to learn more."
+        "tooltipUpgradeRequired": "Subscribe to DB Pro to unlock this feature, click here to learn more."
     },
     "temporalCoverageBar": {
         "title": "Temporal coverage",

--- a/next/public/locales/en/faq.json
+++ b/next/public/locales/en/faq.json
@@ -7,8 +7,8 @@
         "data": "Dados",
         "paidPlans": "Planos Pagos",
         "bigQuery": "BigQuery",
-        "bdLab": "BD Lab",
-        "bdEdu": "BD Edu",
+        "bdLab": "DB Lab",
+        "bdEdu": "DB Edu",
         "institutional": "Institucional"
     },
     "noQuestionsFound": "Unfortunately, we couldn't find any questions related to your search.",

--- a/next/public/locales/en/faq.json
+++ b/next/public/locales/en/faq.json
@@ -1,15 +1,15 @@
 {
     "pageTitle": "Frequently Asked Questions – Data Basis",
     "pageDescription": "Here you can find answers to your questions about Data Basis. Learn more about our data, how to access it using SQL with BigQuery or with the Python and R packages now.",
-    "title": "Frequently Asked Questions (in Portuguese)",
+    "title": "Frequently Asked Questions",
     "searchPlaceholder": "Search",
     "categories": {
-        "data": "Dados",
-        "paidPlans": "Planos Pagos",
+        "data": "Data",
+        "paidPlans": "Paid Plans",
         "bigQuery": "BigQuery",
         "bdLab": "DB Lab",
         "bdEdu": "DB Edu",
-        "institutional": "Institucional"
+        "institutional": "Institutional"
     },
     "noQuestionsFound": "Unfortunately, we couldn't find any questions related to your search.",
     "contactText": "Didn't find your question? ",

--- a/next/public/locales/en/home.json
+++ b/next/public/locales/en/home.json
@@ -1,10 +1,10 @@
 {
   "organized_data": "Organized data.",
   "reliable_analysis": "Reliable analysis.",
-  "description_organized_data": "Data Basis is an NGO that maintains the largest public data platform in Brazil and offers specialized services in data engineering, analysis, and training.",
+  "description_organized_data": "Data Basis is an NGO that maintains a large public data platform and offers specialized services in data engineering, analysis, and training.",
   "organized_data_first_button": "Access the data platform",
   "organized_data_second_button": "Learn about consulting services",
-  "socioeconomic_data": "The main socioeconomic data from Brazil, in one place.",
+  "socioeconomic_data": "The main socioeconomic data, in one place.",
   "productivity_data_analysis": {
     "title": "Gain productivity in your data analysis",
     "subtitle": "Treated tables and standardized variables to easily cross datasets"
@@ -46,7 +46,7 @@
     },
     {
       "title": "Automate the translation of institutional codes",
-      "content": "Save time with automated code translation, such as the 7-digit IBGE identifiers for Brazilian municipalities."
+      "content": "Save time with automated code translation, such as standardized geographic identifiers for municipalities and regions."
     },
     {
       "title": "Build analyses with the support of user guides",

--- a/next/public/locales/en/prices.json
+++ b/next/public/locales/en/prices.json
@@ -48,7 +48,7 @@
         "title": "DB Orgs",
         "subtitle": "For your organization to save time and improve decision quality",
         "features": [
-          "Starting from 10 BD Pro accesses",
+          "Starting from 10 DB Pro accesses",
           "Priority support",
           "Chatbot",
           "Segmented infrastructure for your use",

--- a/next/public/locales/en/transparency.json
+++ b/next/public/locales/en/transparency.json
@@ -21,7 +21,7 @@
     "statuteDescription": "Our statute contains the guidelines that regulate the organization's functioning and decision-making process. The document also includes the rights and duties of members and the competencies of the administrative and fiscal councils.",
     "reportsDescription": "Our reports present all activities undertaken by the team. There are various projects that collaborate with promoting a culture of transparency, socioeconomic development, and the construction of public policies based on data and evidence.",
     "DBStatute": "DB Social Statute",
-    "DBReport": "BD Annual Report",
+    "DBReport": "DB Annual Report",
     "supportTitle1": "Do you also believe in access",
     "supportTitle2": " to quality data?",
     "supportDescription": "Everything we do is only possible because of the people who support our work. Help DB continue to facilitate access to public data. With any amount, you contribute to the maintenance of our projects and the survival of the organization.",

--- a/next/public/locales/en/user.json
+++ b/next/public/locales/en/user.json
@@ -138,7 +138,7 @@
                 ]
             },
             {
-                "question": "What is your main goal with BD?",
+                "question": "What is your main goal with DB?",
                 "options": [
                     "Market analysis",
                     "Competition monitoring",
@@ -151,7 +151,7 @@
                 ]
             },
             {
-                "question": "How did you hear about BD?",
+                "question": "How did you hear about DB?",
                 "options": [
                     "Social media",
                     "Recommendation",

--- a/next/public/locales/en/user.json
+++ b/next/public/locales/en/user.json
@@ -35,7 +35,7 @@
             "termsLink": "Terms of Service",
             "part2": " and ",
             "privacyLink": "Privacy Policy",
-            "part3": " of Base dos Dados."
+            "part3": " of Data Basis."
         },
         "placeholders": {
             "firstName": "Enter your first name",

--- a/next/public/locales/en/user.json
+++ b/next/public/locales/en/user.json
@@ -311,7 +311,7 @@
         "account": "Account",
         "changePassword": "Password",
         "plansAndPayment": "Plans and payment",
-        "accessFor10Accounts": "Starting from 10 BD Pro accesses",
+        "accessFor10Accounts": "Starting from 10 DB Pro accesses",
         "prioritySupport": "Priority support",
         "bdOrgsChatbot": "Chatbot",
         "bdOrgsSegmentedInfrastructure": "Segmented infrastructure for your use",

--- a/next/public/locales/es/chatbot.json
+++ b/next/public/locales/es/chatbot.json
@@ -41,5 +41,95 @@
   "banner": {
     "title": "Crea análisis en segundos con el poder de la IA y el Datalake de Base de los Datos",
     "button": "Prueba ya el chatbot de BD"
+  },
+  "ui": {
+    "newChat": "Nueva conversación",
+    "openMenu": "Abrir menú",
+    "signOut": "Cerrar sesión",
+    "greetingPrefix": "Hola,",
+    "helpQuestion": "¿Cómo puedo ayudarte hoy?",
+    "copy": "Copiar",
+    "copied": "¡Copiado!",
+    "copyResponse": "Copiar respuesta",
+    "goodResponse": "Buena respuesta",
+    "badResponse": "Mala respuesta",
+    "cancel": "Cancelar",
+    "send": "Enviar",
+    "delete": "Eliminar",
+    "error": "Error",
+    "thinkingAria": "Pensando",
+    "suggestedQuestions": "Preguntas Sugeridas",
+    "search": {
+      "placeholder": "Haz una pregunta...",
+      "disclaimer": "El chatbot puede cometer errores. Considera verificar la información importante.",
+      "disclaimerPrivacy": "Toda la información enviada aquí se registra para análisis y mejora del producto."
+    },
+    "sidebar": {
+      "closeMenu": "Cerrar menú",
+      "collapseMenu": "Contraer menú",
+      "expandMenu": "Expandir menú"
+    },
+    "sources": {
+      "title": "Fuentes de Datos"
+    },
+    "feedback": {
+      "title": "Comentarios",
+      "thanks": "¡Gracias por tu comentario!",
+      "detailsLabel": "Añade detalles: (opcional)",
+      "positivePlaceholder": "¿Qué te resultó satisfactorio de la respuesta?",
+      "negativePlaceholder": "¿Qué te resultó insatisfactorio de la respuesta?"
+    },
+    "download": {
+      "label": "Descargar resultados",
+      "csv": "Descargar CSV",
+      "preparing": "Preparando la descarga...",
+      "started": "Descarga iniciada",
+      "availableWhenDone": "Disponible cuando termine la respuesta",
+      "retry": "Error al descargar. Inténtalo de nuevo.",
+      "errors": {
+        "expiredTitle": "Resultado caducado",
+        "expiredDescription": "Estos resultados ya no están disponibles para descargar.",
+        "tooLargeTitle": "Resultado demasiado grande",
+        "tooLargeDescription": "Estos resultados son demasiado grandes para descargarlos en un solo archivo.",
+        "unsupportedTitle": "Formato no compatible",
+        "unsupportedDescription": "El formato solicitado no está disponible para descargar.",
+        "notFoundTitle": "Resultado no encontrado",
+        "notFoundDescription": "No encontramos ese resultado. Puede haber caducado o pertenecer a otra conversación.",
+        "genericTitle": "Error al descargar",
+        "genericDescription": "No se pudo descargar el resultado. Inténtalo de nuevo."
+      }
+    },
+    "thinking": {
+      "request": "Solicitud",
+      "result": "Resultado",
+      "additionalResult": "Resultado adicional",
+      "tools": {
+        "search_datasets": { "running": "Buscando conjuntos de datos", "done": "Conjuntos de datos encontrados" },
+        "get_dataset_details": { "running": "Explorando conjunto de datos", "done": "Conjunto de datos explorado" },
+        "get_table_details": { "running": "Explorando la estructura de la tabla", "done": "Estructura de la tabla explorada" },
+        "execute_bigquery_sql": { "running": "Consultando BigQuery", "done": "Consulta a BigQuery completada" },
+        "decode_table_values": { "running": "Decodificando valores de la tabla", "done": "Valores de la tabla decodificados" },
+        "fallback": { "running": "Ejecutando herramienta", "done": "Herramienta ejecutada" }
+      }
+    },
+    "thread": {
+      "historyTitle": "Conversaciones",
+      "deleteTitle": "Confirmar eliminación de la conversación",
+      "deleteConfirm": "¿Seguro que deseas eliminar esta conversación? Esta acción no se puede deshacer.",
+      "loadError": "Error al cargar el historial.",
+      "tryAgain": "Inténtalo de nuevo."
+    },
+    "table": {
+      "seeMore": "ver más",
+      "seeLess": "ver menos",
+      "showingRows": "Mostrando {{shown}} de {{total}} resultados"
+    },
+    "onboarding": {
+      "items": [
+        { "eyebrow": "Datos", "question": "¿Cuál fue la evolución del número de alcaldías conquistadas por cada partido en Brasil entre 2012 y 2020, destacando los 5 partidos que más crecieron en ese período?" },
+        { "eyebrow": "Análisis", "question": "¿Cuál es la diferencia salarial media entre hombres y mujeres en el estado de São Paulo a lo largo de los últimos cinco años?" },
+        { "eyebrow": "Documentos", "question": "Necesito un csv que cruce los datos del precio medio de la gasolina común con el PIB de los 10 municipios con el mayor PIB de Brasil" }
+      ]
+    }
   }
 }

--- a/next/public/locales/es/chatbot.json
+++ b/next/public/locales/es/chatbot.json
@@ -4,7 +4,7 @@
     "metaTitle": "Chatbot LP - Base de los Datos"
   },
   "hero": {
-    "title": "Conversa con el mayor acervo de datos públicos de Brasil",
+    "title": "Conversa con un gran acervo de datos públicos",
     "description": "Conoce la herramienta de IA que te ayudará a crear análisis en segundos y te guiará por todo el datalake público de BD",
     "button": "Prueba el Chatbot"
   },
@@ -12,7 +12,7 @@
     "title": "¿Por qué el Chatbot de Base de los Datos revolucionará tu trabajo con datos?",
     "items": [
       {
-        "title": "Acceso al mayor datalake público de Brasil",
+        "title": "Acceso a un gran datalake público",
         "content": "Navega por terabytes de datos en más de 740 tablas sobre diversos temas (educación, economía, salud, mercado de trabajo, demografía, medio ambiente).",
         "highlightFeature": 0
       },

--- a/next/public/locales/es/chatbot.json
+++ b/next/public/locales/es/chatbot.json
@@ -1,7 +1,7 @@
 {
   "head": {
-    "pageTitle": "Chatbot LP - Base de los Datos",
-    "metaTitle": "Chatbot LP - Base de los Datos"
+    "pageTitle": "Chatbot - Base de los Datos",
+    "metaTitle": "Chatbot - Base de los Datos"
   },
   "hero": {
     "title": "Conversa con un gran acervo de datos públicos",

--- a/next/public/locales/es/faq.json
+++ b/next/public/locales/es/faq.json
@@ -1,17 +1,17 @@
 {
-    "pageTitle": "Perguntas frecuentes – Base de los Datos",
-    "pageDescription": "Aquí encontrarás respuestas a tus preguntas sobre la Base de los Datos. Conoce más sobre nuestros datos, cómo acceder a ellos usando SQL con BigQuery o con los paquetes Python y R ahora mismo.",
-    "title": "Perguntas Frecuentes (en portugués)",
-    "searchPlaceholder": "Pesquise",
-    "categories": [
-        "Dados",
-        "Planos Pagos",
-        "BigQuery",
-        "BD Lab",
-        "BD Edu",
-        "Institucional"
-    ],
-    "noQuestionsFound": "Infelizmente, no encontramos ninguna pregunta relacionada a su búsqueda.",
-    "notFoundQuestion": "No encontró su pregunta? ",
-    "contactUs": "Contactanos"
+    "pageTitle": "Preguntas frecuentes – Base de los Datos",
+    "pageDescription": "Aquí encontrarás respuestas a tus preguntas sobre Base de los Datos. Conoce más sobre nuestros datos, cómo acceder a ellos usando SQL con BigQuery o con los paquetes Python y R ahora mismo.",
+    "title": "Preguntas Frecuentes",
+    "searchPlaceholder": "Buscar",
+    "categories": {
+        "data": "Datos",
+        "paidPlans": "Planes Pagos",
+        "bigQuery": "BigQuery",
+        "bdLab": "BD Lab",
+        "bdEdu": "BD Edu",
+        "institutional": "Institucional"
+    },
+    "noQuestionsFound": "Lamentablemente, no encontramos ninguna pregunta relacionada con tu búsqueda.",
+    "contactText": "¿No encontraste tu pregunta? ",
+    "contactLink": "Contáctanos"
 }

--- a/next/public/locales/es/home.json
+++ b/next/public/locales/es/home.json
@@ -1,10 +1,10 @@
 {
   "organized_data": "Datos organizados.",
   "reliable_analysis": "Análisis confiables.",
-  "description_organized_data": "Base de los Datos es una ONG que mantiene la mayor plataforma de datos públicos de Brasil y ofrece servicios especializados en ingeniería, análisis y capacitación de datos.",
+  "description_organized_data": "Base de los Datos es una ONG que mantiene una gran plataforma de datos públicos y ofrece servicios especializados en ingeniería, análisis y capacitación de datos.",
   "organized_data_first_button": "Accede a la plataforma de datos",
   "organized_data_second_button": "Conoce los servicios de consultoría",
-  "socioeconomic_data": "Los principales datos socioeconómicos de Brasil, en un solo lugar.",
+  "socioeconomic_data": "Los principales datos socioeconómicos, en un solo lugar.",
   "productivity_data_analysis": {
     "title": "Gana productividad en tu análisis de datos",
     "subtitle": "Tablas tratadas y variables estandarizadas para cruzar conjuntos de datos con facilidad"
@@ -46,7 +46,7 @@
     },
     {
       "title": "Automatiza la traducción de códigos institucionales",
-      "content": "Ahorra tiempo con la traducción automatizada de códigos, como los identificadores de 7 dígitos del IBGE para los municipios brasileños."
+      "content": "Ahorra tiempo con la traducción automatizada de códigos, como identificadores geográficos estandarizados para municipios y regiones."
     },
     {
       "title": "Construye análisis con el apoyo de las guías de uso",

--- a/next/public/locales/pt/chatbot.json
+++ b/next/public/locales/pt/chatbot.json
@@ -1,7 +1,7 @@
 {
   "head": {
-    "pageTitle": "Chatbot LP - Base dos Dados",
-    "metaTitle": "Chatbot LP - Base dos Dados"
+    "pageTitle": "Chatbot - Base dos Dados",
+    "metaTitle": "Chatbot - Base dos Dados"
   },
   "hero": {
     "title": "Converse com o maior acervo de dados públicos do Brasil",

--- a/next/public/locales/pt/chatbot.json
+++ b/next/public/locales/pt/chatbot.json
@@ -41,5 +41,95 @@
   "banner": {
     "title": "Crie análises em segundos com o poder da IA e o Datalake da Base dos Dados",
     "button": "Teste já o chatbot da BD"
+  },
+  "ui": {
+    "newChat": "Nova conversa",
+    "openMenu": "Abrir menu",
+    "signOut": "Sair",
+    "greetingPrefix": "Olá,",
+    "helpQuestion": "Como posso ajudar você hoje?",
+    "copy": "Copiar",
+    "copied": "Copiado!",
+    "copyResponse": "Copiar resposta",
+    "goodResponse": "Boa resposta",
+    "badResponse": "Resposta ruim",
+    "cancel": "Cancelar",
+    "send": "Enviar",
+    "delete": "Excluir",
+    "error": "Erro",
+    "thinkingAria": "Pensando",
+    "suggestedQuestions": "Perguntas Sugeridas",
+    "search": {
+      "placeholder": "Faça uma pergunta...",
+      "disclaimer": "O chatbot pode cometer erros. Considere verificar informações importantes.",
+      "disclaimerPrivacy": "Todas as informações aqui enviadas são registradas para análise e melhoria do produto."
+    },
+    "sidebar": {
+      "closeMenu": "Fechar menu",
+      "collapseMenu": "Recolher menu",
+      "expandMenu": "Expandir menu"
+    },
+    "sources": {
+      "title": "Fontes dos Dados"
+    },
+    "feedback": {
+      "title": "Feedback",
+      "thanks": "Obrigado pelo seu feedback!",
+      "detailsLabel": "Dê os detalhes: (opcional)",
+      "positivePlaceholder": "O que foi satisfatório na resposta?",
+      "negativePlaceholder": "O que foi insatisfatório na resposta?"
+    },
+    "download": {
+      "label": "Baixar resultados",
+      "csv": "Baixar CSV",
+      "preparing": "Preparando o download...",
+      "started": "Download iniciado",
+      "availableWhenDone": "Disponível assim que a resposta terminar",
+      "retry": "Falha ao baixar. Tente novamente.",
+      "errors": {
+        "expiredTitle": "Resultado expirado",
+        "expiredDescription": "Estes resultados não estão mais disponíveis para download.",
+        "tooLargeTitle": "Resultado muito grande",
+        "tooLargeDescription": "Estes resultados são grandes demais para baixar em um único arquivo.",
+        "unsupportedTitle": "Formato não suportado",
+        "unsupportedDescription": "O formato solicitado não está disponível para download.",
+        "notFoundTitle": "Resultado não encontrado",
+        "notFoundDescription": "Não encontramos esse resultado. Ele pode ter expirado ou pertencer a outra conversa.",
+        "genericTitle": "Falha ao baixar",
+        "genericDescription": "Não foi possível baixar o resultado. Tente novamente."
+      }
+    },
+    "thinking": {
+      "request": "Solicitação",
+      "result": "Resultado",
+      "additionalResult": "Resultado adicional",
+      "tools": {
+        "search_datasets": { "running": "Buscando conjuntos de dados", "done": "Conjuntos de dados encontrados" },
+        "get_dataset_details": { "running": "Explorando conjunto de dados", "done": "Conjunto de dados explorado" },
+        "get_table_details": { "running": "Explorando estrutura da tabela", "done": "Estrutura da tabela explorada" },
+        "execute_bigquery_sql": { "running": "Consultando o BigQuery", "done": "Consulta ao BigQuery concluída" },
+        "decode_table_values": { "running": "Decodificando valores da tabela", "done": "Valores da tabela decodificados" },
+        "fallback": { "running": "Executando ferramenta", "done": "Ferramenta executada" }
+      }
+    },
+    "thread": {
+      "historyTitle": "Conversas",
+      "deleteTitle": "Confirmar exclusão de conversa",
+      "deleteConfirm": "Tem certeza que deseja excluir esta conversa? Esta ação não pode ser desfeita.",
+      "loadError": "Erro ao carregar histórico.",
+      "tryAgain": "Tente novamente."
+    },
+    "table": {
+      "seeMore": "ver mais",
+      "seeLess": "ver menos",
+      "showingRows": "Mostrando {{shown}} de {{total}} resultados"
+    },
+    "onboarding": {
+      "items": [
+        { "eyebrow": "Dados", "question": "Qual foi a evolução do número de prefeituras conquistadas por cada partido no Brasil entre 2012 e 2020, destacando os 5 partidos que mais cresceram nesse período?" },
+        { "eyebrow": "Análises", "question": "Qual é a diferença salarial média entre homens e mulheres no estado de São Paulo ao longo dos últimos cinco anos?" },
+        { "eyebrow": "Documentos", "question": "Preciso de um csv que cruze os dados de preço médio da gasolina comum com o PIB dos 10 municípios com o maior PIB do Brasil" }
+      ]
+    }
   }
 }

--- a/next/utils.js
+++ b/next/utils.js
@@ -23,6 +23,18 @@ export function isBasedosdadosDomain() {
   return getDomain() === "basedosdados.org";
 }
 
+// Community Discord invite per interface language. Each locale has its own
+// server, so links must follow the site language rather than always pointing
+// at the Portuguese community.
+export function getDiscordUrl(locale) {
+  const byLocale = {
+    pt: "https://discord.gg/huKWpsVYx4",
+    en: "https://discord.gg/tx57ek6zqQ",
+    es: "https://discord.gg/nNfQYcmrvM",
+  };
+  return byLocale[locale] || byLocale.pt;
+}
+
 // The backend query generator (getTableOneBigTableQuery) always aliases the
 // table as `dados`. Rename that alias to match the interface language so the
 // generated SQL reads naturally per site: pt -> dados, en -> data, es -> datos.

--- a/next/utils.js
+++ b/next/utils.js
@@ -7,6 +7,37 @@ export async function clearClientSession() {
   } catch (_) {}
 }
 
+// Returns the brand domain this build is serving. Prefers the build-time
+// NEXT_PUBLIC_DOMAIN (baked per Docker image: basedosdados.org, data-basis.org,
+// basedelosdatos.org) so it is correct on the server and under Docker, where the
+// browser hostname is localhost. Falls back to the hostname for local npm dev.
+export function getDomain() {
+  if (process.env.NEXT_PUBLIC_DOMAIN) return process.env.NEXT_PUBLIC_DOMAIN.replace(/^www\./, "");
+  if (typeof window !== "undefined") return window.location.hostname.replace(/^www\./, "");
+  return "";
+}
+
+// True only on the Brazilian branch (basedosdados.org), which is the only one
+// that offers consulting services and Brazil-specific content.
+export function isBasedosdadosDomain() {
+  return getDomain() === "basedosdados.org";
+}
+
+// The backend query generator (getTableOneBigTableQuery) always aliases the
+// table as `dados`. Rename that alias to match the interface language so the
+// generated SQL reads naturally per site: pt -> dados, en -> data, es -> datos.
+// The replace is targeted at the alias declaration (`AS dados`) and the column
+// prefixes (`dados.`); word boundaries keep it from touching the project path
+// `basedosdados.<dataset>.<table>` or any other identifier.
+export function localizeQueryTableAlias(query, locale) {
+  const aliasByLocale = { pt: "dados", en: "data", es: "datos" };
+  const alias = aliasByLocale[locale] || "dados";
+  if (alias === "dados" || typeof query !== "string") return query;
+  return query
+    .replace(/\bAS dados\b/g, `AS ${alias}`)
+    .replace(/\bdados\./g, `${alias}.`);
+}
+
 export function filterOnlyValidValues(obj, validValues = null) {
   return Object.entries(obj).filter(
     ([k, v]) =>


### PR DESCRIPTION
> [!WARNING]
> **Do not merge until `staging` has been reset to `main`.**
> Merging now conflicts, because `staging` still carries these same changes under their
> original SHAs. After the reset this applies cleanly.

Reconstructs the language-consistent experience work onto `main`.

These 22 commits were originally pushed straight to `staging` under the old
workflow. `staging` is scheduled to be reset to `main`, so the work has been
cherry-picked onto a branch cut from `main` per the current Git Flow.

### What's here
- **Regional pricing (display):** currency by domain, exact Stripe price ids pinned per region (br / latam / intl), interval-aware fallback for the DB Pro card.
- **i18n:** `/faq` help center, dataset usage guides, column descriptions, Discord link, signup terms, "DB" branding across the en site.
- **Chatbot:** site locale sent when creating a thread, localized chat UI (en/es), login stays on the originating domain, localized tab title, DB logo on the English site.
- **About us:** show only active team roles.

### Verification
- All 22 cherry-picked onto `main` with **zero conflicts**.
- Fidelity checked against `staging`: the only files differing are ones also touched by
  AldemirLucas's 3 staging-only commits — nothing from this set was dropped.
- Original authorship and dates preserved; each commit records its `(cherry picked from …)` provenance.

### Deploy order
Merge **after** the backend PR of the same name. The pinned-price-id display queries
`stripePriceId`; if this reaches prod first, `getPlans` errors and every plan falls back to BRL.
