### PR TITLE
fix(seo): embeds de conjuntos exibem nomes dos conjuntos, e não uma frase genérica

### DIFF
--- a/next/pages/_app.js
+++ b/next/pages/_app.js
@@ -48,6 +48,10 @@ function MyApp({ Component, pageProps }) {
   };
 
   const currentMeta = metaData[locale] || metaData.pt;
+  const canonicalPath = (router.asPath || "/").split(/[?#]/)[0];
+  const canonicalUrl = local
+    ? `${local}${canonicalPath === "/" ? "" : canonicalPath}`
+    : null;
   const pageOgImage =
     pageProps?.meta?.ogImage ||
     Component?.ogImage ||
@@ -68,11 +72,12 @@ function MyApp({ Component, pageProps }) {
         {/* <meta/> para não noindex ambientes de development e staging */}
 
         {pageOgImage ? (
-          <link rel="image_src" href={pageOgImage} />
+          <link rel="image_src" href={pageOgImage} key="imagesrc" />
         ) : (
           <link
             rel="image_src"
             href={`https://storage.googleapis.com/basedosdados-website/thumbnails/${locale}/general.png`}
+            key="imagesrc"
           />
         )}
 
@@ -80,28 +85,24 @@ function MyApp({ Component, pageProps }) {
         <meta name="description" content={currentMeta.description} />
         <link rel="icon" href={currentMeta.icon} />
 
-        {/* Twitter */}
-        <meta property="twitter:card" content="summary_large_image" />
-        <meta property="twitter:url" content={local} />
-        <meta property="twitter:title" content={currentMeta.ogTitle} />
-        <meta property="twitter:description" content={currentMeta.ogDescription} />
-        {pageOgImage ? (
-          <meta property="twitter:image" content={pageOgImage} />
-        ) : (
-          <meta property="twitter:image" content={`https://storage.googleapis.com/basedosdados-website/thumbnails/${locale}/general.png`} />
-        )}
+        {/* Twitter — apenas o card. Sem twitter:title/description/image aqui:
+            os crawlers caem para as tags og: correspondentes, o que faz cada
+            página herdar automaticamente o og: que ela mesma define. */}
+        <meta name="twitter:card" content="summary_large_image" key="twcard" />
 
         {/* Open Graph */}
-        <meta property="og:type" content="website" />
-        <meta property="og:url" content={local} />
-        <meta property="og:title" content={currentMeta.ogTitle} />
-        <meta property="og:description" content={currentMeta.ogDescription} />
-        {pageOgImage ? (
-          <meta property="og:image" content={pageOgImage} />
-        ) : (
-          <meta property="og:image" content={`https://storage.googleapis.com/basedosdados-website/thumbnails/${locale}/general.png`} />
+        <meta property="og:type" content="website" key="ogtype" />
+        {canonicalUrl && (
+          <meta property="og:url" content={canonicalUrl} key="ogurl" />
         )}
-        <meta property="og:site_name" content={currentMeta.siteName} />
+        <meta property="og:title" content={currentMeta.ogTitle} key="ogtitle" />
+        <meta property="og:description" content={currentMeta.ogDescription} key="ogdesc" />
+        {pageOgImage ? (
+          <meta property="og:image" content={pageOgImage} key="ogimage" />
+        ) : (
+          <meta property="og:image" content={`https://storage.googleapis.com/basedosdados-website/thumbnails/${locale}/general.png`} key="ogimage" />
+        )}
+        <meta property="og:site_name" content={currentMeta.siteName} key="ogsitename" />
 
         {/* <!-- Google Tag Manager --> */}
         {local === "https://staging.basedosdados.org" || local === "https://basedosdados.org" ? (

--- a/next/pages/blog/[slug].js
+++ b/next/pages/blog/[slug].js
@@ -103,10 +103,11 @@ export default function Post({ slug, locale, mdxSource, headings }) {
           key="ogdesc"
         />
         <meta name="description" content={frontmatter.description} />
-        <meta property="og:type" content="article" />
+        <meta property="og:type" content="article" key="ogtype" />
         <meta
           property="og:url"
           content={`https://basedosdados.org/blog/${slug}`}
+          key="ogurl"
         />
         <meta
           property="og:image"

--- a/next/pages/dataset/[dataset].js
+++ b/next/pages/dataset/[dataset].js
@@ -30,6 +30,7 @@ import useABTestVariant from "../../hooks/useABTestVariant";
 import Banner from "../../components/molecules/Banner";
 import {
   triggerGAEvent,
+  formatMetaDescription,
   hasBDProSubscription,
   hasChatbotSubscription,
   trackNavigateToChatbotLp,
@@ -328,37 +329,32 @@ export default function DatasetPage ({ dataset, userGuide, hiddenDataset }) {
     }
   };
 
+  const datasetName = dataset[`name${capitalize(locale)}`] || dataset.name
+  const datasetTitle = `${datasetName} – ${t("dataBasis")}`
+  const datasetDescription = formatMetaDescription(
+    dataset[`description${capitalize(locale)}`] || dataset.description
+  )
+  const datasetThumbnail = `https://storage.googleapis.com/basedosdados-website/thumbnails/${locale}/dataset.png`
+  const frontendUrl = process.env.NEXT_PUBLIC_BASE_URL_FRONTEND
+  const datasetUrl = frontendUrl ? `${frontendUrl}/dataset/${dataset._id}` : null
+
   return (
     <MainPageTemplate userTemplate footerTemplate="simple">
       <Head>
-        <title>{`${dataset[`name${capitalize(locale)}`] || dataset.name} – ${t("dataBasis")}`}</title>
+        <title>{datasetTitle}</title>
 
-        <link
-          rel="image_src"
-          href={`https://storage.googleapis.com/basedosdados-website/thumbnails/${locale}/dataset.png`}
-        />
-        <meta
-          property="og:image"
-          content={`https://storage.googleapis.com/basedosdados-website/thumbnails/${locale}/dataset.png`}
-          key="ogimage"
-        />
-        <meta
-          name="twitter:image"
-          content={`https://storage.googleapis.com/basedosdados-website/thumbnails/${locale}/dataset.png`}
-          key="twimage"
-        />
-        <meta
-          property="og:title"
-          content={`${dataset[`name${capitalize(locale)}`] || dataset.name} – ${t("dataBasis")}`}
-          key="ogtitle"
-        />
-        <meta
-          property="og:description"
-          content={
-            dataset[`description${capitalize(locale)}`] || dataset.description
-          }
-          key="ogdesc"
-        />
+        <link rel="image_src" href={datasetThumbnail} key="imagesrc" />
+        {datasetUrl && (
+          <link rel="canonical" href={datasetUrl} key="canonical" />
+        )}
+        <meta property="og:image" content={datasetThumbnail} key="ogimage" />
+        <meta name="twitter:image" content={datasetThumbnail} key="twimage" />
+        <meta property="og:title" content={datasetTitle} key="ogtitle" />
+        {datasetUrl && (
+          <meta property="og:url" content={datasetUrl} key="ogurl" />
+        )}
+        <meta name="description" content={datasetDescription} />
+        <meta property="og:description" content={datasetDescription} key="ogdesc" />
       </Head>
 
       <VStack

--- a/next/pages/docs/[slug].js
+++ b/next/pages/docs/[slug].js
@@ -677,8 +677,8 @@ export default function Docs({ allDocs, slug, locale, mdxSource, headings }) {
           content={`${frontmatter.title} – ${t('pageTitle')}`}
           key="ogtitle"
         />
-        <meta property="og:type" content="article" />
-        <meta property="og:url" content={`https://basedosdados.org/docs/${slug}`} />
+        <meta property="og:type" content="article" key="ogtype" />
+        <meta property="og:url" content={`https://basedosdados.org/docs/${slug}`} key="ogurl" />
       </Head>
 
       <Box

--- a/next/utils.js
+++ b/next/utils.js
@@ -259,6 +259,33 @@ export function cleanString(string) {
   return returnString
 }
 
+// Descrições vêm do backend em markdown. Crawlers de redes sociais exibem o
+// conteúdo de og:description como texto puro e cortam por volta de 200
+// caracteres, então removemos a marcação e truncamos numa fronteira de palavra.
+export function formatMetaDescription(string, maxLength = 200) {
+  if (!string) return ""
+
+  const plain = String(string)
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/`([^`]*)`/g, "$1")
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, " ")
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/^[ \t]{0,3}#{1,6}[ \t]+/gm, "")
+    .replace(/^[ \t]{0,3}>[ \t]?/gm, "")
+    .replace(/^[ \t]{0,3}(?:[-*+]|\d+\.)[ \t]+/gm, "")
+    .replace(/(\*\*|__)(.*?)\1/g, "$2")
+    .replace(/(\*|_)(.*?)\1/g, "$2")
+
+  const cleaned = cleanString(plain)
+  if (cleaned.length <= maxLength) return cleaned
+
+  const truncated = cleaned.slice(0, maxLength - 1)
+  const lastSpace = truncated.lastIndexOf(" ")
+  const cut = lastSpace > maxLength * 0.6 ? truncated.slice(0, lastSpace) : truncated
+
+  return `${cut.trimEnd().replace(/[,;:.\-–—]$/, "")}…`
+}
+
 export function formatBytes(bytes) {
   if (bytes < 1024) {
     return `${bytes} B`


### PR DESCRIPTION
Dataset pages (and every other page) were serving two og:title / og:image tags — the generic one from _app.js first, which is the one crawlers use. Keys the defaults so page-level tags replace them. Verified locally against the production backend across pt/en/es: 0 duplicate tags on 21 pages.