### PR TITLE
feat: Data API frontend (rescued from development before reset)

### DIFF
--- a/next/components/molecules/AddCreditsModal.js
+++ b/next/components/molecules/AddCreditsModal.js
@@ -1,0 +1,105 @@
+import {
+  Stack,
+  Box,
+  Text,
+  NumberInput,
+  NumberInputField,
+  NumberInputStepper,
+  NumberIncrementStepper,
+  NumberDecrementStepper,
+  ModalCloseButton,
+  Button
+} from "@chakra-ui/react";
+import { useState } from "react";
+import { useTranslation } from "next-i18next";
+import { ModalGeneral } from "./uiUserPage";
+
+export default function AddCreditsModal({ 
+  isOpen, 
+  onClose, 
+  apiKey,
+  onSuccess,
+  onError 
+}) {
+  const { t } = useTranslation('user');
+  const [amount, setAmount] = useState(10);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleConfirm = async () => {
+    setIsLoading(true);
+    try {
+      const response = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL}/data_api/credits/add?hashed_key=${apiKey.hash}&amount=${amount}&currency=BRL`
+      );
+      const data = await response.json();
+      
+      if (data.success) {
+        onSuccess(data);
+        onClose();
+      } else {
+        onError(new Error('Failed to add credits'));
+      }
+    } catch (err) {
+      onError(err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <ModalGeneral
+      isOpen={isOpen}
+      onClose={onClose}
+      propsModalContent={{
+        width: "100%",
+        maxWidth: "1008px",
+        margin: "24px"
+      }}
+    >
+      <Stack spacing={0} marginBottom="40px">
+        <Text
+          typography="small"
+          width="100%"
+          color="#2B8C4D"
+        >
+          {t('dataAPI.addCredits')}
+        </Text>
+        <ModalCloseButton
+          fontSize="14px"
+          top="34px"
+          right="26px"
+          _hover={{backgroundColor: "transparent", opacity: 0.7}}
+        />
+      </Stack>
+
+      <Stack spacing={6}>
+        <Box>
+          <Text mb={2}>{t('dataAPI.selectAmount')}</Text>
+          <NumberInput
+            value={amount}
+            onChange={(value) => setAmount(Number(value))}
+          >
+            <NumberInputField />
+            <NumberInputStepper>
+              <NumberIncrementStepper />
+              <NumberDecrementStepper />
+            </NumberInputStepper>
+          </NumberInput>
+        </Box>
+
+        <Button
+          width="100%"
+          backgroundColor="#2B8C4D"
+          color="#FFFFFF"
+          _hover={{
+            backgroundColor: "#22703E"
+          }}
+          onClick={handleConfirm}
+          isLoading={isLoading}
+        >
+          {t('dataAPI.confirm')}
+        </Button>
+      </Stack>
+    </ModalGeneral>
+  );
+} 

--- a/next/components/organisms/PaymentSystemCredits.js
+++ b/next/components/organisms/PaymentSystemCredits.js
@@ -1,0 +1,184 @@
+import { loadStripe } from '@stripe/stripe-js';
+import {
+  Elements,
+  PaymentElement,
+  useElements,
+  useStripe,
+} from "@stripe/react-stripe-js";
+import { useState, useEffect } from "react";
+import { Button, Box, Stack } from "@chakra-ui/react";
+import { useTranslation } from "next-i18next";
+
+const stripePromise = loadStripe(process.env.NEXT_PUBLIC_KEY_STRIPE);
+
+function CheckoutForm({ onSuccess, onError, apiKey, amount }) {
+  const stripe = useStripe();
+  const elements = useElements();
+  const { t } = useTranslation('dataAPI');
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [message, setMessage] = useState(null);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+
+    if (!stripe || !elements) {
+      return;
+    }
+
+    setIsProcessing(true);
+
+    const { error, paymentIntent } = await stripe.confirmPayment({
+      elements,
+      confirmParams: {
+        return_url: `${window.location.origin}/user`,
+      },
+      redirect: "if_required"
+    });
+
+    if (error) {
+      setMessage(error.message);
+      onError(error);
+    } else if (paymentIntent && paymentIntent.status === "succeeded") {
+      // Call the credits API after successful payment
+      try {
+        const response = await fetch(
+          `${process.env.NEXT_PUBLIC_API_URL}/data_api/credits/add?key=${apiKey}&amount=${amount}&currency=BRL`
+        );
+        const data = await response.json();
+        
+        if (data.success) {
+          onSuccess(data);
+        } else {
+          onError(new Error('Failed to add credits'));
+        }
+      } catch (err) {
+        onError(err);
+      }
+    }
+
+    setIsProcessing(false);
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <Stack spacing={4}>
+        <PaymentElement />
+        <Button
+          width="100%"
+          backgroundColor="#2B8C4D"
+          color="#FFFFFF"
+          _hover={{
+            backgroundColor: "#22703E"
+          }}
+          isLoading={isProcessing}
+          disabled={!stripe}
+          type="submit"
+        >
+          {t('pricing.confirmPayment')}
+        </Button>
+        {message && <Box color="red.500">{message}</Box>}
+      </Stack>
+    </form>
+  );
+}
+
+export default function PaymentSystemCredits({
+  amount,
+  apiKey,
+  onSuccess,
+  onError,
+  isLoading
+}) {
+  const [clientSecret, setClientSecret] = useState("");
+  const { t } = useTranslation('dataAPI');
+
+  useEffect(() => {
+    async function createPaymentIntent() {
+      const response = await fetch('/api/stripe/createApiCreditPayment', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          amount,
+          apiKey,
+        }),
+      });
+      
+      const data = await response.json();
+      setClientSecret(data.clientSecret);
+      isLoading(false);
+    }
+
+    isLoading(true);
+    createPaymentIntent();
+  }, [amount, apiKey]);
+
+  const appearance = {
+    theme: "stripe",
+    variables: {
+      fontFamily: 'Roboto, sans-serif',
+      fontSizeBase: "16px",
+      fontSizeSm: "16px",
+      borderRadius: "14px",
+      colorPrimary: "#2B8C4D",
+      colorTextPlaceholder: "#464A51",
+      colorDanger: "#BF3434",
+      colorBackground: "#FFFFFF",
+      colorText: "#252A32",
+    },
+    rules: {
+      ".Input": {
+        borderRadius: "8px",
+        border: "2px solid #EEEEEE",
+        backgroundColor: "#EEEEEE"
+      },
+      ".Input:hover": {
+        backgroundColor: "#DEDFE0",
+        borderColor: "#DEDFE0"
+      },
+      ".Input:focus": {
+        backgroundColor: "#FFFFFF",
+        border: "2px solid #0068C5",
+        borderColor: "#0068C5",
+        boxShadow: "none",
+        outline: "none"
+      },
+      ".Input:focus:hover": {
+        backgroundColor: "#FFFFFF",
+        borderColor: "#0068C5",
+      },
+      ".Tab": {
+        border: "2px solid #ececec",
+        backgroundColor: "#FFF",
+        boxShadow: "none"
+      },
+      ".Tab:focus": {
+        boxShadow: "none"
+      },
+      ".Tab--selected": {
+        boxShadow: "none"
+      },
+      ".Tab--selected:focus": {
+        boxShadow: "none"
+      }
+    }
+  };
+
+  const options = {
+    clientSecret,
+    appearance,
+    fonts: [{ cssSrc: 'https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap' }],
+  };
+
+  return clientSecret ? (
+    <Elements options={options} stripe={stripePromise}>
+      <CheckoutForm 
+        onSuccess={onSuccess} 
+        onError={onError} 
+        apiKey={apiKey}
+        amount={amount}
+      />
+    </Elements>
+  ) : null;
+} 

--- a/next/components/organisms/componentsUserPage/DataAPI.js
+++ b/next/components/organisms/componentsUserPage/DataAPI.js
@@ -11,6 +11,8 @@ import {
 } from "@chakra-ui/react";
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
+import { useRouter } from "next/router";
+import AddCreditsModal from "../../molecules/AddCreditsModal";
 
 import TitleText from "../../atoms/Text/TitleText";
 import BodyText from "../../atoms/Text/BodyText";
@@ -19,8 +21,11 @@ import CheckIcon from "../../../public/img/icons/checkIcon";
 
 export default function DataAPI({ userInfo }) {
   const { t } = useTranslation('user');
+  const router = useRouter();
   const [apiKeys, setApiKeys] = useState([]);
   const [copiedIndex, setCopiedIndex] = useState(null);
+  const [isAddCreditsOpen, setIsAddCreditsOpen] = useState(false);
+  const [selectedApiKey, setSelectedApiKey] = useState(null);
 
   useEffect(() => {
     if (userInfo?.keys?.edges) {
@@ -41,6 +46,22 @@ export default function DataAPI({ userInfo }) {
   const formatDate = (dateString) => {
     const date = new Date(dateString);
     return date.toISOString().split('T')[0];
+  };
+
+  const handleAddCredits = (key) => {
+    setSelectedApiKey(key);
+    setIsAddCreditsOpen(true);
+  };
+
+  const handleAddCreditsSuccess = () => {
+    setIsAddCreditsOpen(false);
+    // Refresh only the current page
+    router.replace(router.asPath);
+  };
+
+  const handleAddCreditsError = () => {
+    // Handle error - could add toast notification here
+    setIsAddCreditsOpen(false);
   };
 
   return (
@@ -124,7 +145,7 @@ export default function DataAPI({ userInfo }) {
                         color: "#22703E",
                         borderColor: "#22703E"
                       }}
-                      onClick={() => window.open('', '_blank')}
+                      onClick={() => handleAddCredits(key)}
                     >
                       {t('dataAPI.addCredits')}
                     </Button>
@@ -180,6 +201,14 @@ export default function DataAPI({ userInfo }) {
           {' '}{t('dataAPI.weWillHelpYou')}
         </BodyText>
       </Box>
+
+      <AddCreditsModal
+        isOpen={isAddCreditsOpen}
+        onClose={() => setIsAddCreditsOpen(false)}
+        apiKey={selectedApiKey}
+        onSuccess={handleAddCreditsSuccess}
+        onError={handleAddCreditsError}
+      />
     </Stack>
   );
 } 

--- a/next/components/organisms/componentsUserPage/DataAPI.js
+++ b/next/components/organisms/componentsUserPage/DataAPI.js
@@ -5,7 +5,9 @@ import {
   GridItem,
   Badge,
   Tooltip,
-  useClipboard
+  useClipboard,
+  Link,
+  Button
 } from "@chakra-ui/react";
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
@@ -37,14 +39,30 @@ export default function DataAPI({ userInfo }) {
   };
 
   const formatDate = (dateString) => {
-    return new Date(dateString).toLocaleDateString();
+    const date = new Date(dateString);
+    return date.toISOString().split('T')[0];
   };
 
   return (
     <Stack spacing={6}>
+        <Box
+          p={4}
+          mb={4}
+          bg="yellow.100"
+          borderRadius="md"
+          borderLeft="4px solid"
+          borderColor="yellow.400"
+        >
+          <BodyText typography="small" fontWeight="bold" marginBottom={2}>
+            {t('dataAPI.earlyRelease')} 🚧
+          </BodyText>
+          <BodyText typography="small">
+            {t('dataAPI.earlyReleaseDescription')}
+          </BodyText>
+        </Box>
       <Box>
         <TitleText typography="small" marginBottom={4}>
-          {t('dataAPI.title')}
+          {t('dataAPI.keys')}
         </TitleText>
         <BodyText typography="small" color="#464A51">
           {t('dataAPI.description')}
@@ -61,11 +79,21 @@ export default function DataAPI({ userInfo }) {
             borderRadius="8px"
           >
             <Stack spacing={4}>
-              <Stack direction="row" justifyContent="space-between" alignItems="center">
+              <Stack direction="row" alignItems="center">
                 <Stack direction="row" alignItems="center" spacing={2}>
                   <BodyText fontWeight="500">
                     {t('dataAPI.prefix')}: {key.prefix}
                   </BodyText>
+                  {key.name && (
+                    <>
+                      <BodyText fontWeight="500" color="#71757A">
+                        |
+                      </BodyText>
+                      <BodyText fontWeight="500">
+                        {t('dataAPI.name')}: {key.name}
+                      </BodyText>
+                    </>
+                  )}
                   <Box
                     cursor="pointer"
                     onClick={() => handleCopyClick(key.prefix, index)}
@@ -77,13 +105,31 @@ export default function DataAPI({ userInfo }) {
                     )}
                   </Box>
                 </Stack>
-                <Badge
-                  colorScheme={key.isActive ? "green" : "red"}
-                  borderRadius="4px"
-                  px={2}
-                >
-                  {key.isActive ? t('dataAPI.active') : t('dataAPI.inactive')}
-                </Badge>
+                <Stack direction="row" alignItems="center" spacing={2}>
+                  <Badge
+                    colorScheme={key.isActive ? "green" : "red"}
+                    borderRadius="4px"
+                    px={2}
+                  >
+                    {key.isActive ? t('dataAPI.active') : t('dataAPI.inactive')}
+                  </Badge>
+                  {key.isActive && (
+                    <Button
+                      size="sm"
+                      color="#2B8C4D"
+                      backgroundColor="#FFF"
+                      border="1px solid #2B8C4D"
+                      _hover={{
+                        backgroundColor: "#FFF",
+                        color: "#22703E",
+                        borderColor: "#22703E"
+                      }}
+                      onClick={() => window.open('', '_blank')}
+                    >
+                      {t('dataAPI.addCredits')}
+                    </Button>
+                  )}
+                </Stack>
               </Stack>
 
               <Grid templateColumns="repeat(3, 1fr)" gap={4}>
@@ -92,7 +138,7 @@ export default function DataAPI({ userInfo }) {
                     {t('dataAPI.balance')}
                   </BodyText>
                   <BodyText typography="small">
-                    {key.balance || 0} credits
+                    {key.balance || 0} {t('dataAPI.reais')}
                   </BodyText>
                 </Box>
                 <Box>
@@ -116,6 +162,24 @@ export default function DataAPI({ userInfo }) {
           </GridItem>
         ))}
       </Grid>
+
+      <Box borderTop="1px solid #DEDFE0" paddingTop={6}>
+        <BodyText typography="small" color="#464A51">
+          {t('dataAPI.needMoreKeys')} {' '}
+          <Link
+            display="inline"
+            fontWeight="500"
+            color="#0068C5"
+            _hover={{
+              color: "#0057A4",
+            }}
+            href="/contact"
+          >
+            {t('dataAPI.contactUs')}
+          </Link>
+          {' '}{t('dataAPI.weWillHelpYou')}
+        </BodyText>
+      </Box>
     </Stack>
   );
 } 

--- a/next/components/organisms/componentsUserPage/DataAPI.js
+++ b/next/components/organisms/componentsUserPage/DataAPI.js
@@ -1,0 +1,121 @@
+import {
+  Stack,
+  Box,
+  Grid,
+  GridItem,
+  Badge,
+  Tooltip,
+  useClipboard
+} from "@chakra-ui/react";
+import { useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+
+import TitleText from "../../atoms/Text/TitleText";
+import BodyText from "../../atoms/Text/BodyText";
+import { CopySolidIcon } from "../../../public/img/icons/copyIcon";
+import CheckIcon from "../../../public/img/icons/checkIcon";
+
+export default function DataAPI({ userInfo }) {
+  const { t } = useTranslation('user');
+  const [apiKeys, setApiKeys] = useState([]);
+  const [copiedIndex, setCopiedIndex] = useState(null);
+
+  useEffect(() => {
+    if (userInfo?.keys?.edges) {
+      setApiKeys(userInfo.keys.edges.map(edge => edge.node));
+    }
+  }, [userInfo]);
+
+  if (!apiKeys.length) {
+    return null;
+  }
+
+  const handleCopyClick = (prefix, index) => {
+    navigator.clipboard.writeText(prefix);
+    setCopiedIndex(index);
+    setTimeout(() => setCopiedIndex(null), 2000);
+  };
+
+  const formatDate = (dateString) => {
+    return new Date(dateString).toLocaleDateString();
+  };
+
+  return (
+    <Stack spacing={6}>
+      <Box>
+        <TitleText typography="small" marginBottom={4}>
+          {t('dataAPI.title')}
+        </TitleText>
+        <BodyText typography="small" color="#464A51">
+          {t('dataAPI.description')}
+        </BodyText>
+      </Box>
+
+      <Grid templateColumns="1fr" gap={4}>
+        {apiKeys.map((key, index) => (
+          <GridItem
+            key={index}
+            p={4}
+            borderWidth="1px"
+            borderColor="#DEDFE0"
+            borderRadius="8px"
+          >
+            <Stack spacing={4}>
+              <Stack direction="row" justifyContent="space-between" alignItems="center">
+                <Stack direction="row" alignItems="center" spacing={2}>
+                  <BodyText fontWeight="500">
+                    {t('dataAPI.prefix')}: {key.prefix}
+                  </BodyText>
+                  <Box
+                    cursor="pointer"
+                    onClick={() => handleCopyClick(key.prefix, index)}
+                  >
+                    {copiedIndex === index ? (
+                      <CheckIcon width="20px" height="20px" fill="#2B8C4D" />
+                    ) : (
+                      <CopySolidIcon width="20px" height="20px" />
+                    )}
+                  </Box>
+                </Stack>
+                <Badge
+                  colorScheme={key.isActive ? "green" : "red"}
+                  borderRadius="4px"
+                  px={2}
+                >
+                  {key.isActive ? t('dataAPI.active') : t('dataAPI.inactive')}
+                </Badge>
+              </Stack>
+
+              <Grid templateColumns="repeat(3, 1fr)" gap={4}>
+                <Box>
+                  <BodyText color="#71757A" typography="small">
+                    {t('dataAPI.balance')}
+                  </BodyText>
+                  <BodyText typography="small">
+                    {key.balance || 0} credits
+                  </BodyText>
+                </Box>
+                <Box>
+                  <BodyText color="#71757A" typography="small">
+                    {t('dataAPI.created')}
+                  </BodyText>
+                  <BodyText typography="small">
+                    {formatDate(key.createdAt)}
+                  </BodyText>
+                </Box>
+                <Box>
+                  <BodyText color="#71757A" typography="small">
+                    {t('dataAPI.expires')}
+                  </BodyText>
+                  <BodyText typography="small">
+                    {key.expiresAt ? formatDate(key.expiresAt) : t('dataAPI.never')}
+                  </BodyText>
+                </Box>
+              </Grid>
+            </Stack>
+          </GridItem>
+        ))}
+      </Grid>
+    </Stack>
+  );
+} 

--- a/next/components/organisms/componentsUserPage/index.js
+++ b/next/components/organisms/componentsUserPage/index.js
@@ -4,6 +4,7 @@ import NewPassword from "./NewPassword";
 import PlansAndPayment from "./PlansAndPayment";
 import BigQuery from "./BigQuery";
 import Accesses from "./Accesses";
+import DataAPI from "./DataAPI";
 
 export {
   ProfileConfiguration,
@@ -11,5 +12,6 @@ export {
   NewPassword,
   PlansAndPayment,
   BigQuery,
-  Accesses
+  Accesses,
+  DataAPI
 }

--- a/next/pages/api/dataAPI/getDataAPIEndpointCategories.js
+++ b/next/pages/api/dataAPI/getDataAPIEndpointCategories.js
@@ -1,0 +1,48 @@
+import axios from "axios";
+import { cleanGraphQLResponse } from "../../../utils";
+import { capitalize } from 'lodash';
+
+const API_URL= `${process.env.NEXT_PUBLIC_API_URL}/api/v1/graphql`
+
+async function getDataAPIEndpointCategories(locale='pt') {
+  try {
+    const res = await axios({
+      url: API_URL,
+      method: "POST",
+      data: {
+        query: `
+        query {
+          allEndpointcategory {
+            edges {
+              node {
+                _id
+                slug
+                name${capitalize(locale)}
+                description${capitalize(locale)}
+                createdAt
+                updatedAt
+              }
+            }
+          }
+        }
+        `,
+        variables: null
+      }
+    })
+    const data = res.data
+    return data
+  } catch (error) {
+    console.error(error)
+    return "err"
+  }
+}
+
+export default async function handler(req, res) {
+  const { locale } = req.query;
+  const result = await getDataAPIEndpointCategories(locale);
+
+  if(result.errors) return res.status(500).json({error: result.errors, success: false})
+  if(result === "err") return res.status(500).json({error: "err", success: false})
+
+  return res.status(200).json({resource: cleanGraphQLResponse(result?.data?.allEndpointcategory?.edges.map((res) => res?.node)), success: true})
+}

--- a/next/pages/api/dataAPI/getDataAPIEndpoints.js
+++ b/next/pages/api/dataAPI/getDataAPIEndpoints.js
@@ -1,0 +1,85 @@
+import axios from "axios";
+import { cleanGraphQLResponse } from "../../../utils";
+import { capitalize } from 'lodash';
+
+const API_URL= `${process.env.NEXT_PUBLIC_API_URL}/api/v1/graphql`
+
+async function getDataAPIEndpoints(locale='pt') {
+  try {
+    const res = await axios({
+      url: API_URL,
+      method: "POST",
+      data: {
+        query: `
+        query {
+          allEndpoint {
+            edges {
+              node {
+                _id
+                slug
+                name${capitalize(locale)}
+                description${capitalize(locale)}
+                createdAt
+                updatedAt
+                isActive
+                isDeprecated
+                parameters {
+                  edges {
+                    node {
+                      _id
+                      name${capitalize(locale)}
+                      description${capitalize(locale)}
+                      type {
+                        name
+                      }
+                      required
+                    }
+                  }
+                }
+                pricingTiers {
+                  edges {
+                    node {
+                      _id
+                      minRequests
+                      maxRequests
+                      pricePerRequest
+                      currency {
+                        slug
+                        name${capitalize(locale)}
+                      }
+                    }
+                  }
+                }
+                category {
+                  _id
+                  slug
+                  name${capitalize(locale)}
+                  description${capitalize(locale)}
+                  createdAt
+                  updatedAt
+                }
+              }
+            }
+          }
+        }
+        `,
+        variables: null
+      }
+    })
+    const data = res.data
+    return data
+  } catch (error) {
+    console.error(error)
+    return "err"
+  }
+}
+
+export default async function handler(req, res) {
+  const { locale } = req.query;
+  const result = await getDataAPIEndpoints(locale);
+
+  if(result.errors) return res.status(500).json({error: result.errors, success: false})
+  if(result === "err") return res.status(500).json({error: "err", success: false})
+
+  return res.status(200).json({resource: cleanGraphQLResponse(result?.data?.allEndpoint?.edges.map((res) => res?.node)), success: true})
+}

--- a/next/pages/api/dataAPI/getDataAPIEndpoints.js
+++ b/next/pages/api/dataAPI/getDataAPIEndpoints.js
@@ -32,7 +32,7 @@ async function getDataAPIEndpoints(locale='pt') {
                       type {
                         name
                       }
-                      required
+                      isRequired
                     }
                   }
                 }

--- a/next/pages/api/stripe/createApiCreditPayment.js
+++ b/next/pages/api/stripe/createApiCreditPayment.js
@@ -1,0 +1,36 @@
+import axios from "axios";
+
+const API_URL = `${process.env.NEXT_PUBLIC_API_URL}/api/v1/graphql`;
+
+export default async function handler(req, res) {
+  const { amount, apiKey } = req.body;
+  const token = req.cookies.token;
+
+  try {
+    const response = await axios({
+      url: API_URL,
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`
+      },
+      data: {
+        query: `
+          mutation {
+            createApiCreditPaymentIntent(
+              amount: ${amount},
+              apiKey: "${apiKey}"
+            ) {
+              clientSecret
+            }
+          }
+        `
+      }
+    });
+
+    res.status(200).json({
+      clientSecret: response.data.data.createApiCreditPaymentIntent.clientSecret
+    });
+  } catch (error) {
+    res.status(500).json({ error: "Failed to create payment intent" });
+  }
+} 

--- a/next/pages/api/user/getUser.js
+++ b/next/pages/api/user/getUser.js
@@ -62,6 +62,7 @@ async function getUser(id, token) {
                   keys {
                     edges {
                       node {
+                        name
                         prefix
                         hash
                         isActive

--- a/next/pages/api/user/getUser.js
+++ b/next/pages/api/user/getUser.js
@@ -62,13 +62,15 @@ async function getUser(id, token) {
                   keys {
                     edges {
                       node {
+                        id
                         name
-                        prefix
                         hash
+                        prefix
                         isActive
                         balance
-                        createdAt
                         expiresAt
+                        createdAt
+                        updatedAt
                       }
                     }
                   }

--- a/next/pages/api/user/getUser.js
+++ b/next/pages/api/user/getUser.js
@@ -59,6 +59,18 @@ async function getUser(id, token) {
                       }
                     }
                   }
+                  keys {
+                    edges {
+                      node {
+                        prefix
+                        hash
+                        isActive
+                        balance
+                        createdAt
+                        expiresAt
+                      }
+                    }
+                  }
                 }
               }
             }

--- a/next/pages/data-api-docs/index.js
+++ b/next/pages/data-api-docs/index.js
@@ -1,0 +1,350 @@
+import { Box, Grid, GridItem, VStack, Text, Accordion, AccordionItem, AccordionButton, AccordionPanel, Code } from "@chakra-ui/react";
+import { useTranslation } from 'next-i18next';
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import { MainPageTemplate } from "../../components/templates/main";
+import { useState, useEffect } from 'react';
+import { capitalize } from 'lodash';
+import { useRouter } from 'next/router';
+import Link from 'next/link';
+
+export async function getStaticProps({ locale }) {
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['common', 'dataAPI'])),
+    },
+    revalidate: 60,
+  };
+}
+
+export default function DataAPIDocs() {
+  const { locale } = useRouter();
+  const { t } = useTranslation('dataAPI');
+  const [selectedEndpoint, setSelectedEndpoint] = useState(null);
+  const [endpointDetails, setEndpointDetails] = useState(null);
+  const [categories, setCategories] = useState([]);
+  const [endpoints, setEndpoints] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [selectedSection, setSelectedSection] = useState('overview');
+
+  useEffect(() => {
+    async function fetchData() {
+      try {
+        console.log('Fetching data for locale:', locale);
+        
+        const [categoriesRes, endpointsRes] = await Promise.all([
+          fetch(`/api/dataAPI/getDataAPIEndpointCategories?locale=${locale}`, { method: "GET" }),
+          fetch(`/api/dataAPI/getDataAPIEndpoints?locale=${locale}`, { method: "GET" })
+        ]);
+
+        const [categoriesData, endpointsData] = await Promise.all([
+          categoriesRes.json(),
+          endpointsRes.json()
+        ]);
+
+        console.log('Categories API response:', categoriesData);
+        console.log('Endpoints API response:', endpointsData);
+
+        const processedCategories = Object.values(categoriesData?.resource || {});
+        const processedEndpoints = Object.values(endpointsData?.resource || {});
+
+        console.log('Processed categories:', processedCategories);
+        console.log('Processed endpoints:', processedEndpoints);
+
+        setCategories(processedCategories);
+        setEndpoints(processedEndpoints);
+      } catch (error) {
+        console.error('Error fetching data:', error);
+        setCategories([]);
+        setEndpoints([]);
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    fetchData();
+  }, [locale]);
+
+  useEffect(() => {
+    console.log('Current categories:', categories);
+    console.log('Current endpoints:', endpoints);
+  }, [categories, endpoints]);
+
+  useEffect(() => {
+    if (selectedEndpoint && endpoints.length > 0) {
+      const selected = endpoints.find(endpoint => endpoint._id === selectedEndpoint);
+      setEndpointDetails(selected);
+    }
+  }, [selectedEndpoint, endpoints]);
+
+  return (
+    <MainPageTemplate>
+      <Grid
+        templateColumns={{ base: "1fr", md: "250px 1fr" }}
+        gap={8}
+        width="100%"
+        maxWidth="1200px"
+        margin="0 auto"
+        padding="24px"
+      >
+        {/* Left Sidebar */}
+        <GridItem>
+          <VStack align="stretch" spacing={6} position="sticky" top="24px">
+            <Box>
+              <Text fontWeight="bold" fontSize="xl" mb={4}>
+                {t('gettingStarted.title')}
+              </Text>
+              <VStack align="stretch" pl={4} mb={6}>
+                <Text 
+                  cursor="pointer" 
+                  _hover={{ color: "blue.500" }}
+                  color={!selectedEndpoint && selectedSection === 'overview' ? "blue.500" : "inherit"}
+                  onClick={() => {
+                    setSelectedEndpoint(null);
+                    setSelectedSection('overview');
+                  }}
+                >
+                  {t('overview.title')}
+                </Text>
+                <Text 
+                  cursor="pointer" 
+                  _hover={{ color: "blue.500" }}
+                  color={!selectedEndpoint && selectedSection === 'authentication' ? "blue.500" : "inherit"}
+                  onClick={() => {
+                    setSelectedEndpoint(null);
+                    setSelectedSection('authentication');
+                  }}
+                >
+                  {t('authentication.title')}
+                </Text>
+                <Text 
+                  cursor="pointer" 
+                  _hover={{ color: "blue.500" }}
+                  color={!selectedEndpoint && selectedSection === 'pricing' ? "blue.500" : "inherit"}
+                  onClick={() => {
+                    setSelectedEndpoint(null);
+                    setSelectedSection('pricing');
+                  }}
+                >
+                  {t('pricing.title')}
+                </Text>
+              </VStack>
+            </Box>
+
+            <Box>
+              <Text fontWeight="bold" fontSize="xl" mb={4}>
+                {t('endpoints.title')}
+              </Text>
+              <VStack align="stretch">
+                {categories.map((category) => (
+                  <Box key={category._id}>
+                    <Text fontWeight="semibold" mb={2}>
+                      {category[`name${capitalize(locale)}`] || category.name}
+                    </Text>
+                    <VStack align="stretch" pl={4} mb={4}>
+                      {endpoints
+                        .filter(endpoint => endpoint.category?._id === category._id && endpoint.isActive)
+                        .map(endpoint => (
+                          <Text
+                            key={endpoint._id}
+                            cursor="pointer"
+                            color={selectedEndpoint === endpoint._id ? "blue.500" : "inherit"}
+                            _hover={{ color: "blue.500" }}
+                            onClick={() => setSelectedEndpoint(endpoint._id)}
+                          >
+                            {endpoint[`name${capitalize(locale)}`] || endpoint.name}
+                          </Text>
+                        ))}
+                    </VStack>
+                  </Box>
+                ))}
+              </VStack>
+            </Box>
+          </VStack>
+        </GridItem>
+
+        {/* Main Content */}
+        <GridItem>
+          {selectedEndpoint ? (
+            endpointDetails && (
+              <VStack align="stretch" spacing={6}>
+                <Text fontSize="2xl" fontWeight="bold">
+                  {endpointDetails[`name${capitalize(locale)}`] || endpointDetails.name}
+                </Text>
+                
+                {/* Status Indicators */}
+                <Box>
+                  {endpointDetails.isDeprecated && (
+                    <Text color="red.500" fontWeight="semibold" mb={2}>
+                      ⚠️ {t('endpoints.deprecated')}
+                    </Text>
+                  )}
+                  {!endpointDetails.isActive && (
+                    <Text color="orange.500" fontWeight="semibold" mb={2}>
+                      ⚠️ {t('endpoints.inactive')}
+                    </Text>
+                  )}
+                </Box>
+
+                {/* Description */}
+                <Box>
+                  <Text fontWeight="bold" mb={2}>{t('endpoints.description')}</Text>
+                  <Text>{endpointDetails[`description${capitalize(locale)}`] || endpointDetails.description}</Text>
+                </Box>
+                
+                {/* Endpoint URL */}
+                <Box>
+                  <Text fontWeight="bold" mb={2}>{t('endpoints.endpointURL')}</Text>
+                  <Code p={4} borderRadius="md" display="block">
+                    https://api.basedosdados.org/data?category={endpointDetails.category.slug}&endpoint={endpointDetails.slug}&parameters={"<PARAMETER1:VALUE1,PARAMETER2:VALUE2>"}&key={"<API_KEY>"}
+                  </Code>
+                </Box>
+
+                {/* Parameters */}
+                {endpointDetails.parameters && Object.keys(endpointDetails.parameters).length > 0 && (
+                  <Box>
+                    <Text fontWeight="bold" fontSize="lg" mb={4}>{t('endpoints.parameters')}</Text>
+                    <Grid templateColumns="repeat(auto-fit, minmax(300px, 1fr))" gap={4}>
+                      {Object.values(endpointDetails.parameters).map((param) => (
+                        <Box 
+                          key={param._id} 
+                          p={4} 
+                          borderWidth={1} 
+                          borderRadius="md"
+                          backgroundColor="gray.50"
+                        >
+                          <Text fontWeight="semibold" color="blue.600">
+                            {param[`name${capitalize(locale)}`] || param.name}
+                            {param.required && <Text as="span" color="red.500">*</Text>}
+                          </Text>
+                          <Text fontSize="sm" color="gray.600" mb={2}>
+                            {param.type?.name}
+                          </Text>
+                          <Text>{param[`description${capitalize(locale)}`] || param.description}</Text>
+                        </Box>
+                      ))}
+                    </Grid>
+                  </Box>
+                )}
+
+                {/* Pricing Tiers */}
+                {endpointDetails.pricingTiers && Object.keys(endpointDetails.pricingTiers).length > 0 && (
+                  <Box>
+                    <Text fontWeight="bold" fontSize="lg" mb={4}>{t('endpoints.pricingTiers')}</Text>
+                    <Grid templateColumns="repeat(auto-fit, minmax(250px, 1fr))" gap={4}>
+                      {Object.values(endpointDetails.pricingTiers).map((tier) => (
+                        <Box 
+                          key={tier._id}
+                          p={4}
+                          borderWidth={1}
+                          borderRadius="md"
+                          backgroundColor="blue.50"
+                        >
+                          <Text fontWeight="semibold" mb={2}>
+                            {tier.minRequests} - {tier.maxRequests || '∞'} {t('endpoints.requests')}
+                          </Text>
+                          <Text>
+                            {tier.pricePerRequest} {tier.currency?.[`name${capitalize(locale)}`] || tier.currency?.name} / {t('endpoints.request')}
+                          </Text>
+                        </Box>
+                      ))}
+                    </Grid>
+                  </Box>
+                )}
+
+                {/* Last Updated */}
+                <Text fontSize="sm" color="gray.600" mt={4}>
+                  {t('endpoints.lastUpdated')}: {new Date(endpointDetails.updatedAt).toLocaleDateString()}
+                </Text>
+              </VStack>
+            )
+          ) : (
+            <VStack align="stretch" spacing={6}>
+              {selectedSection === 'overview' ? (
+                <>
+                  <Box
+                    p={4}
+                    mb={6}
+                    bg="yellow.100"
+                    borderRadius="md"
+                    borderLeft="4px solid"
+                    borderColor="yellow.400"
+                  >
+                    <Text fontWeight="bold" mb={2}>
+                      {t('overview.earlyRelease')} 🚧
+                    </Text>
+                    <Text>
+                      {t('overview.earlyReleaseDescription')}
+                    </Text>
+                  </Box>
+                  <Text fontSize="2xl" fontWeight="bold">
+                    {t('overview.title')}
+                  </Text>
+                  <Text>
+                    {t('overview.welcome')}
+                  </Text>
+                  <Text>
+                    {t('overview.description')}
+                  </Text>
+                  <Text>
+                    {t('overview.descriptionPricing')}
+                  </Text>
+                  <Box>
+                    <Text fontWeight="bold" mb={2}>{t('overview.baseURL')}</Text>
+                    <Code p={4} borderRadius="md" display="block">
+                      api.basedosdados.org/data
+                    </Code>
+                  </Box>
+                </>
+              ) : selectedSection === 'authentication' ? (
+                <>
+                  <Text fontSize="2xl" fontWeight="bold">
+                    {t('authentication.title')}
+                  </Text>
+                  <Text>
+                    {t('authentication.description')}
+                  </Text>
+                  <Box>
+                    <Text fontWeight="bold" mb={2}>{t('authentication.apiKey')}</Text>
+                    <Text mb={4}>
+                      {t('authentication.getApiKeyBy')}
+                    </Text>
+                    <VStack align="stretch" spacing={2} pl={4}>
+                      <Text>1. {t('authentication.getApiKeyBy1')}</Text>
+                      <Text>2. {t('authentication.getApiKeyBy2Contactus')} <Link href="/contact" fontWeight="700">{t('authentication.getApiKeyBy2ContactusLink')}</Link>.</Text>
+                    </VStack>
+                    <br></br>
+                    <Text>
+                      {t('authentication.weWillAnswerYou')}
+                    </Text>
+                  </Box>
+                </>
+              ) : (
+                <>
+                  <Text fontSize="2xl" fontWeight="bold">
+                    {t('pricing.title')}
+                  </Text>
+                  <Text>
+                    {t('pricing.description')}
+                  </Text>
+                  <Box>
+                    <Text mb={4}>
+                      {t('pricing.addCredits')}
+                    </Text>
+                    <VStack align="stretch" spacing={2} pl={4}>
+                      <Text>{t('pricing.step1')}</Text>
+                      <Text>{t('pricing.step2')}</Text>
+                      <Text>{t('pricing.step3')}</Text>
+                    </VStack>
+                    <Text mt={4} fontStyle="italic">
+                      {t('pricing.note')}
+                    </Text>
+                  </Box>
+                </>
+              )}
+            </VStack>
+          )}
+        </GridItem>
+      </Grid>
+    </MainPageTemplate>
+  );
+} 

--- a/next/pages/data-api-docs/index.js
+++ b/next/pages/data-api-docs/index.js
@@ -319,7 +319,11 @@ export default function DataAPIDocs() {
                     </Text>
                     <VStack align="stretch" spacing={2} pl={4}>
                       <Text>1. {t('authentication.getApiKeyBy1')}</Text>
-                      <Text>2. {t('authentication.getApiKeyBy2Contactus')} <Link href="/contact" fontWeight="700">{t('authentication.getApiKeyBy2ContactusLink')}</Link>.</Text>
+                      <Text>2. {t('authentication.getApiKeyBy2Contactus')} <Link href="/contact">
+                        <Text as="span" fontWeight="700" cursor="pointer">
+                          {t('authentication.getApiKeyBy2ContactusLink')}
+                        </Text>
+                      </Link>.</Text>
                     </VStack>
                     <br></br>
                     <Text>

--- a/next/pages/data-api-docs/index.js
+++ b/next/pages/data-api-docs/index.js
@@ -10,7 +10,7 @@ import Link from 'next/link';
 export async function getStaticProps({ locale }) {
   return {
     props: {
-      ...(await serverSideTranslations(locale, ['common', 'dataAPI'])),
+      ...(await serverSideTranslations(locale, ['common', 'menu', 'dataAPI'])),
     },
     revalidate: 60,
   };
@@ -78,6 +78,15 @@ export default function DataAPIDocs() {
 
   return (
     <MainPageTemplate>
+      <Text
+        fontSize="4xl"
+        fontWeight="bold"
+        textAlign="center"
+        mb={8}
+        mt={4}
+      >
+        {t('title')}
+      </Text>
       <Grid
         templateColumns={{ base: "1fr", md: "250px 1fr" }}
         gap={8}

--- a/next/pages/data-api-docs/index.js
+++ b/next/pages/data-api-docs/index.js
@@ -297,6 +297,9 @@ export default function DataAPIDocs() {
                   <Text>
                     {t('overview.descriptionPricing')}
                   </Text>
+                  <Text>
+                    {t('overview.needForKeys')}
+                  </Text>
                   <Box>
                     <Text fontWeight="bold" mb={2}>{t('overview.baseURL')}</Text>
                     <Code p={4} borderRadius="md" display="block">
@@ -309,11 +312,7 @@ export default function DataAPIDocs() {
                   <Text fontSize="2xl" fontWeight="bold">
                     {t('authentication.title')}
                   </Text>
-                  <Text>
-                    {t('authentication.description')}
-                  </Text>
                   <Box>
-                    <Text fontWeight="bold" mb={2}>{t('authentication.apiKey')}</Text>
                     <Text mb={4}>
                       {t('authentication.getApiKeyBy')}
                     </Text>
@@ -348,7 +347,8 @@ export default function DataAPIDocs() {
                       <Text>{t('pricing.step2')}</Text>
                       <Text>{t('pricing.step3')}</Text>
                     </VStack>
-                    <Text mt={4} fontStyle="italic">
+                    <br></br>
+                    <Text>
                       {t('pricing.note')}
                     </Text>
                   </Box>

--- a/next/pages/data-api-docs/index.js
+++ b/next/pages/data-api-docs/index.js
@@ -223,7 +223,7 @@ export default function DataAPIDocs() {
                         >
                           <Text fontWeight="semibold" color="blue.600">
                             {param[`name${capitalize(locale)}`] || param.name}
-                            {param.required && <Text as="span" color="red.500">*</Text>}
+                            {param.isRequired && <Text as="span" color="red.500">*</Text>}
                           </Text>
                           <Text fontSize="sm" color="gray.600" mb={2}>
                             {param.type?.name}

--- a/next/pages/user/[username].js
+++ b/next/pages/user/[username].js
@@ -20,7 +20,8 @@ import {
   NewPassword,
   PlansAndPayment,
   BigQuery,
-  Accesses
+  Accesses,
+  DataAPI
 } from "../../components/organisms/componentsUserPage";
 
 export async function getServerSideProps(context) {
@@ -129,14 +130,16 @@ export default function UserPage({ getUser, isUserPro, haveInterprisePlan }) {
   }, [getUser])
 
   const choices = [
-    {bar: t('username.publicProfile'), title: t('username.publicProfile'), value: "profile", index: 0},
-    {bar: t('username.account'), title: t('username.account'), value: "account", index: 1},
-    {bar: t('username.changePassword'), title: t('username.changePassword'), value: "new_password", index: 2},
-    {bar: t('username.plansAndPayment'), title: t('username.plansAndPayment'), value: "plans_and_payment", index: 3},
-    isUserPro && {bar: "BigQuery", title: "BigQuery", value: "big_query", index: 4},
-    haveInterprisePlan && {bar: t('username.access'), title: t('username.access'), value: "accesses", index: 5},
-    userInfo?.keys?.edges?.length > 0 && {bar: "Data API", title: "Data API", value: "data_api", index: 6}
-  ].filter(Boolean)
+    {bar: t('username.publicProfile'), title: t('username.publicProfile'), value: "profile"},
+    {bar: t('username.account'), title: t('username.account'), value: "account"},
+    {bar: t('username.changePassword'), title: t('username.changePassword'), value: "new_password"},
+    {bar: t('username.plansAndPayment'), title: t('username.plansAndPayment'), value: "plans_and_payment"},
+    isUserPro && {bar: "BigQuery", title: "BigQuery", value: "big_query"},
+    haveInterprisePlan && {bar: t('username.access'), title: t('username.access'), value: "accesses"},
+    userInfo?.keys?.edges?.length > 0 && {bar: t('dataAPI.title'), title: t('dataAPI.title'), value: "data_api"}
+  ]
+    .filter(Boolean)
+    .map((choice, index) => ({ ...choice, index }))
 
   useEffect(() => {
     const key = Object.keys(query)
@@ -230,13 +233,13 @@ export default function UserPage({ getUser, isUserPro, haveInterprisePlan }) {
           </TitleText>
           <Divider marginBottom="24px !important" borderColor="#DEDFE0"/>
 
-          {sectionSelected === 0 && <ProfileConfiguration userInfo={userInfo}/>}
-          {sectionSelected === 1 && <Account userInfo={userInfo}/>}
-          {sectionSelected === 2 && <NewPassword userInfo={userInfo}/>}
-          {sectionSelected === 3 && <PlansAndPayment userData={userInfo}/>}
-          {sectionSelected === 4 && <BigQuery userInfo={userInfo}/>}
-          {sectionSelected === 5 && <Accesses userInfo={userInfo}/>}
-          {sectionSelected === 6 && <DataAPI userInfo={userInfo}/>}
+          {choices[sectionSelected].value === "profile" && <ProfileConfiguration userInfo={userInfo}/>}
+          {choices[sectionSelected].value === "account" && <Account userInfo={userInfo}/>}
+          {choices[sectionSelected].value === "new_password" && <NewPassword userInfo={userInfo}/>}
+          {choices[sectionSelected].value === "plans_and_payment" && <PlansAndPayment userData={userInfo}/>}
+          {choices[sectionSelected].value === "big_query" && <BigQuery userInfo={userInfo}/>}
+          {choices[sectionSelected].value === "accesses" && <Accesses userInfo={userInfo}/>}
+          {choices[sectionSelected].value === "data_api" && <DataAPI userInfo={userInfo}/>}
         </Stack>
       </Stack>
     </MainPageTemplate>

--- a/next/pages/user/[username].js
+++ b/next/pages/user/[username].js
@@ -134,7 +134,8 @@ export default function UserPage({ getUser, isUserPro, haveInterprisePlan }) {
     {bar: t('username.changePassword'), title: t('username.changePassword'), value: "new_password", index: 2},
     {bar: t('username.plansAndPayment'), title: t('username.plansAndPayment'), value: "plans_and_payment", index: 3},
     isUserPro && {bar: "BigQuery", title: "BigQuery", value: "big_query", index: 4},
-    haveInterprisePlan && {bar: t('username.access'), title: t('username.access'), value: "accesses", index: 5}
+    haveInterprisePlan && {bar: t('username.access'), title: t('username.access'), value: "accesses", index: 5},
+    userInfo?.keys?.edges?.length > 0 && {bar: "Data API", title: "Data API", value: "data_api", index: 6}
   ].filter(Boolean)
 
   useEffect(() => {
@@ -235,6 +236,7 @@ export default function UserPage({ getUser, isUserPro, haveInterprisePlan }) {
           {sectionSelected === 3 && <PlansAndPayment userData={userInfo}/>}
           {sectionSelected === 4 && <BigQuery userInfo={userInfo}/>}
           {sectionSelected === 5 && <Accesses userInfo={userInfo}/>}
+          {sectionSelected === 6 && <DataAPI userInfo={userInfo}/>}
         </Stack>
       </Stack>
     </MainPageTemplate>

--- a/next/pages/user/[username].js
+++ b/next/pages/user/[username].js
@@ -119,7 +119,7 @@ export default function UserPage({ getUser, isUserPro, haveInterprisePlan }) {
   const router = useRouter()
   const { query } = router
   const [userInfo, setUserInfo] = useState({})
-  const [sectionSelected, setSectionSelected] = useState(0)
+  const [sectionSelected, setSectionSelected] = useState("profile")
 
   if (!ready) return null
 
@@ -130,16 +130,14 @@ export default function UserPage({ getUser, isUserPro, haveInterprisePlan }) {
   }, [getUser])
 
   const choices = [
-    {bar: t('username.publicProfile'), title: t('username.publicProfile'), value: "profile"},
-    {bar: t('username.account'), title: t('username.account'), value: "account"},
-    {bar: t('username.changePassword'), title: t('username.changePassword'), value: "new_password"},
-    {bar: t('username.plansAndPayment'), title: t('username.plansAndPayment'), value: "plans_and_payment"},
-    isUserPro && {bar: "BigQuery", title: "BigQuery", value: "big_query"},
-    haveInterprisePlan && {bar: t('username.access'), title: t('username.access'), value: "accesses"},
-    userInfo?.keys?.edges?.length > 0 && {bar: t('dataAPI.title'), title: t('dataAPI.title'), value: "data_api"}
-  ]
-    .filter(Boolean)
-    .map((choice, index) => ({ ...choice, index }))
+    {bar: t('username.publicProfile'), title: t('username.publicProfile'), value: "profile", id: "profile"},
+    {bar: t('username.account'), title: t('username.account'), value: "account", id: "account"},
+    {bar: t('username.changePassword'), title: t('username.changePassword'), value: "new_password", id: "password"},
+    {bar: t('username.plansAndPayment'), title: t('username.plansAndPayment'), value: "plans_and_payment", id: "plans"},
+    isUserPro && {bar: "BigQuery", title: "BigQuery", value: "big_query", id: "bigquery"},
+    haveInterprisePlan && {bar: t('username.access'), title: t('username.access'), value: "accesses", id: "accesses"},
+    userInfo?.keys?.edges?.length > 0 && {bar: t('dataAPI.title'), title: t('dataAPI.title'), value: "data_api", id: "dataapi"}
+  ].filter(Boolean)
 
   useEffect(() => {
     const key = Object.keys(query)
@@ -150,7 +148,7 @@ export default function UserPage({ getUser, isUserPro, haveInterprisePlan }) {
 
     for (const elements of choices) {
       if (elements && elements.value === key[0]) {
-        setSectionSelected(elements.index)
+        setSectionSelected(elements.id)
       }
     }
   }, [query])
@@ -182,30 +180,30 @@ export default function UserPage({ getUser, isUserPro, haveInterprisePlan }) {
           </TitleText>
 
           <Stack width="267px" spacing={0}>
-            {choices.map((section, index) => (
+            {choices.map((section) => (
               <Stack
-                key={index}
+                key={section.id}
                 flexDirection="row"
                 alignItems="center"
                 paddingRight="5px"
                 spacing={0}
                 gap="4px"
                 cursor="pointer"
-                pointerEvents={sectionSelected === index ? "none" : "default"}
+                pointerEvents={sectionSelected === section.id ? "none" : "default"}
               >
                 <Box 
                   width="3px"
                   height="24px"
-                  backgroundColor={sectionSelected === index && "#2B8C4D"}
+                  backgroundColor={sectionSelected === section.id && "#2B8C4D"}
                   borderRadius="10px"
                 />
                 <LabelText
                   typography="small"
                   width="100%"
-                  color={sectionSelected === index ? "#2B8C4D" : "#71757A"}
-                  backgroundColor={sectionSelected === index && "#F7F7F7"}
+                  color={sectionSelected === section.id ? "#2B8C4D" : "#71757A"}
+                  backgroundColor={sectionSelected === section.id && "#F7F7F7"}
                   _hover={{
-                    backgroundColor:sectionSelected === index ? "#F7F7F7" :"#EEEEEE",
+                    backgroundColor:sectionSelected === section.id ? "#F7F7F7" :"#EEEEEE",
                   }}
                   borderRadius="8px"
                   padding="6px 8px"
@@ -229,17 +227,17 @@ export default function UserPage({ getUser, isUserPro, haveInterprisePlan }) {
           spacing={0}
         >
           <TitleText marginBottom="8px">
-            {choices[sectionSelected].title}
+            {choices.find(choice => choice.id === sectionSelected)?.title}
           </TitleText>
           <Divider marginBottom="24px !important" borderColor="#DEDFE0"/>
 
-          {choices[sectionSelected].value === "profile" && <ProfileConfiguration userInfo={userInfo}/>}
-          {choices[sectionSelected].value === "account" && <Account userInfo={userInfo}/>}
-          {choices[sectionSelected].value === "new_password" && <NewPassword userInfo={userInfo}/>}
-          {choices[sectionSelected].value === "plans_and_payment" && <PlansAndPayment userData={userInfo}/>}
-          {choices[sectionSelected].value === "big_query" && <BigQuery userInfo={userInfo}/>}
-          {choices[sectionSelected].value === "accesses" && <Accesses userInfo={userInfo}/>}
-          {choices[sectionSelected].value === "data_api" && <DataAPI userInfo={userInfo}/>}
+          {sectionSelected === "profile" && <ProfileConfiguration userInfo={userInfo}/>}
+          {sectionSelected === "account" && <Account userInfo={userInfo}/>}
+          {sectionSelected === "password" && <NewPassword userInfo={userInfo}/>}
+          {sectionSelected === "plans" && <PlansAndPayment userData={userInfo}/>}
+          {sectionSelected === "bigquery" && <BigQuery userInfo={userInfo}/>}
+          {sectionSelected === "accesses" && <Accesses userInfo={userInfo}/>}
+          {sectionSelected === "dataapi" && <DataAPI userInfo={userInfo}/>}
         </Stack>
       </Stack>
     </MainPageTemplate>

--- a/next/public/locales/en/dataAPI.json
+++ b/next/public/locales/en/dataAPI.json
@@ -13,9 +13,9 @@
       "title": "Authentication",
       "description": "Learn how to authenticate with the Data API",
       "apiKey": "API Key",
-      "getApiKeyBy": "To access the API, you'll need an API key. You can get one by:",
-      "getApiKeyBy1": "Creating an account on DB.",
-      "getApiKeyBy2Contactus": "Contacting us to request a key",
+      "getApiKeyBy": "To access the API, you'll need an API key. To get one:",
+      "getApiKeyBy1": "Create an account on DB.",
+      "getApiKeyBy2Contactus": "Contact us to request a key",
       "getApiKeyBy2ContactusLink": "here",
       "weWillAnswerYou": "We will answer you as soon as possible."
     },
@@ -39,9 +39,9 @@
         "title": "Pricing",
         "description": "To use the Data API, you'll need to add credits to your API key.",
         "addCredits": "To add credits to your API key:",
-        "step1": "1. Visit our payment portal",
-        "step2": "2. Select the amount of credits you want to add",
-        "step3": "3. Complete the payment through our secure Stripe payment system",
+        "step1": "1. Browse to your user area in the Data API section.",
+        "step2": "2. For your API key, click on the 'Add Credits' button.",
+        "step3": "3. Select the amount of credits you want to add and complete the payment.",
         "note": "Credits will be immediately available after successful payment."
     }
   }

--- a/next/public/locales/en/dataAPI.json
+++ b/next/public/locales/en/dataAPI.json
@@ -3,16 +3,15 @@
     "overview": {
         "title": "Overview",
         "welcome": "Welcome to the Data API documentation.",
-        "description": "With the API, you can access our data in a programmatic way, without depending on BigQuery.",
+        "description": "With the API, you can access our data in a programmatic way via endpoints, without depending on BigQuery.",
         "descriptionPricing": "Each endpoint has a different pricing tier, depending on the number of requests accumulated in the month.",
+        "needForKeys": "To use the API, you'll need an API key. The instructions on how to get one are available in the authentication section.",
         "baseURL": "Base URL",
         "earlyRelease": "Alpha Version",
         "earlyReleaseDescription": "This is an early release version of our Data API. We are currently testing and improving our services. Some of the features may be unstable. More endpoints, features, and detailed documentation will be released in the future."
     },
     "authentication": {
       "title": "Authentication",
-      "description": "Learn how to authenticate with the Data API",
-      "apiKey": "API Key",
       "getApiKeyBy": "To access the API, you'll need an API key. To get one:",
       "getApiKeyBy1": "Create an account on DB.",
       "getApiKeyBy2Contactus": "Contact us to request a key",

--- a/next/public/locales/en/user.json
+++ b/next/public/locales/en/user.json
@@ -475,6 +475,8 @@
         "credits": "credits",
         "reais": "reais",
         "addCredits": "Add credits",
+        "selectAmount": "Select how much you want to add",
+        "confirm": "Confirm",
         "needMoreKeys": "Need more API keys?",
         "contactUs": "Contact us",
         "weWillHelpYou": "and we'll send you a new key as soon as possible.",

--- a/next/public/locales/en/user.json
+++ b/next/public/locales/en/user.json
@@ -461,14 +461,24 @@
         "passwordRequired": "Please enter the password."
     },
     "dataAPI": {
-        "title": "Data API Keys",
+        "title": "Data API",
+        "keys": "Keys",
         "description": "Manage your Data API keys and monitor their usage.",
         "prefix": "Key Prefix",
         "active": "Active",
         "inactive": "Inactive",
+        "name": "Name",
         "balance": "Balance",
         "created": "Created",
         "expires": "Expires",
-        "never": "Never"
+        "never": "Never",
+        "credits": "credits",
+        "reais": "reais",
+        "addCredits": "Add credits",
+        "needMoreKeys": "Need more API keys?",
+        "contactUs": "Contact us",
+        "weWillHelpYou": "and we'll send you a new key as soon as possible.",
+        "earlyRelease": "Early Release",
+        "earlyReleaseDescription": "The Data API is currently in early release. Features and documentation may change as we continue to improve the service."
     }
 }

--- a/next/public/locales/en/user.json
+++ b/next/public/locales/en/user.json
@@ -459,5 +459,16 @@
         "passwordNoSpaces": "Passwords entered cannot contain spaces.",
         "passwordMismatch": "The password entered does not match the password created in the field above. Please check for typing errors and try again.",
         "passwordRequired": "Please enter the password."
+    },
+    "dataAPI": {
+        "title": "Data API Keys",
+        "description": "Manage your Data API keys and monitor their usage.",
+        "prefix": "Key Prefix",
+        "active": "Active",
+        "inactive": "Inactive",
+        "balance": "Balance",
+        "created": "Created",
+        "expires": "Expires",
+        "never": "Never"
     }
 }

--- a/next/public/locales/es/dataAPI.json
+++ b/next/public/locales/es/dataAPI.json
@@ -3,16 +3,15 @@
     "overview": {
         "title": "Visión General",
         "welcome": "Bienvenidos a la documentación de la API de Datos de la Base de los Datos.",
-        "description": "Con la API, puedes acceder a nuestros datos de forma programática, sin depender de BigQuery.",
+        "description": "Con la API, puedes acceder a nuestros datos de forma programática via endpoints, sin depender de BigQuery.",
         "descriptionPricing": "Cada endpoint tiene un diferente nivel de precio, dependiendo del número de solicitudes acumuladas en el mes.",
+        "needForKeys": "Para usar la API, necesitará una clave de API. Las instrucciones sobre cómo obtener una están disponibles en la sección de autenticación.",
         "baseURL": "URL Base",
         "earlyRelease": "Versión Alpha",
         "earlyReleaseDescription": "Esta es una versión preliminar de nuestra API de Datos. Estamos actualmente probando y mejorando nuestros servicios. Algunos recursos pueden ser inestables. Más endpoints, recursos y documentación detallada serán lanzados en el futuro."
     },
     "authentication": {
       "title": "Autenticación",
-      "description": "Aprenda como autenticar con la API de Datos de la BD",
-      "apiKey": "Clave de API",
       "getApiKeyBy": "Para acceder a la API, necesitará una clave. Para obtener una:",
       "getApiKeyBy1": "Crea una cuenta en la BD.",
       "getApiKeyBy2Contactus": "Contacta con nosotros para solicitar una clave",

--- a/next/public/locales/es/dataAPI.json
+++ b/next/public/locales/es/dataAPI.json
@@ -13,9 +13,9 @@
       "title": "Autenticación",
       "description": "Aprenda como autenticar con la API de Datos de la BD",
       "apiKey": "Clave de API",
-      "getApiKeyBy": "Para acceder a la API, necesitará una clave. Puede obtener una:",
-      "getApiKeyBy1": "Creando una cuenta en la BD.",
-      "getApiKeyBy2Contactus": "Contactando con nosotros para solicitar una clave",
+      "getApiKeyBy": "Para acceder a la API, necesitará una clave. Para obtener una:",
+      "getApiKeyBy1": "Crea una cuenta en la BD.",
+      "getApiKeyBy2Contactus": "Contacta con nosotros para solicitar una clave",
       "getApiKeyBy2ContactusLink": "aquí",
       "weWillAnswerYou": "Nos pondremos en contacto con usted lo antes posible."
     },
@@ -39,9 +39,9 @@
         "title": "Precificación",
         "description": "Para usar la API de Datos, necesitará agregar créditos a su clave de API.",
         "addCredits": "Para agregar créditos a su clave de API:",
-        "step1": "1. Visite nuestro portal de pago",
-        "step2": "2. Seleccione la cantidad de créditos que desea agregar",
-        "step3": "3. Complete el pago a través de nuestro sistema seguro de pago Stripe",
+        "step1": "1. Navegue a su área de usuario en la sección de API de Datos.",
+        "step2": "2. Para su clave de API, haga clic en el botón 'Agregar Créditos'.",
+        "step3": "3. Seleccione la cantidad de créditos que desea agregar y complete el pago.",
         "note": "Los créditos estarán disponibles inmediatamente después del pago exitoso."
     }
   }

--- a/next/public/locales/es/user.json
+++ b/next/public/locales/es/user.json
@@ -484,6 +484,8 @@
         "credits": "créditos",
         "reais": "reais",
         "addCredits": "Agregar créditos",
+        "selectAmount": "Seleccione cuánto desea agregar",
+        "confirm": "Confirmar",
         "needMoreKeys": "¿Necesita más claves de API?",
         "contactUs": "Contáctenos",
         "weWillHelpYou": "y te enviaremos una nueva clave tan pronto como sea posible.",

--- a/next/public/locales/es/user.json
+++ b/next/public/locales/es/user.json
@@ -470,14 +470,24 @@
         ]
     },
     "dataAPI": {
-        "title": "Claves de la API de Datos",
+        "title": "API de Datos",
+        "keys": "Claves",
         "description": "Gerencie sus claves de la API de Datos y supervise su uso.",
         "prefix": "Prefijo de la clave",
         "active": "Activo",
         "inactive": "Inactivo",
+        "name": "Nombre",
         "balance": "Saldo",
         "created": "Creado",
         "expires": "Expira",
-        "never": "Nunca"
+        "never": "Nunca",
+        "credits": "créditos",
+        "reais": "reais",
+        "addCredits": "Agregar créditos",
+        "needMoreKeys": "¿Necesita más claves de API?",
+        "contactUs": "Contáctenos",
+        "weWillHelpYou": "y te enviaremos una nueva clave tan pronto como sea posible.",
+        "earlyRelease": "Lanzamiento en versión alfa",
+        "earlyReleaseDescription": "La API de Datos está actualmente en lanzamiento en versión alfa. Las características y la documentación pueden cambiar a medida que continuamos mejorando el servicio."
     }
 }

--- a/next/public/locales/es/user.json
+++ b/next/public/locales/es/user.json
@@ -468,5 +468,16 @@
                 ]
             }
         ]
+    },
+    "dataAPI": {
+        "title": "Claves de la API de Datos",
+        "description": "Gerencie sus claves de la API de Datos y supervise su uso.",
+        "prefix": "Prefijo de la clave",
+        "active": "Activo",
+        "inactive": "Inactivo",
+        "balance": "Saldo",
+        "created": "Creado",
+        "expires": "Expira",
+        "never": "Nunca"
     }
 }

--- a/next/public/locales/pt/dataAPI.json
+++ b/next/public/locales/pt/dataAPI.json
@@ -13,9 +13,9 @@
       "title": "Autenticação",
       "description": "Aprenda como autenticar com a API de Dados da BD",
       "apiKey": "Chave de API",
-      "getApiKeyBy": "Para acessar a API, você precisará de uma chave. Você pode obtê-la:",
-      "getApiKeyBy1": "Criando uma conta na BD.",
-      "getApiKeyBy2Contactus": "Nos contatando para solicitar uma chave",
+      "getApiKeyBy": "Para acessar a API, você precisará de uma chave. Para obtê-la:",
+      "getApiKeyBy1": "Crie uma conta na BD.",
+      "getApiKeyBy2Contactus": "Nos contate para solicitar uma chave",
       "getApiKeyBy2ContactusLink": "aqui",
       "weWillAnswerYou": "Nós responderemos o mais breve possível."
     },
@@ -39,9 +39,9 @@
         "title": "Precificação",
         "description": "Para usar a API de Dados, você precisará adicionar créditos à sua chave de API.",
         "addCredits": "Para adicionar créditos à sua chave de API:",
-        "step1": "1. Visite nosso portal de pagamento",
-        "step2": "2. Selecione a quantidade de créditos que deseja adicionar",
-        "step3": "3. Complete o pagamento através do nosso sistema seguro de pagamento Stripe",
+        "step1": "1. Visite a área de usuário na seção de API de Dados.",
+        "step2": "2. Para sua chave de API, clique no botão 'Adicionar Créditos'.",
+        "step3": "3. Selecione a quantidade de créditos que deseja adicionar e complete o pagamento.",
         "note": "Os créditos estarão disponíveis imediatamente após o pagamento bem-sucedido."
     }
   }

--- a/next/public/locales/pt/dataAPI.json
+++ b/next/public/locales/pt/dataAPI.json
@@ -5,14 +5,13 @@
         "earlyReleaseDescription": "Esta é uma versão preliminar da API de Dados da BD. Estamos atualmente testando e melhorando nosso serviço. Alguns recursos podem ficar instáveis. Mais endpoints, recursos e documentação detalhada serão lançados no futuro.",
         "title": "Visão Geral",
         "welcome": "Bem-vindos à documentação da API de Dados da Base dos Dados.",
-        "description": "Com a API é possível acessar os nossos dados de forma programática, sem depender do BigQuery.",
+        "description": "Com a API é possível acessar os nossos dados de forma programática via endpoints, sem depender do BigQuery.",
         "descriptionPricing": "Cada endpoint tem uma faixa de preço diferente, conforme o número de requisições acumuladas no mês.",
+        "needForKeys": "Para usar a API, você precisará de uma chave de API. As instruções de como obter uma estão disponíveis na seção de autenticação.",
         "baseURL": "URL Base"
     },
     "authentication": {
       "title": "Autenticação",
-      "description": "Aprenda como autenticar com a API de Dados da BD",
-      "apiKey": "Chave de API",
       "getApiKeyBy": "Para acessar a API, você precisará de uma chave. Para obtê-la:",
       "getApiKeyBy1": "Crie uma conta na BD.",
       "getApiKeyBy2Contactus": "Nos contate para solicitar uma chave",
@@ -37,7 +36,7 @@
     },
     "pricing": {
         "title": "Precificação",
-        "description": "Para usar a API de Dados, você precisará adicionar créditos à sua chave de API.",
+        "description": "Para usar a API de Dados, você precisará adicionar créditos à cada chave de API.",
         "addCredits": "Para adicionar créditos à sua chave de API:",
         "step1": "1. Visite a área de usuário na seção de API de Dados.",
         "step2": "2. Para sua chave de API, clique no botão 'Adicionar Créditos'.",

--- a/next/public/locales/pt/user.json
+++ b/next/public/locales/pt/user.json
@@ -475,5 +475,16 @@
         "passwordNoSpaces": "As senhas inseridas não podem conter espaçamentos.",
         "passwordMismatch": "A senha inserida não coincide com a senha criada no campo acima. Por favor, verifique se não há erros de digitação e tente novamente.",
         "passwordRequired": "Por favor, insira a senha."
+    },
+    "dataAPI": {
+        "title": "Chaves da API de Dados",
+        "description": "Gerencie suas chaves da API de Dados e monitore seu uso.",
+        "prefix": "Prefixo da chave",
+        "active": "Ativo",
+        "inactive": "Inativo",
+        "balance": "Saldo",
+        "created": "Criado",
+        "expires": "Expira",
+        "never": "Nunca"
     }
 }

--- a/next/public/locales/pt/user.json
+++ b/next/public/locales/pt/user.json
@@ -491,6 +491,8 @@
         "credits": "créditos",
         "reais": "reais",
         "addCredits": "Adicionar créditos",
+        "selectAmount": "Selecione qual valor deseja adicionar",
+        "confirm": "Confirmar",
         "needMoreKeys": "Precisa de mais chaves da API?",
         "contactUs": "Nos contate",
         "weWillHelpYou": "e te enviaremos uma nova chave assim que possível.",

--- a/next/public/locales/pt/user.json
+++ b/next/public/locales/pt/user.json
@@ -477,14 +477,24 @@
         "passwordRequired": "Por favor, insira a senha."
     },
     "dataAPI": {
-        "title": "Chaves da API de Dados",
+        "title": "API de Dados",
+        "keys": "Chaves",
         "description": "Gerencie suas chaves da API de Dados e monitore seu uso.",
         "prefix": "Prefixo da chave",
         "active": "Ativo",
         "inactive": "Inativo",
+        "name": "Nome",
         "balance": "Saldo",
         "created": "Criado",
         "expires": "Expira",
-        "never": "Nunca"
+        "never": "Nunca",
+        "credits": "créditos",
+        "reais": "reais",
+        "addCredits": "Adicionar créditos",
+        "needMoreKeys": "Precisa de mais chaves da API?",
+        "contactUs": "Nos contate",
+        "weWillHelpYou": "e te enviaremos uma nova chave assim que possível.",
+        "earlyRelease": "Lançamento em versão alfa",
+        "earlyReleaseDescription": "A API de Dados está atualmente em lançamento em versão alfa. As características e a documentação podem ser alteradas à medida que continuamos melhorando o serviço."
     }
 }


### PR DESCRIPTION
### Purpose

Rescue the Data API frontend work onto a `main`-based branch before `development` is reset.

The feature was developed in Feb–May 2025 and never reached production: its commits exist only on `origin/development`, which diverged from `main` under the old workflow and is scheduled to be reset.

**Draft on purpose.** Per Git Flow this must be validated via PRs into `development` and `staging` first. Those will be opened once the branches are reset; this PR stays in draft until then and merges into `main` last.

### Description

7 commits cherry-picked with `-x` from `origin/development`, oldest→newest, original authorship preserved:

| commit | subject |
|---|---|
| `a1bb17c8` | feat: init data API docs |
| `cea0ddb8` | feat: user page for Data API keys |
| `2cea36db` | feat: data API in user area |
| `afcfcdf8` | chore: required -> isRequired |
| `6bc7322f` | chore: adjustments to authentication and pricing communication |
| `6bdeba3f` | feat: bring back user Data API page, add credits modal |
| `345b0ec8` | updates to data API page |

Adds the `/data-api-docs` page, the Data API section of the user area, the credits modal and Stripe credit-payment endpoint, and the endpoint/category API routes.

Two commits from the range were deliberately dropped:
- `e3b5ed0e` — byte-identical duplicate of `6bc7322f` (the same change was committed twice, once on the mainline and once on the feature branch).
- `8ce54ff5` — became empty; it only stripped two comments that no longer exist after the resolutions below.

### Already partly on `main`

`next/public/locales/{en,es,pt}/dataAPI.json` were already on `main` at their initial `a1bb17c8` state — they arrived via PR #1152 (`feat/accesses`). The later copy refinements in `6bc7322f` and `345b0ec8` were still missing and are included here.

### Conflict resolutions worth reviewing

- **`pages/user/[username].js`** — `main` had already migrated `sectionSelected` from array indices to string ids. The incoming index-based render block (`choices[sectionSelected].value === …`) was stale and would have broken the page, so `6bdeba3f`'s string-id version was taken, matching `main`.
- **`pages/api/user/getUser.js`** — the GraphQL field set was **unioned** rather than taken from either side. `6bdeba3f` re-added the `keys` block from scratch after a revert and dropped `name`, but its own `DataAPI.js` still renders `key.name`; taking it literally would have shipped a silently blank field. This is the one place the result differs from a literal cherry-pick and is worth a look.
- **`locales/es/user.json`** — add/add conflict against `main`'s new `survey` block; both keys kept, JSON validated.

Auth-related hunks in `[username].js` conflicted because `main` moved the token from a query parameter to a `Cookie` header. `main`'s version was kept in every case — the incoming side was the older, less safe form.

### Testing and evidence

Verified so far: all six locale JSON files parse; `DataAPI` is exported and imported correctly; relative imports in the new files resolve; no conflict markers remain. **Not yet run:** a build or any browser check. Both should happen on the `development` PR, along with an end-to-end check of the credits flow against the backend.

### Next steps

1. Hold in draft until `development` is reset.
2. Open PRs into `development` and `staging`; validate there.
3. Merge into `main` last.

Depends on the backend PR in `basedosdados/backend` — the user area needs the `keys` GraphQL field to render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
