### PR TITLE
feat(chatbot): implement chatbot trial survey and tracking

### DIFF
--- a/next/components/organisms/chatbot/ChatbotAccessGate.js
+++ b/next/components/organisms/chatbot/ChatbotAccessGate.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import cookies from "js-cookie";
-import { redirectToChatbotCheckout, clearClientSession } from "../../../utils";
+import { redirectToChatbotCheckout, clearClientSession, consumeChatbotTrialFollowup } from "../../../utils";
 
 async function clearAuthCookiesAndRedirectLogin(router) {
   if (typeof window !== "undefined") {
@@ -27,10 +27,14 @@ export default function ChatbotAccessGate({ children }) {
   const [canEnter, setCanEnter] = useState(false);
 
   useEffect(() => {
+    if (!router.isReady) return;
+
     let cancelled = false;
 
     async function checkAccess() {
       if (typeof window === "undefined") return;
+      await consumeChatbotTrialFollowup(router);
+      if (cancelled) return;
       if (!hasUserCookie()) {
         await clearAuthCookiesAndRedirectLogin(router);
         return;
@@ -60,7 +64,7 @@ export default function ChatbotAccessGate({ children }) {
     return () => {
       cancelled = true;
     };
-  }, [router]);
+  }, [router.isReady]);
 
   if (!canEnter) return null;
   return children;

--- a/next/components/organisms/componentsUserPage/ChatbotTrialSurveyModal.js
+++ b/next/components/organisms/componentsUserPage/ChatbotTrialSurveyModal.js
@@ -1,0 +1,128 @@
+import { useEffect, useState } from "react";
+import { Box, Stack, ModalCloseButton } from "@chakra-ui/react";
+import { useTranslation } from "react-i18next";
+import TitleText from "../../atoms/Text/TitleText";
+import BodyText from "../../atoms/Text/BodyText";
+import { ModalGeneral, Button } from "../../molecules/uiUserPage";
+
+const ChatbotTrialSurveyOptions = [
+  { value: "already_knew_bd", labelKey: "alreadyKnewBd" },
+  { value: "instagram_ads", labelKey: "instagramAds" },
+  { value: "facebook_ads", labelKey: "facebookAds" },
+  { value: "google_ads", labelKey: "googleAds" },
+  { value: "google_search", labelKey: "googleSearch" },
+  { value: "linkedin", labelKey: "linkedin" },
+  { value: "referral", labelKey: "referral" },
+  { value: "newsletter", labelKey: "newsletter" },
+  { value: "other", labelKey: "other" },
+];
+
+const SurveyOptionBaseProps = {
+  borderRadius: "16px",
+  cursor: "pointer",
+  width: { base: "100%", sm: "fit-content" },
+  maxWidth: "100%",
+  fontFamily: "Roboto",
+  fontWeight: "500",
+  fontSize: { base: "16px", md: "18px" },
+  lineHeight: { base: "24px", md: "28px" },
+};
+
+export default function ChatbotTrialSurveyModal({ isOpen, onSubmit, onSkip }) {
+  const { t } = useTranslation("user");
+  const [selected, setSelected] = useState("");
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setSelected("");
+    setError("");
+  }, [isOpen]);
+
+  function handleContinue() {
+    if (!selected) {
+      setError(t("survey.error"));
+      return;
+    }
+    onSubmit(selected);
+  }
+
+  return (
+    <ModalGeneral
+      isOpen={isOpen}
+      onClose={onSkip}
+      propsModal={{ id: "modal-chatbot-trial-survey", closeOnOverlayClick: false }}
+      propsModalContent={{
+        width: "100%",
+        maxWidth: "656px",
+      }}
+    >
+      <Stack spacing={0} marginBottom="16px">
+        <Box height="24px" />
+        <ModalCloseButton
+          fontSize="14px"
+          top="28px"
+          right="26px"
+          _hover={{ backgroundColor: "transparent", opacity: 0.7 }}
+        />
+      </Stack>
+
+      <Stack spacing={0} gap="16px" marginBottom="24px">
+        <TitleText>{t("username.chatbotTrialSurvey.title")}</TitleText>
+        <BodyText color="#464A51">
+          {t("username.chatbotTrialSurvey.description")}
+        </BodyText>
+
+        {error && (
+          <BodyText color="#BF3434">{error}</BodyText>
+        )}
+
+        <Stack
+          flexDirection="row"
+          flexWrap="wrap"
+          width="100%"
+          gap="12px"
+          spacing={0}
+          paddingTop="8px"
+        >
+          {ChatbotTrialSurveyOptions.map((option) => {
+            const isSelected = selected === option.value;
+            return (
+              <Box
+                key={option.value}
+                as="button"
+                type="button"
+                onClick={() => {
+                  setSelected(option.value);
+                  setError("");
+                }}
+                {...SurveyOptionBaseProps}
+                border={isSelected ? "2px solid #2B8C4D" : "1px solid #DEDFE0"}
+                backgroundColor={isSelected ? "#D5E8DB" : "#FFF"}
+                padding={isSelected ? "11px" : "12px"}
+                color={isSelected ? "#2B8C4D" : "#464A51"}
+              >
+                {t(`username.chatbotTrialSurvey.options.${option.labelKey}`)}
+              </Box>
+            );
+          })}
+        </Stack>
+      </Stack>
+
+      <Stack
+        flexDirection={{ base: "column-reverse", lg: "row" }}
+        spacing={0}
+        gap="16px"
+        width="100%"
+        justifyContent="end"
+      >
+        <Button isVariant width={{ base: "100%", lg: "fit-content" }} onClick={onSkip}>
+          {t("survey.skip")}
+        </Button>
+        <Button width={{ base: "100%", lg: "fit-content" }} onClick={handleContinue}>
+          {t("survey.continue")}
+        </Button>
+      </Stack>
+    </ModalGeneral>
+  );
+}

--- a/next/components/organisms/componentsUserPage/PlansAndPayment.js
+++ b/next/components/organisms/componentsUserPage/PlansAndPayment.js
@@ -23,6 +23,7 @@ import BodyText from "../../atoms/Text/BodyText";
 import Toggle from "../../atoms/Toggle";
 import { SectionPrice } from "../../../pages/prices";
 import PaymentSystem from "../../organisms/PaymentSystem";
+import ChatbotTrialSurveyModal from "./ChatbotTrialSurveyModal";
 import { triggerGAEvent, triggerGAEventWithData, hasBDProSubscription, hasChatbotSubscription, getSubscriptionStatusKey, isSubscriptionTrialing } from "../../../utils";
 import { selectPlans, localeToRegion, formatCurrency } from "../../../constants/stripePlans";
 
@@ -131,6 +132,7 @@ export default function PlansAndPayment ({ userData }) {
 
   const PaymentModal = useDisclosure()
   const EmailModal = useDisclosure()
+  const TrialSurveyModal = useDisclosure()
   const SucessPaymentModal = useDisclosure()
   const ErroPaymentModal = useDisclosure()
   const PlansModal = useDisclosure()
@@ -152,6 +154,7 @@ export default function PlansAndPayment ({ userData }) {
   const [isStartingChatbotTrial, setIsStartingChatbotTrial] = useState(false)
   const [isSetupIntentCheckout, setIsSetupIntentCheckout] = useState(false)
   const successCheckoutKindRef = useRef(null)
+  const trialSurveyFinishedRef = useRef(false)
 
   const internalSubscriptions = userData?.internalSubscription?.edges?.map((edge) => edge?.node) || []
   const bdProSubscriptionInfo = internalSubscriptions.find((subscription) => {
@@ -345,9 +348,7 @@ export default function PlansAndPayment ({ userData }) {
       }).then((res) => res.json())
 
       if (trial?.started) {
-        successCheckoutKindRef.current = "chatbot"
-        setIsChatbotTrialSuccess(true)
-        SucessPaymentModal.onOpen()
+        openChatbotTrialSuccessFlow()
         return
       }
 
@@ -515,10 +516,32 @@ export default function PlansAndPayment ({ userData }) {
     )
   }
 
+  function openChatbotTrialSuccessFlow() {
+    successCheckoutKindRef.current = "chatbot"
+    trialSurveyFinishedRef.current = false
+    setIsChatbotTrialSuccess(true)
+    PaymentModal.onClose()
+    TrialSurveyModal.onOpen()
+  }
+
+  function finishChatbotTrialSurvey(source) {
+    if (trialSurveyFinishedRef.current) return
+    trialSurveyFinishedRef.current = true
+    triggerGAEventWithData("chatbot_trial_survey", {
+      value: source || "skipped",
+    })
+    TrialSurveyModal.onClose()
+    SucessPaymentModal.onOpen()
+  }
+
   const openModalSucess = (isTrial = false) => {
     const isChatbotPurchase =
       checkoutInfos?.productName?.toLowerCase().includes("chatbot") ||
       checkoutInfos?.productSlug?.toLowerCase().includes("chatbot")
+    if (isTrial && isChatbotPurchase) {
+      openChatbotTrialSuccessFlow()
+      return
+    }
     successCheckoutKindRef.current = isChatbotPurchase ? "chatbot" : "bd_pro"
     setIsChatbotTrialSuccess(isTrial)
     PaymentModal.onClose()
@@ -1176,6 +1199,12 @@ export default function PlansAndPayment ({ userData }) {
           </Button>
         </Stack>
       </ModalGeneral>
+
+      <ChatbotTrialSurveyModal
+        isOpen={TrialSurveyModal.isOpen}
+        onSubmit={finishChatbotTrialSurvey}
+        onSkip={() => finishChatbotTrialSurvey("skipped")}
+      />
 
       {/* success */}
       <ModalGeneral

--- a/next/public/locales/en/user.json
+++ b/next/public/locales/en/user.json
@@ -282,6 +282,21 @@
         "chatbotSubscriptionSuccessDescription": "Your payment was approved and your Chatbot plan is now active. If you need help setting up or using the product, <1>contact our support team</1>.",
         "chatbotTrialSuccessTitle": "You can now use the chatbot",
         "chatbotTrialSuccessDescription": "Enjoy the free trial period to explore all chatbot features.",
+        "chatbotTrialSurvey": {
+            "title": "How did you find the chatbot?",
+            "description": "Your answer helps us understand which channels work best.",
+            "options": {
+                "alreadyKnewBd": "I already knew Data Basis",
+                "instagramAds": "Instagram ad",
+                "facebookAds": "Facebook ad",
+                "googleAds": "Google ad",
+                "googleSearch": "Google search",
+                "linkedin": "LinkedIn",
+                "referral": "Someone referred me",
+                "newsletter": "Email or newsletter",
+                "other": "Other"
+            }
+        },
         "viewChatbotSubscription": "View subscription",
         "paymentFailed": "Payment failed",
         "paymentError": "An error occurred while processing your payment. Please try again or contact support:",

--- a/next/public/locales/es/user.json
+++ b/next/public/locales/es/user.json
@@ -197,6 +197,21 @@
         "chatbotSubscriptionSuccessDescription": "Su pago fue aprobado y su plan de Chatbot ya está activo. Si necesita ayuda para configurar o usar el producto, <1>contacte al soporte</1>.",
         "chatbotTrialSuccessTitle": "Ya puedes usar el chatbot",
         "chatbotTrialSuccessDescription": "Aprovecha el período de prueba gratuito para experimentar todas las funcionalidades del chatbot.",
+        "chatbotTrialSurvey": {
+            "title": "¿Cómo llegaste al chatbot?",
+            "description": "Tu respuesta nos ayuda a entender qué canales funcionan mejor.",
+            "options": {
+                "alreadyKnewBd": "Ya conocía Base de los Datos",
+                "instagramAds": "Anuncio en Instagram",
+                "facebookAds": "Anuncio en Facebook",
+                "googleAds": "Anuncio en Google",
+                "googleSearch": "Búsqueda en Google",
+                "linkedin": "LinkedIn",
+                "referral": "Me lo recomendaron",
+                "newsletter": "Correo o newsletter",
+                "other": "Otro"
+            }
+        },
         "viewChatbotSubscription": "Ver suscripción",
         "paymentFailed": "Pago fallido",
         "paymentError": "Ocurrió un error al procesar su pago. Por favor, intente nuevamente o contacte al soporte:",

--- a/next/public/locales/pt/user.json
+++ b/next/public/locales/pt/user.json
@@ -276,6 +276,21 @@
         "chatbotSubscriptionSuccessDescription": "Seu pagamento foi aprovado e seu plano do Chatbot já está ativo. Se precisar de ajuda para configurar ou usar o produto, <1>fale com o suporte</1>.",
         "chatbotTrialSuccessTitle": "Você já pode usar o chatbot",
         "chatbotTrialSuccessDescription": "Aproveite o período de teste grátis para experimentar todas as funcionalidades do chatbot.",
+        "chatbotTrialSurvey": {
+            "title": "Como você chegou até o chatbot?",
+            "description": "Sua resposta nos ajuda a entender quais canais funcionam melhor.",
+            "options": {
+                "alreadyKnewBd": "Já conhecia a Base dos Dados",
+                "instagramAds": "Anúncio no Instagram",
+                "facebookAds": "Anúncio no Facebook",
+                "googleAds": "Anúncio no Google",
+                "googleSearch": "Pesquisa no Google",
+                "linkedin": "LinkedIn",
+                "referral": "Indicação de alguém",
+                "newsletter": "E-mail ou newsletter",
+                "other": "Outro"
+            }
+        },
         "viewChatbotSubscription": "Ver assinatura",
         "paymentFailed": "Falha no pagamento",
         "paymentError": "Ocorreu um erro ao processar seu pagamento. Por favor, tente novamente ou entre em contato com o suporte:",

--- a/next/utils.js
+++ b/next/utils.js
@@ -270,6 +270,72 @@ export function triggerGAEventWithData(category, data) {
   window.dataLayer.push(eventData);
 }
 
+const UtmParamKeys = ["utm_source", "utm_medium", "utm_campaign", "utm_content", "utm_term"]
+const ChatbotTrialFollowupCampaign = "chatbot_trial_followup"
+
+let chatbotTrialFollowupTracked = false
+
+function readQueryParam(source, key) {
+  const value = source?.[key]
+  if (value == null || value === "") return null
+  return Array.isArray(value) ? value[0] : String(value)
+}
+
+function getUtmQueryParams(query) {
+  const windowQuery =
+    typeof window === "undefined"
+      ? {}
+      : Object.fromEntries(new URLSearchParams(window.location.search))
+  const source = { ...windowQuery, ...(query || {}) }
+  const utm = {}
+
+  for (const key of UtmParamKeys) {
+    const value = readQueryParam(source, key)
+    if (value) utm[key] = value
+  }
+
+  return utm
+}
+
+function stripUtmQueryParams(router) {
+  const query = { ...(router?.query || {}) }
+  let changed = false
+
+  for (const key of UtmParamKeys) {
+    if (key in query) {
+      delete query[key]
+      changed = true
+    }
+  }
+
+  if (!changed) return Promise.resolve()
+
+  return router.replace(
+    { pathname: router.pathname, query },
+    undefined,
+    { shallow: true }
+  )
+}
+
+export async function consumeChatbotTrialFollowup(router) {
+  if (typeof window === "undefined" || !router) return
+
+  const utm = getUtmQueryParams(router.query)
+  if (utm.utm_campaign !== ChatbotTrialFollowupCampaign) return
+
+  if (!chatbotTrialFollowupTracked) {
+    chatbotTrialFollowupTracked = true
+    const user = getUserFromCookie()
+    triggerGAEventWithData("chatbot_trial_followup", {
+      value: "email",
+      ...utm,
+      is_logged_in: Boolean(user?.username),
+    })
+  }
+
+  await stripUtmQueryParams(router)
+}
+
 const CHATBOT_LP_DESKTOP_PLACEMENTS = new Set([
   "desktop_header_right",
   "desktop_solutions_dropdown",


### PR DESCRIPTION
- Added a new ChatbotTrialSurveyModal component for user feedback on chatbot discovery channels.
- Integrated the survey modal into the PlansAndPayment component, triggered upon successful chatbot trial initiation.
- Implemented UTM parameter handling in utils.js to track chatbot trial follow-up events.
- Updated localization files to include survey titles and options in English, Spanish, and Portuguese.