### PR TITLE
feat: atualizar testes Cypress e2e de usuário e checkout

### DIFF
--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -6,12 +6,11 @@ on:
       - main
     paths:
       - "next/**/*"
-      - ".github/workflows/cypress-tests.yaml"
+      - ".github/workflows/cypress-tests.yml"
 
 jobs:
   cypress-run:
     name: Cypress E2E Tests
-    if: github.base_ref == 'main' && github.head_ref == 'staging'
     runs-on: ubuntu-latest
     environment: staging
     env:

--- a/next/components/organisms/PaymentSystem.js
+++ b/next/components/organisms/PaymentSystem.js
@@ -63,7 +63,13 @@ const PaymentForm = ({ onSucess, onErro, clientSecret}) => {
         className={styles.content}
         onSubmit={handlerSubmit}
       >
-        <PaymentElement className={styles.payment}/>
+        <PaymentElement
+          className={styles.payment}
+          options={{
+            layout: "tabs",
+            paymentMethodOrder: ["card", "boleto"],
+          }}
+        />
 
         <Button
           width="100%"
@@ -88,6 +94,7 @@ export default function PaymentSystem({
   onErro,
   isLoading,
   onClientSecretReady,
+  enableChatbotTrial = false,
 }) {
   const [clientSecret, setClientSecret] = useState("")
 
@@ -153,13 +160,15 @@ export default function PaymentSystem({
   }
 
   const customerCreatPost = async (id, coupon) => {
-    const trial = await fetch(`/api/stripe/startChatbotTrial?p=${btoa(id)}`, {method: "GET"})
-      .then(res => res.json())
+    if (enableChatbotTrial) {
+      const trial = await fetch(`/api/stripe/startChatbotTrial?p=${btoa(id)}`, {method: "GET"})
+        .then(res => res.json())
 
-    if (trial?.started) {
-      setClientSecret(null)
-      onClientSecretReady?.({ isSetupIntent: false, isTrialStarted: true })
-      return isLoading(false)
+      if (trial?.started) {
+        setClientSecret(null)
+        onClientSecretReady?.({ isSetupIntent: false, isTrialStarted: true })
+        return isLoading(false)
+      }
     }
 
     const clientSecret = await fetch(`/api/stripe/createSubscription?p=${btoa(id)}&c=${btoa(coupon)}`, {method: "GET"})

--- a/next/components/organisms/componentsUserPage/PlansAndPayment.js
+++ b/next/components/organisms/componentsUserPage/PlansAndPayment.js
@@ -1107,6 +1107,7 @@ export default function PlansAndPayment ({ userData }) {
                 userData={userData}
                 plan={plan}
                 coupon={coupon}
+                enableChatbotTrial={isChatbotCheckout && !hasSubscribed}
                 onSucess={(isTrial) => openModalSucess(isTrial)}
                 onErro={() => openModalErro()}
                 isLoading={(e) => setIsLoadingClientSecret(e)}

--- a/next/cypress.config.js
+++ b/next/cypress.config.js
@@ -4,13 +4,31 @@ module.exports = defineConfig({
   e2e: {
     setupNodeEvents(on, config) {
       config.env.NEXT_PUBLIC_BASE_URL_FRONTEND = process.env.NEXT_PUBLIC_BASE_URL_FRONTEND
-      return config
+
+      on("before:browser:launch", (browser, launchOptions) => {
+        if (browser.family === "chromium" && browser.name !== "electron") {
+          launchOptions.args.push("--disable-features=IsolateOrigins,site-per-process");
+          launchOptions.args.push("--disable-site-isolation-trials");
+          launchOptions.args.push("--disable-web-security");
+          launchOptions.args.push("--window-size=1920,1080");
+          launchOptions.args.push("--force-device-scale-factor=1");
+        }
+        return launchOptions;
+      });
+
+      return config;
     },
     baseUrl: process.env.NEXT_PUBLIC_BASE_URL_FRONTEND,
     video: false,
     viewportWidth: 1920,
     viewportHeight: 1080,
-    chromeWebSecurity: false
+    chromeWebSecurity: false,
+    defaultCommandTimeout: 10000,
+    pageLoadTimeout: 120000,
+    retries: {
+      runMode: 1,
+      openMode: 0,
+    },
   },
   env: {
     CRYPRESS_AUTH_EMAIL: process.env.CRYPRESS_AUTH_EMAIL,

--- a/next/cypress/e2e/check-email.cy.js
+++ b/next/cypress/e2e/check-email.cy.js
@@ -1,0 +1,36 @@
+describe('Página de confirmação de e-mail', () => {
+  it('Deve redirecionar para a home sem e-mail no sessionStorage', () => {
+    cy.visit('/user/check-email');
+    cy.url({ timeout: 10000 }).should('eq', Cypress.config().baseUrl + '/');
+  });
+
+  it('Deve exibir o e-mail pendente de confirmação', () => {
+    cy.visit('/user/check-email', {
+      onBeforeLoad(win) {
+        win.sessionStorage.setItem('registration_email_bd', 'test@example.com');
+      }
+    });
+
+    cy.contains('Confirme seu endereço de e-mail').should('be.visible');
+    cy.contains('test@example.com').should('be.visible');
+    cy.contains('Reenviar e-mail').should('be.visible');
+  });
+
+  it('Deve reenviar o e-mail de confirmação', () => {
+    cy.mockGetIdUser({
+      statusCode: 200,
+      body: { id: 'AccountNode:user123', isActive: false }
+    });
+    cy.intercept('POST', '**/account/account_activate/**', { statusCode: 200 }).as('activationApi');
+
+    cy.visit('/user/check-email', {
+      onBeforeLoad(win) {
+        win.sessionStorage.setItem('registration_email_bd', 'test@example.com');
+      }
+    });
+
+    cy.contains('Reenviar e-mail').click();
+    cy.wait(['@getIdUser', '@activationApi']);
+    cy.contains(/Espere \d+ segundos/).should('be.visible');
+  });
+});

--- a/next/cypress/e2e/login.cy.js
+++ b/next/cypress/e2e/login.cy.js
@@ -9,11 +9,18 @@ describe('Fluxo de Login - Cenários Principais', () => {
 
   it('Deve exibir o formulário corretamente', () => {
     cy.contains('h1', 'Faça login').should('be.visible');
+    cy.contains('Continuar com o Google').should('be.visible');
     cy.get('input[name=username]').should('exist');
     cy.get('input[name=password]').should('exist');
     cy.contains('button', 'Entrar').should('be.visible');
     cy.contains('Esqueceu a senha?').should('be.visible');
     cy.contains('Cadastre-se').should('be.visible');
+  });
+
+  it('Deve ir para a recuperação de senha', () => {
+    cy.contains('Esqueceu a senha?').click();
+    cy.url().should('include', '/user/password-recovery');
+    cy.contains('Redefina sua senha').should('be.visible');
   });
 
   it('Deve permitir alternar visibilidade da senha', () => {

--- a/next/cypress/e2e/login.cy.js
+++ b/next/cypress/e2e/login.cy.js
@@ -44,6 +44,46 @@ describe('Fluxo de Login - Cenários Principais', () => {
     });
   });
 
+  it('Deve logar com o usuário Cypress de verdade', function () {
+    const email = Cypress.env('CRYPRESS_AUTH_EMAIL');
+    const password = Cypress.env('CRYPRESS_AUTH_PASSWORD');
+
+    if (!email || !password) {
+      this.skip();
+    }
+
+    cy.window().then((win) => {
+      win.localStorage.removeItem('previousPath');
+    });
+
+    cy.intercept('GET', '/api/user/getToken*').as('realGetToken');
+    cy.intercept('GET', '/api/user/getUser*').as('realGetUser');
+
+    cy.login(email, password);
+
+    cy.wait('@realGetToken', { timeout: 30000 })
+      .its('response.statusCode')
+      .should('eq', 200);
+
+    cy.wait('@realGetUser', { timeout: 30000 })
+      .its('response.statusCode')
+      .should('eq', 200);
+
+    cy.getCookie('userBD', { timeout: 20000 }).should('exist');
+
+    cy.location('pathname', { timeout: 20000 }).should((pathname) => {
+      expect(pathname).to.not.eq('/user/login');
+      expect(
+        pathname === '/' || pathname.startsWith('/user/'),
+        `redirect após login real: ${pathname}`
+      ).to.eq(true);
+    });
+
+    cy.parseUserBdCookie().then((user) => {
+      expect(user.username).to.eq('cypress_test');
+    });
+  });
+
   it('Deve redirecionar para survey quando workDataTool é null', () => {
     cy.intercept('GET', '/api/user/getToken*', { id: 'user123' });
     cy.intercept('GET', '/api/user/getUser*', { 

--- a/next/cypress/e2e/password-recovery.cy.js
+++ b/next/cypress/e2e/password-recovery.cy.js
@@ -1,0 +1,110 @@
+describe('Fluxo de Recuperação de Senha - Pedido de e-mail', () => {
+  beforeEach(() => {
+    cy.visit('/user/password-recovery');
+  });
+
+  it('Deve exibir o formulário corretamente', () => {
+    cy.contains('Redefina sua senha').should('be.visible');
+    cy.contains('Insira o endereço de e-mail que você usou para cadastrar sua conta').should('be.visible');
+    cy.get('input[placeholder="Insira seu e-mail"]').should('exist');
+    cy.contains('button', 'Enviar e-mail de redefinição').should('be.visible');
+    cy.contains('entre em contato').should('be.visible');
+  });
+
+  it('Deve mostrar erro quando o e-mail é inválido', () => {
+    cy.get('input[placeholder="Insira seu e-mail"]').type('invalido', { force: true });
+    cy.contains('button', 'Enviar e-mail de redefinição').click();
+    cy.contains('Endereço de e-mail inválido.').should('be.visible');
+  });
+
+  it('Deve mostrar erro quando o usuário não existe', () => {
+    cy.mockGetIdUser({ statusCode: 200, body: { error: 'err, user not found' } });
+
+    cy.get('input[placeholder="Insira seu e-mail"]').type('missing@example.com');
+    cy.contains('button', 'Enviar e-mail de redefinição').click();
+
+    cy.wait('@getIdUser');
+    cy.contains('Endereço de e-mail inválido.').should('be.visible');
+  });
+
+  it('Deve enviar o e-mail de redefinição com sucesso', () => {
+    cy.mockGetIdUser({
+      statusCode: 200,
+      body: { id: 'AccountNode:user123', isActive: true }
+    });
+    cy.intercept('POST', '**/account/password_reset/**', { statusCode: 200 }).as('passwordReset');
+
+    cy.get('input[placeholder="Insira seu e-mail"]').type('test@example.com');
+    cy.contains('button', 'Enviar e-mail de redefinição').click();
+
+    cy.wait(['@getIdUser', '@passwordReset']);
+    cy.contains(/Espere \d+ segundos/).should('be.visible');
+  });
+});
+
+describe('Fluxo de Recuperação de Senha - Nova senha', () => {
+  beforeEach(() => {
+    cy.visit('/user/password-recovery?q=uid123&p=token123');
+  });
+
+  it('Deve exibir o formulário de nova senha', () => {
+    cy.contains('Redefina sua nova senha').should('be.visible');
+    cy.get('input[id="password"]').should('exist');
+    cy.get('input[id="confirmPassword"]').should('exist');
+    cy.contains('button', 'Atualizar senha').should('be.visible');
+  });
+
+  it('Deve validar campos obrigatórios', () => {
+    cy.contains('button', 'Atualizar senha').click();
+    cy.contains('Por favor, insira a senha.').should('be.visible');
+    cy.contains('Confirmar a senha é necessário').should('be.visible');
+  });
+
+  it('Deve validar requisitos da senha', () => {
+    cy.get('input[id="confirmPassword"]').type('weak');
+    cy.contains('button', 'Atualizar senha').click();
+
+    const requirements = [
+      '8 caracteres',
+      'Uma letra maiúscula',
+      'Uma letra minúscula',
+      'Um número',
+      'Um caractere especial, dentre ! @ # ? ! % & *'
+    ];
+
+    requirements.forEach((text) => {
+      cy.contains('li', text)
+        .should('have.css', 'color', 'rgb(191, 52, 52)');
+    });
+  });
+
+  it('Deve validar confirmação de senha', () => {
+    cy.get('input[id="password"]').type('ValidPass123!');
+    cy.get('input[id="confirmPassword"]').type('Diferent123!');
+    cy.contains('button', 'Atualizar senha').click();
+    cy.contains('A senha inserida não coincide com a senha criada no campo acima. Por favor, verifique se não há erros de digitação e tente novamente.').should('be.visible');
+  });
+
+  it('Deve atualizar a senha e redirecionar para o login', () => {
+    cy.intercept('POST', '**/account/password_reset_confirm/**', { statusCode: 200 }).as('passwordResetConfirm');
+
+    cy.get('input[id="password"]').type('ValidPass123!');
+    cy.get('input[id="confirmPassword"]').type('ValidPass123!');
+    cy.contains('button', 'Atualizar senha').click();
+
+    cy.wait('@passwordResetConfirm');
+    cy.url({ timeout: 10000 }).should('include', '/user/login');
+  });
+
+  it('Deve voltar ao pedido de e-mail quando a confirmação falhar', () => {
+    cy.intercept('POST', '**/account/password_reset_confirm/**', { statusCode: 400 }).as('passwordResetConfirm');
+
+    cy.get('input[id="password"]').type('ValidPass123!');
+    cy.get('input[id="confirmPassword"]').type('ValidPass123!');
+    cy.contains('button', 'Atualizar senha').click();
+
+    cy.wait('@passwordResetConfirm');
+    cy.url({ timeout: 10000 }).should('include', '/user/password-recovery');
+    cy.contains('Redefina sua senha').should('be.visible');
+  });
+});

--- a/next/cypress/e2e/payment.cy.js
+++ b/next/cypress/e2e/payment.cy.js
@@ -2,21 +2,29 @@ describe('Área do Usuário e Sistema de pagamento', () => {
   const username = 'cypress_test';
 
   function getSafeUserBdCookie() {
-    return cy.getCookie('userBD').then(cookie => {
-      if (!cookie?.value) throw new Error('Cookie userBD não encontrado');
-      
-      try {
-        const decoded = decodeURIComponent(cookie.value);
-        return JSON.parse(decoded);
-      } catch (e1) {
-        try {
-          return JSON.parse(cookie.value);
-        } catch (e2) {
-          throw new Error(`Falha ao parsear cookie: ${e2.message}`);
-        }
-      }
-    });
+    return cy.parseUserBdCookie();
   }
+
+  it('Não deve acessar sem autenticação', () => {
+    cy.clearCookies();
+    cy.visit(`/user/${username}?plans_and_payment`);
+    cy.url().should('include', '/user/login');
+  });
+
+  describe('com autenticação', () => {
+  before(() => {
+    cy.cancelActiveSubscription();
+    cy.then(() => {
+      Cypress.session.clearAllSavedSessions();
+    });
+  });
+
+  after(() => {
+    cy.cancelActiveSubscription();
+    cy.then(() => {
+      Cypress.session.clearAllSavedSessions();
+    });
+  });
 
   beforeEach(() => {
     cy.session('userSession', () => {
@@ -26,17 +34,12 @@ describe('Área do Usuário e Sistema de pagamento', () => {
       cy.getCookie('userBD').should('exist');
     });
 
-    cy.intercept('GET', '/api/stripe/getPlans').as('getPlans');
+    cy.intercept('GET', '**/api/stripe/getPlans*').as('getPlans');
 
-    cy.visit(`/user/${username}?plans_and_payment`);
+    cy.visit(`/user/${username}?plans_and_payment`, { timeout: 120000 });
 
-    cy.wait('@getPlans', { timeout: 15000 });
-  });
-
-  it('Não deve acessar sem autenticação', () => {
-    cy.clearCookies();
-    cy.visit(`/user/${username}?plans_and_payment`);
-    cy.url().should('include', '/user/login');
+    cy.location('pathname', { timeout: 60000 }).should('include', `/user/${username}`);
+    cy.contains('Planos e pagamento', { timeout: 60000 }).should('be.visible');
   });
 
   it('Deve acessar a página do usuário com autenticação', () => {
@@ -45,23 +48,19 @@ describe('Área do Usuário e Sistema de pagamento', () => {
   });
 
   it('Deve verificar se o plano grátis está ativo', () => {
-    cy.contains('span', 'Ativo').should('be.visible');
     cy.contains('p', 'BD Grátis').should('be.visible');
+    cy.contains('button', 'Comparar planos').should('be.visible');
   })
 
   it('Deve validar a exibição de todos os planos no modal', () => {
-    cy.contains('button', 'Comparar planos')
-      .should('be.visible')
-      .click();
+    cy.openPlansModal();
 
-    cy.get('section[role="dialog"].chakra-modal__content')
-      .should('be.visible')
-      .as('plansModal')
-      .within(() => {
+    cy.get('@plansModal').within(() => {
         cy.contains('p', 'BD Pro').should('be.visible');
-        cy.contains('p', 'BD Empresas').should('be.visible');
+        cy.contains('p', 'BD Orgs').should('be.visible');
         cy.contains('R$ 37').should('be.visible');
-        cy.contains('R$ 280').should('be.visible');
+        cy.contains('Sob consulta').should('be.visible');
+        cy.contains('Entre em contato').should('be.visible');
 
         cy.get('#toggle-prices')
           .should('exist')
@@ -70,7 +69,7 @@ describe('Área do Usuário e Sistema de pagamento', () => {
           .click({ force: true });
 
         cy.contains('R$ 47').should('be.visible');
-        cy.contains('R$ 385').should('be.visible');
+        cy.contains('Sob consulta').should('be.visible');
       });
 
       cy.get('@plansModal').within(() => {
@@ -83,37 +82,33 @@ describe('Área do Usuário e Sistema de pagamento', () => {
         .should('not.exist');
   });
 
-  it('Deve chegar no checkout', () => {
-    cy.contains('button', 'Comparar planos')
-      .should('be.visible')
-      .click();
+  it('Deve exibir a seção do Chatbot na área de planos', () => {
+    cy.contains(/Assinar Chatbot|Acessar chatbot/).should('be.visible');
+  });
 
+  it('Deve chegar no checkout', () => {
+    cy.openPlansModal();
     cy.arrivingAtCheckout('#bd_pro_button_sub_btn');
+    cy.proceedToPaymentStep();
 
     cy.get('@checkoutModal').within(() => {
       cy.contains('Pagamento', { timeout: 20000 })
         .should('be.visible');
 
-      cy.contains('BD Pro', { timeout: 25000 })
-        .should(($el) => {
-          expect($el).to.be.visible;
-          const rect = $el[0].getBoundingClientRect();
-          expect(rect.top).to.be.greaterThan(0);
-          expect(rect.bottom).to.be.lessThan(Cypress.config('viewportHeight'));
-          expect($el.text().trim()).to.not.be.empty;
-        });
+      cy.contains('button', 'Confirmar pagamento', { timeout: 60000 })
+        .should('be.visible');
+
+      cy.get('iframe[name^="__privateStripeFrame"]', { timeout: 60000 })
+        .should('be.visible');
     });
   });
 
   it('Verificar preços e trocar o plano no modal', () => {
-    cy.contains('button', 'Comparar planos')
-      .should('be.visible')
-      .click();
-
+    cy.openPlansModal();
     cy.arrivingAtCheckout('#bd_pro_button_sub_btn');
 
     cy.get('@checkoutModal').within(() => {
-      cy.contains('Pagamento', { timeout: 20000 })
+      cy.contains('Confirme seu plano', { timeout: 20000 })
         .should('be.visible');
 
       cy.verifyElement('BD Pro');
@@ -130,37 +125,33 @@ describe('Área do Usuário e Sistema de pagamento', () => {
       cy.contains('R$ 47,00/mês', { timeout: 20000 })
         .should('be.visible');
 
+      cy.clearCookie('plan_selected');
+
       cy.contains('Trocar plano')
         .should('be.visible')
         .click();
     });
 
-    cy.arrivingAtCheckout('#bd_pro_empresas_button_sub_btn');
-
-    cy.get('@checkoutModal').within(() => {
-      cy.contains('Pagamento', { timeout: 20000 })
-        .should('be.visible');
-
-      cy.verifyElement('BD Empresas');
-
-      cy.contains('R$ 3.700,00/ano')
-        .should('be.visible');
-
-      cy.get('#toggle-prices-modal-checkout')
-        .should('exist')
-        .and('have.attr', 'type', 'checkbox')
-        .and('be.checked')
-        .click({ force: true });
-
-      cy.contains('R$ 385,00/mês', { timeout: 20000 })
-        .should('be.visible');
+    cy.get('body', { timeout: 15000 }).should(($body) => {
+      const $checkout = $body.find('#chakra-modal-modal-stripe-checkout');
+      expect(
+        $checkout.length === 0 || $checkout.css('display') === 'none' || $checkout.css('opacity') === '0',
+        'checkout fechado'
+      ).to.eq(true);
     });
+
+    cy.get('section[role="dialog"].chakra-modal__content:visible')
+      .should('be.visible')
+      .and('have.css', 'opacity', '1')
+      .within(() => {
+        cy.contains('p', 'BD Orgs', { timeout: 20000 }).should('be.visible');
+        cy.contains('Sob consulta').should('be.visible');
+        cy.contains('Entre em contato').should('be.visible');
+      });
   });
 
   it('Verificar aplicação de cupons', () => {
-    cy.contains('button', 'Comparar planos')
-      .should('be.visible')
-      .click();
+    cy.openPlansModal();
 
     cy.get('#toggle-prices')
       .should('exist')
@@ -174,7 +165,7 @@ describe('Área do Usuário e Sistema de pagamento', () => {
     cy.arrivingAtCheckout('#bd_pro_button_sub_btn');
 
     cy.get('@checkoutModal').within(() => {
-      cy.contains('Pagamento', { timeout: 20000 })
+      cy.contains('Confirme seu plano', { timeout: 20000 })
         .should('be.visible');
 
       cy.verifyElement('BD Pro');
@@ -188,13 +179,20 @@ describe('Área do Usuário e Sistema de pagamento', () => {
     });
   });
 
-  const isLocalhost = Cypress.env('NEXT_PUBLIC_BASE_URL_FRONTEND')?.startsWith('http://localhost');
+  const baseUrl = String(
+    Cypress.env('NEXT_PUBLIC_BASE_URL_FRONTEND') || Cypress.config('baseUrl') || ''
+  ).toLowerCase();
+  const isSafeStripeEnv =
+    baseUrl.includes('localhost') ||
+    baseUrl.includes('127.0.0.1') ||
+    baseUrl.includes('staging') ||
+    baseUrl.includes('development');
+  const canFillStripeIframe =
+    Cypress.browser.family === 'chromium' && Cypress.browser.name !== 'electron';
 
-  if (isLocalhost) {
+  if (isSafeStripeEnv && canFillStripeIframe) {
     it('Fazer fluxo de assinatura BDPro', () => {
-      cy.contains('button', 'Comparar planos')
-        .should('be.visible')
-        .click();
+      cy.openPlansModal();
 
       cy.get('#toggle-prices')
         .should('exist')
@@ -206,6 +204,7 @@ describe('Área do Usuário e Sistema de pagamento', () => {
         .should('be.visible');
 
       cy.arrivingAtCheckout('#bd_pro_button_sub_btn');
+      cy.proceedToPaymentStep();
 
       cy.get('@checkoutModal').within(() => {
         cy.contains('Pagamento', { timeout: 20000 })
@@ -215,31 +214,38 @@ describe('Área do Usuário e Sistema de pagamento', () => {
 
         cy.contains('R$ 47,00/mês')
           .should('be.visible');
-
-        cy.get('iframe[name^="__privateStripeFrame"]', { timeout: 60000 })
-          .should('be.visible')
-          .its('0.contentDocument.body')
-          .should('not.be.empty')
-          .then(cy.wrap)
-
-        cy.fillStripeInput('cardNumber', '4242424242424242');
-        cy.fillStripeInput('cardExpiry', '12/30');
-        cy.fillStripeInput('cardCvc', '123');
-
-        cy.intercept('POST', 'https://api.stripe.com/v1/payment_intents/pi_*/confirm')
-          .as('stripeConfirmation');
-
-        cy.contains('button', 'Confirmar pagamento', { timeout: 1500 })
-          .should('be.visible')
-          .click();
-
-        cy.wait('@stripeConfirmation', { timeout: 30000 }).then((interception) => {
-          expect(interception.response.statusCode).to.be.oneOf([200, 201]);
-          expect(interception.response.body.status).to.eq('succeeded');
-        });
       });
 
-      cy.get('#chakra-modal-modal-stripe-payment_intent-succeeded', { timeout: 300000 })
+      cy.get('iframe[name^="__privateStripeFrame"]', { timeout: 60000 })
+        .should('be.visible');
+
+      cy.contains('button', 'Confirmar pagamento', { timeout: 60000 })
+        .should('be.visible');
+
+      cy.fillStripeCard();
+
+      cy.intercept(
+        'POST',
+        /https:\/\/api\.stripe\.com\/v1\/(payment_intents|setup_intents)\/.+\/confirm/
+      ).as('stripeConfirmation');
+
+      cy.get('@checkoutModal').within(() => {
+        cy.contains('button', 'Confirmar pagamento', { timeout: 20000 })
+          .should('be.visible')
+          .click();
+      });
+
+      cy.wait('@stripeConfirmation', { timeout: 30000 }).then((interception) => {
+        expect(interception.response.statusCode).to.be.oneOf([200, 201]);
+        const body = interception.response.body || {};
+        const status =
+          body.status ||
+          body.paymentIntent?.status ||
+          body.setupIntent?.status;
+        expect(status).to.eq('succeeded');
+      });
+
+      cy.get('#chakra-modal-modal-stripe-payment_intent-succeeded', { timeout: 60000 })
         .should('be.visible')
         .and('have.css', 'opacity', '1')
         .as('paymentIntentSucceeded')
@@ -252,14 +258,14 @@ describe('Área do Usuário e Sistema de pagamento', () => {
             .click();
         });
 
-      cy.get('#chakra-modal-modal-stripe-payment_intent-succeeded', { timeout: 300000 })
+      cy.get('#chakra-modal-modal-stripe-payment_intent-succeeded', { timeout: 20000 })
         .should('not.be.visible');
 
       cy.wait(30000);
     });
 
     it('Verificar se BDPro está ativo e cancelar', () => {
-      cy.contains('Ativo')
+      cy.contains('Ativo', { timeout: 30000 })
         .should('be.visible');
 
       cy.contains('p', 'BD Pro')
@@ -299,7 +305,7 @@ describe('Área do Usuário e Sistema de pagamento', () => {
 
         cy.request({
           method: 'GET',
-          url: `/api/stripe/getSubscriptionActive?p=${btoa(userId)}`,
+          url: `/api/stripe/getSubscriptionActive?p=${btoa(userId)}&t=${btoa('bd_pro')}`,
           headers: {
             'Content-Type': 'application/json',
           }
@@ -325,132 +331,11 @@ describe('Área do Usuário e Sistema de pagamento', () => {
         });
       });
     });
-
-    it('Fazer fluxo de assinatura BDEmpresas', () => {
-      cy.contains('button', 'Comparar planos')
-        .should('be.visible')
-        .click();
-
-      cy.arrivingAtCheckout('#bd_pro_empresas_button_sub_btn');
-
-      cy.get('@checkoutModal').within(() => {
-        cy.contains('Pagamento', { timeout: 20000 })
-          .should('be.visible');
-
-        cy.verifyElement('BD Empresas');
-
-        cy.contains('R$ 3.700,00/ano')
-          .should('be.visible');
-
-        cy.get('iframe[name^="__privateStripeFrame"]', { timeout: 60000 })
-          .should('be.visible')
-          .its('0.contentDocument.body')
-          .should('not.be.empty')
-          .then(cy.wrap)
-
-        cy.fillStripeInput('cardNumber', '4242424242424242');
-        cy.fillStripeInput('cardExpiry', '12/30');
-        cy.fillStripeInput('cardCvc', '123');
-
-        cy.intercept('POST', 'https://api.stripe.com/v1/payment_intents/pi_*/confirm')
-          .as('stripeConfirmation');
-
-        cy.contains('button', 'Confirmar pagamento', { timeout: 1500 })
-          .should('be.visible')
-          .click();
-
-        cy.wait('@stripeConfirmation', { timeout: 30000 }).then((interception) => {
-          expect(interception.response.statusCode).to.be.oneOf([200, 201]);
-          expect(interception.response.body.status).to.eq('succeeded');
-        });
-      });
-
-      cy.get('#chakra-modal-modal-stripe-payment_intent-succeeded', { timeout: 300000 })
-        .should('be.visible')
-        .and('have.css', 'opacity', '1')
-        .as('paymentIntentSucceeded')
-        .within(() => {
-          cy.contains('Assinatura efetuada com sucesso!', { timeout: 20000 })
-            .should('be.visible');
-
-          cy.get('button[aria-label="Close"]')
-            .first()
-            .click();
-        });
-
-      cy.get('#chakra-modal-modal-stripe-payment_intent-succeeded', { timeout: 60000 })
-        .should('not.be.visible');
-
-      cy.wait(30000);
-    });
-
-    it('Verificar se BDEmpresas está ativo e cancelar', () => {
-      cy.contains('Ativo')
-        .should('be.visible');
-
-      cy.contains('p', 'BD Empresas')
-        .should('be.visible');
-
-      cy.contains('(Anual)')
-        .should('be.visible');
-
-      cy.contains('Próxima data de renovação automática:')
-        .should('be.visible');
-
-      cy.contains('button', 'Cancelar plano')
-        .should('be.visible')
-        .click();
-
-      cy.get('#chakra-modal-modal-cancel-sub', { timeout: 15000 })
-        .should('be.visible')
-        .and('have.css', 'opacity', '1')
-        .as('cancelSub')
-        .within(() => {
-          cy.contains('button','Cancelar plano')
-            .should('be.visible')
-            .click();
-        });
-
-      cy.get('#chakra-modal-modal-cancel-sub', { timeout: 300000 })
-        .should('not.exist');
-
-      cy.contains('Cancelado')
-        .should('be.visible');
-
-      cy.contains('Acesso ao plano disponível até:')
-        .should('be.visible');
-
-      getSafeUserBdCookie().then(userData => {
-        const userId = userData.id.split(':')[1];
-
-        cy.request({
-          method: 'GET',
-          url: `/api/stripe/getSubscriptionActive?p=${btoa(userId)}`,
-          headers: {
-            'Content-Type': 'application/json',
-          }
-        }).then((subscriptionResponse) => {
-          const subscriptionId = subscriptionResponse.body;
-
-          cy.request({
-            method: 'GET',
-            url: `/api/stripe/removeSubscriptionImmediately?p=${btoa(subscriptionId)}`,
-            headers: {
-              'Content-Type': 'application/json',
-            }
-          }).then((response) => {
-            expect(response.status).to.eq(200);
-            expect(response.body).to.have.property('success', true);
-            cy.wait(60000);
-
-            cy.visit(`/user/${username}?plans_and_payment`);
-
-            cy.contains('p', 'BD Grátis', { timeout: 10000 })
-              .should('be.visible');
-          });
-        });
-      });
+  } else {
+    it('Fazer fluxo de assinatura BDPro', function () {
+      this.skip();
     });
   }
+  });
 });
 

--- a/next/cypress/e2e/payment.cy.js
+++ b/next/cypress/e2e/payment.cy.js
@@ -179,6 +179,80 @@ describe('Área do Usuário e Sistema de pagamento', () => {
     });
   });
 
+  it('Deve mostrar erro para cupom inválido', () => {
+    cy.openPlansModal();
+
+    cy.get('#toggle-prices')
+      .should('exist')
+      .and('have.attr', 'type', 'checkbox')
+      .and('be.checked')
+      .click({ force: true });
+
+    cy.contains('R$ 47/mês', { timeout: 20000 })
+      .should('be.visible');
+
+    cy.arrivingAtCheckout('#bd_pro_button_sub_btn');
+
+    cy.get('@checkoutModal').within(() => {
+      cy.contains('Confirme seu plano', { timeout: 20000 })
+        .should('be.visible');
+
+      cy.get('input[placeholder="Digite o cupom"]', { timeout: 15000 })
+        .clear({ force: true })
+        .type('cupom_invalido_xyz', { force: true });
+
+      cy.contains('button', 'Aplicar', { timeout: 30000 })
+        .should('be.visible')
+        .click({ force: true });
+
+      cy.contains('Por favor, insira um cupom válido.', { timeout: 30000 })
+        .should('be.visible');
+    });
+  });
+
+  it('Deve chegar no checkout ou no trial do Chatbot', () => {
+    cy.get('body').then(($body) => {
+      const canSubscribe = $body.find('button:visible').filter((_, el) =>
+        (el.textContent || '').includes('Assinar Chatbot')
+      ).length > 0;
+
+      if (!canSubscribe) {
+        cy.contains('a:visible, button:visible', 'Acessar chatbot').should('be.visible');
+        cy.contains('button', 'Cancelar assinatura do chatbot').should('be.visible');
+        return;
+      }
+
+      cy.wait(1000);
+      cy.contains('button', 'Assinar Chatbot', { timeout: 20000 })
+        .should('be.visible')
+        .click();
+
+      cy.get(
+        '#chakra-modal-modal-chatbot-trial-survey, #chakra-modal-modal-stripe-checkout',
+        { timeout: 60000 }
+      )
+        .filter(':visible')
+        .should('have.length.at.least', 1);
+
+      cy.get('body').then(($after) => {
+        const $survey = $after.find('#chakra-modal-modal-chatbot-trial-survey');
+        const surveyOpen = $survey.length && $survey.is(':visible');
+
+        if (surveyOpen) {
+          cy.contains('Como você chegou até o chatbot?').should('be.visible');
+          return;
+        }
+
+        cy.get('#chakra-modal-modal-stripe-checkout')
+          .should('be.visible')
+          .within(() => {
+            cy.contains('Confirme seu plano').should('be.visible');
+            cy.contains(/chatbot/i).should('be.visible');
+          });
+      });
+    });
+  });
+
   const baseUrl = String(
     Cypress.env('NEXT_PUBLIC_BASE_URL_FRONTEND') || Cypress.config('baseUrl') || ''
   ).toLowerCase();
@@ -222,28 +296,7 @@ describe('Área do Usuário e Sistema de pagamento', () => {
       cy.contains('button', 'Confirmar pagamento', { timeout: 60000 })
         .should('be.visible');
 
-      cy.fillStripeCard();
-
-      cy.intercept(
-        'POST',
-        /https:\/\/api\.stripe\.com\/v1\/(payment_intents|setup_intents)\/.+\/confirm/
-      ).as('stripeConfirmation');
-
-      cy.get('@checkoutModal').within(() => {
-        cy.contains('button', 'Confirmar pagamento', { timeout: 20000 })
-          .should('be.visible')
-          .click();
-      });
-
-      cy.wait('@stripeConfirmation', { timeout: 30000 }).then((interception) => {
-        expect(interception.response.statusCode).to.be.oneOf([200, 201]);
-        const body = interception.response.body || {};
-        const status =
-          body.status ||
-          body.paymentIntent?.status ||
-          body.setupIntent?.status;
-        expect(status).to.eq('succeeded');
-      });
+      cy.confirmStripePayment();
 
       cy.get('#chakra-modal-modal-stripe-payment_intent-succeeded', { timeout: 60000 })
         .should('be.visible')

--- a/next/cypress/e2e/register.cy.js
+++ b/next/cypress/e2e/register.cy.js
@@ -5,6 +5,7 @@ describe('Fluxo de Registro', () => {
 
   it('Deve exibir o formulário corretamente', () => {
     cy.contains('h1', 'Cadastre-se').should('be.visible');
+    cy.contains('Continuar com o Google').should('be.visible');
     cy.get('input[name="firstName"]').should('exist');
     cy.get('input[name="lastName"]').should('exist');
     cy.get('input[name="user"]').should('exist');

--- a/next/cypress/support/commands.js
+++ b/next/cypress/support/commands.js
@@ -50,6 +50,68 @@ Cypress.Commands.add('mockRegisterApi', (response) => {
   cy.intercept('GET', '/api/user/registerAccount*', response).as('registerApi');
 });
 
+Cypress.Commands.add('mockGetIdUser', (response) => {
+  cy.intercept('GET', '/api/user/getIdUser*', response).as('getIdUser');
+});
+
+Cypress.Commands.add('parseUserBdCookie', () => {
+  return cy.getCookie('userBD').then((cookie) => {
+    if (!cookie?.value) throw new Error('Cookie userBD não encontrado');
+
+    try {
+      return JSON.parse(decodeURIComponent(cookie.value));
+    } catch (e1) {
+      return JSON.parse(cookie.value);
+    }
+  });
+});
+
+Cypress.Commands.add('cancelActiveSubscription', () => {
+  cy.loginAndSetCookies().then(({ user }) => {
+    const userData = typeof user === 'string' ? JSON.parse(user) : user;
+    const rawId = userData?.id;
+    if (!rawId) return;
+
+    const userId = String(rawId).includes(':')
+      ? String(rawId).split(':')[1]
+      : String(rawId);
+
+    cy.request({
+      method: 'GET',
+      url: `/api/stripe/getSubscriptionActive?p=${btoa(userId)}&t=${btoa('bd_pro')}`,
+      failOnStatusCode: false,
+    }).then((subscriptionResponse) => {
+      if (subscriptionResponse.status !== 200 || !subscriptionResponse.body) {
+        cy.log('Nenhuma assinatura BD Pro ativa para cancelar');
+        return;
+      }
+
+      cy.request({
+        method: 'GET',
+        url: `/api/stripe/removeSubscriptionImmediately?p=${btoa(subscriptionResponse.body)}`,
+        failOnStatusCode: false,
+      }).then((response) => {
+        if (response.status === 200 && response.body?.success) {
+          cy.log('Assinatura cancelada imediatamente');
+          cy.wait(60000);
+          cy.loginAndSetCookies().then(({ user: refreshedUser }) => {
+            const refreshed = typeof refreshedUser === 'string'
+              ? JSON.parse(refreshedUser)
+              : refreshedUser;
+            if (refreshed?.proSubscription === 'bd_pro') {
+              cy.wait(30000);
+              cy.loginAndSetCookies();
+            }
+          });
+          return;
+        }
+
+        cy.log(`Falha ao cancelar assinatura: status ${response.status}`);
+      });
+    });
+  });
+});
+
 Cypress.Commands.add('loginAndSetCookies', () => {
   const email = Cypress.env('CRYPRESS_AUTH_EMAIL');
   const password = Cypress.env('CRYPRESS_AUTH_PASSWORD');
@@ -85,34 +147,75 @@ Cypress.Commands.add('loginAndSetCookies', () => {
   });
 });
 
-Cypress.Commands.add('arrivingAtCheckout', (button) => {
-  cy.get(button, { timeout: 10000 })
-    .should('be.visible')  
+Cypress.Commands.add('openPlansModal', () => {
+  cy.contains('button', 'Comparar planos')
+    .should('be.visible')
     .click();
 
-  cy.get('#chakra-modal-modal-email-gcp', { timeout: 15000 })
+  cy.get('section[role="dialog"].chakra-modal__content', { timeout: 20000 })
     .should('be.visible')
     .and('have.css', 'opacity', '1')
     .as('plansModal')
     .within(() => {
-      cy.contains('E-mail de acesso ao BigQuery', { timeout: 15000 })
-        .should('be.visible');
+      cy.contains('p', 'BD Pro', { timeout: 20000 }).should('be.visible');
+    });
+});
 
+Cypress.Commands.add('arrivingAtCheckout', (button) => {
+  cy.intercept('GET', '/api/user/changeUserGcpEmail*', { body: { ok: true } }).as('changeGcpEmail');
+
+  cy.get('section[role="dialog"].chakra-modal__content', { timeout: 20000 })
+    .should('be.visible')
+    .and('have.css', 'opacity', '1')
+    .within(($modal) => {
+      const $byId = button ? $modal.find(button) : $modal.find('#bd_pro_button_sub_btn');
+
+      if ($byId.length) {
+        cy.wrap($byId)
+          .should('be.visible')
+          .click({ force: true });
+        return;
+      }
+
+      cy.contains(/Iniciar teste grátis|Assinar/)
+        .should('be.visible')
+        .click({ force: true });
+    });
+
+  cy.contains('E-mail de acesso ao BigQuery', { timeout: 20000 })
+    .should('be.visible');
+
+  cy.get('#chakra-modal-modal-email-gcp', { timeout: 15000 })
+    .should('be.visible')
+    .as('emailGcpModal')
+    .within(() => {
       cy.contains('button', 'Próximo')
         .should('be.visible')
         .click();
     });
 
-    cy.get('#chakra-modal-modal-stripe-checkout', { timeout: 30000 })
-      .should('be.visible')
-      .and('have.css', 'opacity', '1')
-      .as('checkoutModal');
+  cy.wait('@changeGcpEmail');
 
-    cy.get('@checkoutModal').should(($modal) => {
-      expect($modal.height()).to.be.greaterThan(0);
-      expect($modal.width()).to.be.greaterThan(0);
-      expect($modal.find('*').length).to.be.greaterThan(0);
-    });
+  cy.get('#chakra-modal-modal-stripe-checkout', { timeout: 30000 })
+    .should('be.visible')
+    .as('checkoutModal');
+
+  cy.get('@checkoutModal').within(() => {
+    cy.contains('Confirme seu plano', { timeout: 20000 }).should('be.visible');
+  });
+});
+
+Cypress.Commands.add('proceedToPaymentStep', () => {
+  cy.get('@checkoutModal').within(() => {
+    cy.contains('button', 'Próximo')
+      .should('be.visible')
+      .click();
+
+    cy.contains('Pagamento', { timeout: 20000 }).should('be.visible');
+  });
+
+  cy.get('iframe[name^="__privateStripeFrame"]', { timeout: 60000 })
+    .should('be.visible');
 });
 
 Cypress.Commands.add('verifyElement', (text) => {
@@ -126,19 +229,159 @@ Cypress.Commands.add('verifyElement', (text) => {
     });
 })
 
-Cypress.Commands.add('fillStripeInput', (fieldName, value) => {
-  const selectors = {
-    cardNumber: 'input[id="Field-numberInput"]',
-    cardExpiry: 'input[id="Field-expiryInput"]',
-    cardCvc: 'input[id="Field-cvcInput"]'
-  };
+Cypress.Commands.add('fillStripeCard', ({
+  number = '4242424242424242',
+  expiry = '1230',
+  cvc = '123',
+} = {}) => {
+  const cdp = (command, params = {}) =>
+    Cypress.automation('remote:debugger:protocol', { command, params });
 
-  cy.get('iframe[name^="__privateStripeFrame"]', { timeout: 60000 })
-    .its('0.contentDocument.body')
-    .should('not.be.empty')
-    .then(cy.wrap)
-    .find(selectors[fieldName])
-    .type(value, { force: true, delay: 50 });
+  const clickNode = (nodeId) =>
+    cdp('DOM.scrollIntoViewIfNeeded', { nodeId })
+      .catch(() => null)
+      .then(() => cdp('DOM.getContentQuads', { nodeId }))
+      .then(({ quads }) => {
+        const quad = quads && quads[0];
+        if (!quad || quad.length < 8) return false;
+        const x = (quad[0] + quad[2] + quad[4] + quad[6]) / 4;
+        const y = (quad[1] + quad[3] + quad[5] + quad[7]) / 4;
+        return cdp('Input.dispatchMouseEvent', {
+          type: 'mousePressed',
+          x,
+          y,
+          button: 'left',
+          clickCount: 1,
+        }).then(() =>
+          cdp('Input.dispatchMouseEvent', {
+            type: 'mouseReleased',
+            x,
+            y,
+            button: 'left',
+            clickCount: 1,
+          })
+        ).then(() => true);
+      })
+      .catch(() => false);
+
+  const clickSearch = (query, { exactText } = {}) =>
+    cdp('DOM.getDocument', { depth: -1, pierce: true }).then(() =>
+      cdp('DOM.performSearch', { query }).then((search) => {
+        if (!search.resultCount) {
+          return cdp('DOM.discardSearchResults', { searchId: search.searchId }).then(() => false);
+        }
+
+        return cdp('DOM.getSearchResults', {
+          searchId: search.searchId,
+          fromIndex: 0,
+          toIndex: Math.min(search.resultCount, 30),
+        }).then((result) => {
+          const nodeIds = result.nodeIds || [];
+          const inspect = (index, candidates) => {
+            if (index >= nodeIds.length) {
+              const sorted = candidates.sort((a, b) => a.length - b.length);
+              const tryClick = (i) => {
+                if (i >= sorted.length) {
+                  return cdp('DOM.discardSearchResults', { searchId: search.searchId }).then(() => false);
+                }
+                return clickNode(sorted[i].nodeId).then((clicked) => {
+                  if (clicked) {
+                    return cdp('DOM.discardSearchResults', { searchId: search.searchId }).then(() => true);
+                  }
+                  return tryClick(i + 1);
+                });
+              };
+              return tryClick(0);
+            }
+
+            return cdp('DOM.getOuterHTML', { nodeId: nodeIds[index] }).then(({ outerHTML }) => {
+              const text = String(outerHTML || '')
+                .replace(/<[^>]+>/g, ' ')
+                .replace(/\s+/g, ' ')
+                .trim();
+
+              const matches = exactText
+                ? text === exactText || text.includes(exactText)
+                : true;
+
+              if (matches) {
+                candidates.push({ nodeId: nodeIds[index], length: text.length });
+              }
+
+              return inspect(index + 1, candidates);
+            }).catch(() => inspect(index + 1, candidates));
+          };
+
+          return inspect(0, []);
+        });
+      })
+    );
+
+  const typeChars = (value) =>
+    value.split('').reduce(
+      (chain, char) =>
+        chain.then(() =>
+          cdp('Input.insertText', { text: char }).then(
+            () => new Cypress.Promise((resolve) => setTimeout(resolve, 35))
+          )
+        ),
+      Cypress.Promise.resolve()
+    );
+
+  const pressTab = () =>
+    cdp('Input.dispatchKeyEvent', {
+      type: 'rawKeyDown',
+      key: 'Tab',
+      code: 'Tab',
+      windowsVirtualKeyCode: 9,
+      nativeVirtualKeyCode: 9,
+    }).then(() =>
+      cdp('Input.dispatchKeyEvent', {
+        type: 'keyUp',
+        key: 'Tab',
+        code: 'Tab',
+        windowsVirtualKeyCode: 9,
+        nativeVirtualKeyCode: 9,
+      })
+    );
+
+  cy.get('#chakra-modal-modal-stripe-checkout iframe[name^="__privateStripeFrame"]', { timeout: 60000 })
+    .should('be.visible');
+
+  cy.then(() =>
+    clickSearch('Cartão', { exactText: 'Cartão' }).then((clicked) => {
+      if (clicked) return true;
+      return clickSearch('Card', { exactText: 'Card' }).then((clickedCard) => {
+        if (clickedCard) return true;
+        return clickSearch('Boleto', { exactText: 'Boleto' }).then(() =>
+          new Cypress.Promise((resolve) => setTimeout(resolve, 500)).then(() =>
+            clickSearch('Cartão', { exactText: 'Cartão' })
+          )
+        );
+      });
+    })
+  );
+
+  cy.wait(1000);
+
+  cy.then(() =>
+    clickSearch('Número do cartão', { exactText: 'Número do cartão' }).then((clicked) => {
+      if (clicked) return true;
+      return clickSearch('Card number', { exactText: 'Card number' }).then((clickedEn) => {
+        if (clickedEn) return true;
+        return clickSearch('1234 1234 1234 1234');
+      });
+    }).then((clickedNumber) => {
+      if (!clickedNumber) {
+        throw new Error('Campo de cartão do Stripe não encontrado após selecionar Cartão');
+      }
+      return typeChars(number)
+        .then(pressTab)
+        .then(() => typeChars(expiry))
+        .then(pressTab)
+        .then(() => typeChars(cvc));
+    })
+  );
 });
 
 Cypress.Commands.add('applyCoupon', (coupon, text) => {

--- a/next/cypress/support/commands.js
+++ b/next/cypress/support/commands.js
@@ -66,7 +66,7 @@ Cypress.Commands.add('parseUserBdCookie', () => {
   });
 });
 
-Cypress.Commands.add('cancelActiveSubscription', () => {
+Cypress.Commands.add('cancelActiveSubscription', (types = ['bd_pro', 'chatbot']) => {
   cy.loginAndSetCookies().then(({ user }) => {
     const userData = typeof user === 'string' ? JSON.parse(user) : user;
     const rawId = userData?.id;
@@ -76,39 +76,52 @@ Cypress.Commands.add('cancelActiveSubscription', () => {
       ? String(rawId).split(':')[1]
       : String(rawId);
 
-    cy.request({
-      method: 'GET',
-      url: `/api/stripe/getSubscriptionActive?p=${btoa(userId)}&t=${btoa('bd_pro')}`,
-      failOnStatusCode: false,
-    }).then((subscriptionResponse) => {
-      if (subscriptionResponse.status !== 200 || !subscriptionResponse.body) {
-        cy.log('Nenhuma assinatura BD Pro ativa para cancelar');
+    const cancelNext = (index, didCancel) => {
+      if (index >= types.length) {
+        if (!didCancel) return;
+
+        cy.wait(60000);
+        cy.loginAndSetCookies().then(({ user: refreshedUser }) => {
+          const refreshed = typeof refreshedUser === 'string'
+            ? JSON.parse(refreshedUser)
+            : refreshedUser;
+          if (refreshed?.proSubscription === 'bd_pro') {
+            cy.wait(30000);
+            cy.loginAndSetCookies();
+          }
+        });
         return;
       }
 
+      const type = types[index];
+
       cy.request({
         method: 'GET',
-        url: `/api/stripe/removeSubscriptionImmediately?p=${btoa(subscriptionResponse.body)}`,
+        url: `/api/stripe/getSubscriptionActive?p=${btoa(userId)}&t=${btoa(type)}`,
         failOnStatusCode: false,
-      }).then((response) => {
-        if (response.status === 200 && response.body?.success) {
-          cy.log('Assinatura cancelada imediatamente');
-          cy.wait(60000);
-          cy.loginAndSetCookies().then(({ user: refreshedUser }) => {
-            const refreshed = typeof refreshedUser === 'string'
-              ? JSON.parse(refreshedUser)
-              : refreshedUser;
-            if (refreshed?.proSubscription === 'bd_pro') {
-              cy.wait(30000);
-              cy.loginAndSetCookies();
-            }
-          });
-          return;
+      }).then((subscriptionResponse) => {
+        if (subscriptionResponse.status !== 200 || !subscriptionResponse.body) {
+          cy.log(`Nenhuma assinatura ${type} ativa para cancelar`);
+          return cancelNext(index + 1, didCancel);
         }
 
-        cy.log(`Falha ao cancelar assinatura: status ${response.status}`);
+        cy.request({
+          method: 'GET',
+          url: `/api/stripe/removeSubscriptionImmediately?p=${btoa(subscriptionResponse.body)}`,
+          failOnStatusCode: false,
+        }).then((response) => {
+          if (response.status === 200 && response.body?.success) {
+            cy.log(`Assinatura ${type} cancelada imediatamente`);
+            return cancelNext(index + 1, true);
+          }
+
+          cy.log(`Falha ao cancelar assinatura ${type}: status ${response.status}`);
+          cancelNext(index + 1, didCancel);
+        });
       });
-    });
+    };
+
+    cancelNext(0, false);
   });
 });
 
@@ -328,27 +341,55 @@ Cypress.Commands.add('fillStripeCard', ({
       Cypress.Promise.resolve()
     );
 
-  const pressTab = () =>
-    cdp('Input.dispatchKeyEvent', {
-      type: 'rawKeyDown',
-      key: 'Tab',
-      code: 'Tab',
-      windowsVirtualKeyCode: 9,
-      nativeVirtualKeyCode: 9,
-    }).then(() =>
-      cdp('Input.dispatchKeyEvent', {
-        type: 'keyUp',
-        key: 'Tab',
-        code: 'Tab',
-        windowsVirtualKeyCode: 9,
-        nativeVirtualKeyCode: 9,
-      })
-    );
+  const clickFirstMatch = (queries) => {
+    const tryQuery = (index) => {
+      if (index >= queries.length) return Cypress.Promise.resolve(false);
+      const { query, exactText } = queries[index];
+      return clickSearch(query, exactText ? { exactText } : {}).then((clicked) => {
+        if (clicked) return true;
+        return tryQuery(index + 1);
+      });
+    };
+    return tryQuery(0);
+  };
 
-  cy.get('#chakra-modal-modal-stripe-checkout iframe[name^="__privateStripeFrame"]', { timeout: 60000 })
-    .should('be.visible');
+  const fillField = (queries, value) =>
+    clickFirstMatch(queries).then((clicked) => {
+      if (!clicked) return false;
+      return typeChars(value).then(() => true);
+    });
 
-  cy.then(() =>
+  const fillCardFields = () =>
+    fillField(
+      [
+        { query: 'Número do cartão', exactText: 'Número do cartão' },
+        { query: 'Card number', exactText: 'Card number' },
+        { query: '1234 1234 1234 1234' },
+      ],
+      number
+    ).then((okNumber) => {
+      if (!okNumber) return false;
+      return fillField(
+        [
+          { query: 'MM / AA' },
+          { query: 'MM/AA' },
+          { query: 'Data de validade', exactText: 'Data de validade' },
+        ],
+        expiry
+      ).then((okExpiry) => {
+        if (!okExpiry) return false;
+        return fillField(
+          [
+            { query: 'CVC' },
+            { query: 'CVV' },
+            { query: 'Código de segurança', exactText: 'Código de segurança' },
+          ],
+          cvc
+        );
+      });
+    });
+
+  const selectCardTab = () =>
     clickSearch('Cartão', { exactText: 'Cartão' }).then((clicked) => {
       if (clicked) return true;
       return clickSearch('Card', { exactText: 'Card' }).then((clickedCard) => {
@@ -359,29 +400,50 @@ Cypress.Commands.add('fillStripeCard', ({
           )
         );
       });
-    })
-  );
+    });
+
+  cy.get('#chakra-modal-modal-stripe-checkout iframe[name^="__privateStripeFrame"]', { timeout: 60000 })
+    .should('be.visible');
 
   cy.wait(1000);
 
   cy.then(() =>
-    clickSearch('Número do cartão', { exactText: 'Número do cartão' }).then((clicked) => {
-      if (clicked) return true;
-      return clickSearch('Card number', { exactText: 'Card number' }).then((clickedEn) => {
-        if (clickedEn) return true;
-        return clickSearch('1234 1234 1234 1234');
-      });
-    }).then((clickedNumber) => {
-      if (!clickedNumber) {
-        throw new Error('Campo de cartão do Stripe não encontrado após selecionar Cartão');
-      }
-      return typeChars(number)
-        .then(pressTab)
-        .then(() => typeChars(expiry))
-        .then(pressTab)
-        .then(() => typeChars(cvc));
+    fillCardFields().then((filled) => {
+      if (filled) return true;
+      return selectCardTab()
+        .then(() => new Cypress.Promise((resolve) => setTimeout(resolve, 1000)))
+        .then(() => fillCardFields())
+        .then((filledAfterSelect) => {
+          if (!filledAfterSelect) {
+            throw new Error('Campo de cartão do Stripe não encontrado após selecionar Cartão');
+          }
+          return true;
+        });
     })
   );
+});
+
+Cypress.Commands.add('confirmStripePayment', () => {
+  cy.intercept(
+    'POST',
+    /https:\/\/api\.stripe\.com\/v1\/(payment_intents|setup_intents)\/.+\/confirm/
+  ).as('stripeConfirmation');
+
+  cy.fillStripeCard();
+
+  cy.contains('button', 'Confirmar pagamento', { timeout: 20000 })
+    .should('be.visible')
+    .click();
+
+  cy.wait('@stripeConfirmation', { timeout: 30000 }).then((interception) => {
+    expect(interception.response.statusCode).to.be.oneOf([200, 201]);
+    const body = interception.response.body || {};
+    const status =
+      body.status ||
+      body.paymentIntent?.status ||
+      body.setupIntent?.status;
+    expect(status).to.eq('succeeded');
+  });
 });
 
 Cypress.Commands.add('applyCoupon', (coupon, text) => {

--- a/next/cypress/support/e2e.js
+++ b/next/cypress/support/e2e.js
@@ -1,1 +1,17 @@
 import './commands'
+import 'cypress-plugin-stripe-elements'
+import 'cypress-real-events'
+
+Cypress.on('uncaught:exception', (err) => {
+  if (/loaderUi Element didn't mount normally/i.test(err.message)) {
+    return false
+  }
+  return true
+})
+
+Cypress.Commands.overwrite('visit', (originalFn, url, options) => {
+  originalFn(url, options)
+  cy.get('body', { timeout: 30000 }).should(($body) => {
+    expect($body.css('display')).to.not.eq('none')
+  })
+})

--- a/next/package-lock.json
+++ b/next/package-lock.json
@@ -53,6 +53,7 @@
       "devDependencies": {
         "cypress": "^14.4.0",
         "cypress-plugin-stripe-elements": "^1.0.2",
+        "cypress-real-events": "^1.15.0",
         "medium-2-md": "github:gautamdhameja/medium-2-md",
         "puppeteer": "^23.1.1",
         "puppeteer-core": "^23.1.1",
@@ -3177,6 +3178,15 @@
       "integrity": "sha512-tNXZ9BHooO8IGGmOpVRhNfGde/vmPY4D56pi4VHw1EWbfSuwCoveeqqjKDeRfPzMTD5gGYGwXdX2qO1S9O9GEg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cypress-real-events": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/cypress-real-events/-/cypress-real-events-1.15.0.tgz",
+      "integrity": "sha512-in98xxTnnM9Z7lZBvvVozm99PBT2eEOjXRG5LKWyYvQnj9mGWXMiPNpfw7e7WiraBFh7XlXIxnE9Cu5o+52kQQ==",
+      "dev": true,
+      "peerDependencies": {
+        "cypress": "^4.x || ^5.x || ^6.x || ^7.x || ^8.x || ^9.x || ^10.x || ^11.x || ^12.x || ^13.x || ^14.x || ^15.x"
+      }
     },
     "node_modules/cypress/node_modules/proxy-from-env": {
       "version": "1.0.0",

--- a/next/package.json
+++ b/next/package.json
@@ -9,7 +9,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "NODE_OPTIONS='-r next-logger' next start",
-    "cypress": "npx cypress open"
+    "cypress": "npx cypress open",
+    "cypress:run": "npx cypress run --browser chrome",
+    "cypress:run:electron": "npx cypress run"
   },
   "dependencies": {
     "@chakra-ui/icons": "^1.1.7",
@@ -57,6 +59,7 @@
   "devDependencies": {
     "cypress": "^14.4.0",
     "cypress-plugin-stripe-elements": "^1.0.2",
+    "cypress-real-events": "^1.15.0",
     "medium-2-md": "github:gautamdhameja/medium-2-md",
     "puppeteer": "^23.1.1",
     "puppeteer-core": "^23.1.1",

--- a/next/pages/prices.js
+++ b/next/pages/prices.js
@@ -54,7 +54,7 @@ export const CardPrice = ({
     if (button.onClick) {
       button.onClick();
     }
-    if (button.href) {
+    if (button.href && router.asPath !== button.href) {
       router.push(button.href);
     }
   };
@@ -635,6 +635,7 @@ export function SectionPrice({
                 (feature) => ({ name: feature }),
               )}
               button={{
+                id: "bd_chatbot_button_sub_btn",
                 text: isBDChatbot.isCurrentPlan
                     ? t("currentPlan")
                     : hasSubscribedChatbot
@@ -676,6 +677,7 @@ export function SectionPrice({
               }),
             )}
             button={{
+              id: "bd_pro_button_sub_btn",
               text: isBDPro.isCurrentPlan
                   ? t("currentPlan")
                   : hasSubscribedBDPro
@@ -718,6 +720,7 @@ export function SectionPrice({
                   },
             )}
             button={{
+              id: "bd_orgs_button_contact_btn",
               text: isBDEmp.isCurrentPlan
                   ? t("currentPlan")
                   : t("contactUs"),


### PR DESCRIPTION
## Summary
- Atualiza os testes Cypress de login, cadastro, recuperação de senha, check-email e pagamento para o checkout em duas etapas, Google login e trial do Chatbot.
- Ajusta o Payment Element para abrir no cartão primeiro (`paymentMethodOrder`) e só ativa trial do Chatbot na primeira assinatura (`enableChatbotTrial`).
- Roda o workflow de Cypress em todo PR para `main` (não só `staging` → `main`) e corrige o path do YAML.
