### PR TITLE
feat(blog): localized post slugs, and the blog in en and es (21/54 posts)

### DIFF
--- a/next/blog/en/analisando-atividade-economica-do-rio-de-janeiro.md
+++ b/next/blog/en/analisando-atividade-economica-do-rio-de-janeiro.md
@@ -1,11 +1,12 @@
 ---
-title: Análise da Atividade Econômica do Estado do Rio de Janeiro e da influência da capital
-description: Explorando dados da RAIS para analisar as principais atividades econômicas do estado e sua relação com a capital
+title: Economic activity in the state of Rio de Janeiro and the pull of its capital
+description: Using RAIS data to analyse the state's main economic activities and their relationship with the capital
+slug: economic-activity-in-rio-de-janeiro-state
 date:
   created: "2024-04-10T15:00:00"
 authors:
   - name: Laryssa Bertin Ribeiro
-    role: Autora
+    role: Author
     social: https://medium.com/@lary.bertin
 thumbnail: /blog/analisando-atividade-economica-do-rio-de-janeiro/image_4.webp
 categories: [analise]
@@ -16,37 +17,37 @@ published: true
 
 ## TL;DR
 
-Este relatório apresenta uma investigação detalhada sobre os dados relacionados às principais atividades econômicas do Estado do Rio de Janeiro, focando na relação com sua capital.
+This report investigates the main economic activities of the state of Rio de Janeiro, focusing on their relationship with the state capital.
 
-O estudo também avalia a dinâmica da geração dos empregos ativos ao longo de um período determinado. Utilizando dados da [Relação Anual de Informações Sociais](/dataset/3e7c4d58-96ba-448e-b053-d385a829ef00?table=c3a5121e-f00d-41ff-b46f-bd26be8d4af3) (RAIS), o trabalho emprega análises estatísticas para compreender a evolução desses padrões e suas implicações na relação com os demais municípios do estado do Rio de Janeiro.
+It also examines how active employment was generated over a defined period. Drawing on data from the [Annual Social Information Report](/dataset/3e7c4d58-96ba-448e-b053-d385a829ef00?table=c3a5121e-f00d-41ff-b46f-bd26be8d4af3) (RAIS), it applies statistical analysis to trace how these patterns evolved and what they imply for the other municipalities in the state.
 
-> Este artigo foi produzido como Projeto Final do Curso de Análise de Dados Públicos com SQl e Sheets, da Base dos Dados. Para saber mais sobre o curso, acesse [aqui](https://info.basedosdados.org/bd-edu-cursos)
+> This article was produced as the final project of Data Basis' course on Public Data Analysis with SQL and Sheets. To find out more about the course, see [here](https://info.basedosdados.org/bd-edu-cursos)
 
-## Introdução
+## Introduction
 
-Segundo a [Pesquisa Mensal de Emprego](https://www.data.rio/documents/4e6901873b314e2bacce25f8645046bd/explore) (PME), do IBGE, em 2016 o grupamento _Educação, Saúde e Administração Pública_ ocupava 23,3% dos empregos na cidade do Rio de Janeiro (680 mil); _Outros Serviços_ empregavam 19,9% (581 mil); os _Serviços Prestados às Empresas_, 18,7% (548 mil); o _Comércio_, 17,0% (496 mil); a Indústria,11,2% (328 mil); a _Construção_, 5,7% (166 mil) e os _Serviços Domésticos_, 3,7% (108 mil).
+According to IBGE's [Monthly Employment Survey](https://www.data.rio/documents/4e6901873b314e2bacce25f8645046bd/explore) (PME), in 2016 the grouping _Education, Health and Public Administration_ accounted for 23.3% of jobs in the city of Rio de Janeiro (680,000); _Other Services_ for 19.9% (581,000); _Business Services_ for 18.7% (548,000); _Commerce_ for 17.0% (496,000); Industry for 11.2% (328,000); _Construction_ for 5.7% (166,000); and _Domestic Services_ for 3.7% (108,000).
 
-Segundo o IBGE, em fevereiro de 2016 haviam 5 milhões e 910 mil pessoas em idade ativa (PIA) no Município do Rio de Janeiro. Essa população ficou ligeiramente estável durante o ano. Desse total de pessoas em idade ativa, 49,4% encontravam-se ocupadas (nível de ocupação), 2,7% desocupadas e 47,8% não estavam economicamente ativas. O rendimento médio real da população ocupada no município foi estimado em R$ 3.038,40, o que traduzia a renda per capita do carioca.
+IBGE recorded 5,910,000 people of working age in the municipality of Rio de Janeiro in February 2016, a figure that held roughly steady across the year. Of those, 49.4% were employed, 2.7% unemployed and 47.8% not economically active. Average real income among the employed population in the municipality was estimated at R$ 3,038.40, which stood as the per capita income of a Rio resident.
 
-Em relação à população ocupada, os empregados com carteira assinada no setor privado representaram 47,0% (1.373 mil), os empregados sem carteira assinada no setor privado, 7,2% (210 mil), os trabalhadores por conta própria, 21,8% (636 mil) e os Militares ou funcionários públicos estatutários, 13,5% (395 mil).
+Within the employed population, formally registered private sector employees made up 47.0% (1,373,000), unregistered private sector employees 7.2% (210,000), self-employed workers 21.8% (636,000), and military or statutory public servants 13.5% (395,000).
 
-Os CNAEs foram oficializados através da Resolução do IBGE/CONCLA (Figura 1), do dia 4 de setembro de 2006. Direcionada tecnicamente pelo IBGE (Instituto Brasileiro de Geografia e Estatística), o CNAE é coordenado pela Secretaria da Receita Federal. Formado por uma combinação de 7 números, eles representam a junção de seções, grupos, divisões, classes e subclasses.
+The CNAE economic activity codes were formalised by an IBGE/CONCLA resolution (Figure 1) of 4 September 2006. Technically directed by IBGE, the Brazilian Institute of Geography and Statistics, CNAE is coordinated by the Federal Revenue Secretariat. Each code combines seven digits representing sections, groups, divisions, classes and subclasses.
 
-A primeira versão do detalhamento das subclasses CNAE foi definida em 1998, com a denominação CNAE-Fiscal. Passou por ajustes em 2001 (versão CNAE-Fiscal 1.0) e em 2002 (versão CNAE-Fiscal 1.1), esta última acompanhando alterações pontuais na estrutura da CNAE (versão CNAE 1.0) em função de ajustes na classificação internacional versão ISIC/CIIU 3.1 (Figura 2).
+The first detailed version of the CNAE subclasses was defined in 1998 under the name CNAE-Fiscal. It was adjusted in 2001 (CNAE-Fiscal 1.0) and again in 2002 (CNAE-Fiscal 1.1), the latter tracking specific changes to the CNAE structure (CNAE 1.0) that followed adjustments to the international ISIC/CIIU 3.1 classification (Figure 2).
 
 <Image src="/blog/analisando-atividade-economica-do-rio-de-janeiro/image_0.webp"/>
 
-## Metodologia
+## Methodology
 
-Este estudo baseia-se na análise de dados provenientes da base [Relação Anual de Informações Sociais](https://ftp.ibge.gov.br/Trabalho_e_Rendimento/Pesquisa_Mensal_de_Emprego/Municipio_RJ/Comentarios/2016/pme-rj_201602comentarios.pdf) (RAIS), que é um relatório de informações socioeconômicas solicitado pela Secretaria de Trabalho do Ministério da Economia brasileiro às pessoas jurídicas e outros empregadores anualmente. O relatório possui periodicidade anual e apresenta informações sobre todos os estabelecimentos formais e vínculos celetistas e estatutários no Brasil. A geração das estatísticas da RAIS 2021 contou, portanto, com duas fontes de captação de dados: o eSocial e o GDRAIS, com as seguintes definições:
+This study analyses data from the [Annual Social Information Report](https://ftp.ibge.gov.br/Trabalho_e_Rendimento/Pesquisa_Mensal_de_Emprego/Municipio_RJ/Comentarios/2016/pme-rj_201602comentarios.pdf) (RAIS), a socioeconomic return that the Labour Secretariat of Brazil's Ministry of the Economy requires annually from companies and other employers. It is published yearly and covers every formal establishment and every contractual and statutory employment relationship in Brazil. The 2021 RAIS statistics drew on two data sources, eSocial and GDRAIS, with the following definitions:
 
-- **Estoque de empregos formais**: Diz respeito ao número de vínculos ativos em 31/12 do ano anterior, ou seja, um retrato do mercado de trabalho.
-- **Estabelecimentos**: A obrigatoriedade de declaração da RAIS é por cada estabelecimento, permitindo análise de suas principais características como: setor de atividade econômica, natureza jurídica e localização geográfica. Desde 1995, os estabelecimentos sem empregados passaram a ser obrigados a enviar a chamada RAIS negativa.
-- **Grupamento de Atividades Econômicas**: Classificação derivada da agregação das Seções da Classificação Nacional de Atividades Econômicas (CNAE2.0).
+- **Stock of formal jobs**: the number of active employment relationships on 31 December of the previous year — a snapshot of the labour market.
+- **Establishments**: RAIS must be filed per establishment, which allows analysis of characteristics such as economic sector, legal status and geographic location. Since 1995, establishments with no employees have been required to file what is known as a negative RAIS.
+- **Economic Activity Grouping**: a classification derived from aggregating the Sections of the National Classification of Economic Activities (CNAE 2.0).
 
-Foram utilizadas consultas SQL e o datalake público da Base dos Dados, que pode ser acessado pela plataforma BigQuery para coletar e visualizar os dados relevantes. A consulta SQL específica utilizada para extrair os dados necessários para a análise básica, que trata dos vínculos ativos no período de 2018 a 2022 para cada CNAE no estado do Rio de Janeiro, está apresentada abaixo:
+We used SQL queries against the public Data Basis datalake, accessible through BigQuery, to collect and visualise the relevant data. The query used to extract the data for the basic analysis — active employment relationships from 2018 to 2022 for each CNAE in the state of Rio de Janeiro — is shown below:
 
-**Consulta A**
+**Query A**
 
 ```sql
 SELECT
@@ -91,10 +92,9 @@ GROUP BY
 ORDER BY
   CNAE DESC;
 ```
+<Image src="/blog/analisando-atividade-economica-do-rio-de-janeiro/image_1.webp" caption="Table A1: Jobs by CNAE, state of Rio de Janeiro, 2018 to 2022"/>
 
-<Image src="/blog/analisando-atividade-economica-do-rio-de-janeiro/image_1.webp" caption="Tabela A1: Empregos por CNAEs, estado do Rio de Janeiro, 2018 a 2022"/>
-
-**Consulta B**
+**Query B**
 
 ```sql
 SELECT
@@ -142,41 +142,40 @@ GROUP BY
 ORDER BY
   CNAE DESC;
 ```
+## Analysis and results
 
-## Desenvolvimento e resultados
+The economy of a region shapes how many jobs it generates. The city of Rio de Janeiro has a large metropolitan area and considerable pull over other cities in the state.
 
-A economia de uma região geográfica influencia a quantidade de empregos gerados. A cidade do Rio de Janeiro possui uma grande região metropolitana e uma grande influência em outras cidades do estado.
+One aim of **Query A** was to identify the economic activities accounting for more than 50% of jobs generated in the state of Rio de Janeiro. For this purpose the study set a cut-off of 35 CNAEs out of a total of 1,318, together holding 52.82% of the total job stock at the start of 2022, as shown in **Table A1**.
 
-Um dos objetivos da **Consulta A** foi identificar as atividades econômicas que representam mais de 50% dos empregados gerados no estado do Rio de Janeiro. A pesquisa estabeleceu como uma linha de corte para efeitos dessa pesquisa 35 CNAEs, de um total de 1.318, com 52,82% do estoque total de empregos no início de 2022 conforme a **Tabela A1**.
+**Chart A** was then produced to identify the main job-generating economic activities in the state, drawing on **Table A2**, which presents the groupings of those activities.
 
-Dessa forma, o **Gráfico A** foi gerado para identificar as principais atividades econômicas geradoras de empregos no estado do Rio de Janeiro a partir da **Tabela A2,** que apresenta os grupamentos das principais atividades econômicas.
+<Image src="/blog/analisando-atividade-economica-do-rio-de-janeiro/image_2.webp" caption="Chart A: Main economic activities accounting for more than 50% of jobs"/>
 
-<Image src="/blog/analisando-atividade-economica-do-rio-de-janeiro/image_2.webp" caption="Gráfico A: Principais atividades econômicas com mais de 50% dos empregos"/>
+<Image src="/blog/analisando-atividade-economica-do-rio-de-janeiro/image_3.webp" caption="Table A2: Jobs by grouping, state of Rio de Janeiro"/>
 
-<Image src="/blog/analisando-atividade-economica-do-rio-de-janeiro/image_3.webp" caption="Tabela A2: Empregos por Grupamentos, estado do Rio de Janeiro"/>
+One aim of **Query B** was to identify the economic activities generating the most jobs in the city of Rio de Janeiro, shown in **Table B**. Summing total jobs generated in the state and in the city across 2018 to 2022 allowed **Chart B** to be built, showing how the two move together.
 
-Um dos objetivos da **Consulta B** foi identificar as principais atividades econômicas que geraram mais empregos na cidade do Rio de Janeiro, conforme é possível observar na **Tabela B**. Com o somatório do total de empregos gerados no estado e na cidade ao longo do período 2018 a 2022, foi possível elaborar o **Gráfico B** para identificar sua relação dinâmica.
+DataMPE Brasil, a service producing and disseminating data relevant to small business development created by SEBRAE Rio de Janeiro, used RAIS data to establish that 3,938,871 employees were registered in the state in 2021, a change of 4.56% on the previous year. Average worker pay in 2021 was R$ 2,333.58, and 560,871 establishments were registered, a change of 2.84% on the previous year.
 
-O DataMPE Brasil, serviço para a produção e disseminação de dados e informações relevantes para o desenvolvimento dos pequenos negócios criado pelo SEBRAE Rio de Janeiro, utilizando os dados da Relação Anual de Informações Sociais (RAIS), identificou que o número de empregados cadastrados no estado foi 3.938.871 em 2021, o que representa uma variação de 4.56% em relação ao ano anterior. A remuneração média do trabalhador no ano de 2021 foi de R$ 2.333,58, e o número de estabelecimentos cadastrados foi 560.871, o que representa uma variação de 2.84% em relação ao ano anterior.
+In the state of Rio de Janeiro, the economic sectors employing the most workers in 2021 were _Public Administration, Defence and Social Security_ (730,013), _Retail Commerce_ (598,989) and _Education_ (231,811).
 
-No Estado de Rio De Janeiro, os setores econômicos que mais reuniram trabalhadores em 2021 foram a _Administração Pública_, _Defesa e Seguridade Social_ (730.013), o _Comércio Varejista_ (598.989), e _Educação_ (231.811).
+In the same year, 42.9% of workers were women, with average pay of R$ 3,186.91, and 57.1% were men, with average pay of R$ 3,780.99.
 
-No mesmo ano, 42.9% dos trabalhadores eram mulheres, com uma remuneração média por pessoa de R$ 3186,91; 57.1% correspondiam a homens, com remuneração média de R$ 3780,99.
+According to Brazil's Federal Revenue Service, of all establishments registered up to 2023, 10.3% fall under _Other_ (214,564 establishments), 62.8% are _Individual Micro-entrepreneurs (MEI)_ (1,312,029), 22.5% are _Micro-enterprises (ME)_ (470,895), and 4.44% are _Small Businesses (EPP)_ (92,755).
 
-De acordo com os dados da Receita Federal do Brasil (RFB), do total de estabelecimentos com registro até 2023, 10.3% correspondem a _Outros_ (214.564 estabelecimentos), 62.8% correspondem a _Micro Empresário Individual_ _(MEI)_ (1.312.029 estabelecimentos), 22.5% correspondem a _Microempresa (ME)_ (470.895 estabelecimentos), e 4.44% correspondem a _Empresa de Pequeno Porte (EPP)_ (92.755 estabelecimentos).
+About 13.2 million people worked as individual micro-entrepreneurs (MEIs) in Brazil in 2021, equivalent to 69.7% of all companies and other organisations and 19.2% of all formally employed people. Of the 673 classes in CNAE 2.0, MEIs were present in 206 in 2021. More than half of MEIs (55.7%) fall within the first 15 classes and almost 75% within the first 30. About half (50.2%) were in the Services sector in 2021. Commerce and 'repair of motor vehicles and motorcycles' accounted for 29.3%, and that activity had the largest number of MEI employees (48.3%).
 
-Cerca de 13,2 milhões de pessoas trabalhavam como microempreendedores individuais (MEIs) no Brasil em 2021, o equivalente a 69,7% do total de empresas e outras organizações e 19,2% do total de ocupados formais. Em 2021, do total de 673 classes da CNAE 2.0, o MEI esteve presente em 206. Mais da metade dos MEIs (55,7%) estão presentes nas 15 primeiras classes e quase 75% nas 30 primeiras. Cerca de metade dos MEIs (50,2%) estava presente no setor de Serviços em 2021. O Comércio ‘reparação de veículo automotores e motocicletas’ respondeu por 29,3%, sendo essa atividade a que apresentou o maior quantitativo de empregados dos MEIs (48,3%).
+Rio de Janeiro was the federal unit with the highest proportion of MEIs relative to total formal employment (26%), followed by Espírito Santo (24.8%).
 
-O Rio de Janeiro foi a unidade da federação com maior proporção de MEIs em relação ao total de ocupados formais (26%), seguida pelo Espírito Santo (24,8%).
+We consulted the [Federal Revenue](https://www8.receita.fazenda.gov.br/simplesnacional/aplicacoes/atbhe/estatisticassinac.app/EstatisticasOptantesPorCNAE.aspx?tipoConsulta=2&optanteSimei=&anoConsulta=MjAyMg%3D%3D) site, which holds figures on MEIs by CNAE. The search found 35 CNAEs accounting for 67.42% of all individual micro-entrepreneurs as of 18 November 2023.
 
-Consultamos o site da [Receita federal](https://www8.receita.fazenda.gov.br/simplesnacional/aplicacoes/atbhe/estatisticassinac.app/EstatisticasOptantesPorCNAE.aspx?tipoConsulta=2&optanteSimei=&anoConsulta=MjAyMg%3D%3D) que contém informações sobre a quantidade de MEIs por CNAE. A pesquisa encontrou 35 CNAEs com 67,42% do total de microempresários individuais em 18/11/2023.
+<Image src="/blog/analisando-atividade-economica-do-rio-de-janeiro/image_4.webp" caption="Chart B: Employment relationship between the city and state of Rio de Janeiro"/>
 
-<Image src="/blog/analisando-atividade-economica-do-rio-de-janeiro/image_4.webp" caption="Gráfico B: Relação de emprego cidade/estado do Rio de Janeiro"/>
+## Conclusion
 
-## Conclusão
+The analysis shows how much economic activity tied to Public Administration weighs on the economy of the state of Rio de Janeiro, as **Chart A** makes clear. Many of these activities are plausibly carried out by companies providing technical or administrative services to state entities, public organisations and municipal and state governments.
 
-A análise revela a significativa influência das atividades econômicas ligadas à Administração Pública no panorama econômico do Estado do Rio de Janeiro, evidenciada pelo **Gráfico A**. É plausível que muitas dessas atividades sejam conduzidas por empresas que oferecem serviços técnicos ou administrativos complementares às entidades estatais, organizações públicas e governos municipais e estaduais.
+To understand the picture better, future work could identify the centres of influence for public economic activity, which would allow comparison against salary distribution patterns across the state.
 
-Para avançar no entendimento desse cenário, futuras pesquisas podem se concentrar na identificação dos centros de influência das atividades econômicas públicas, possibilitando comparações com os padrões de distribuição salarial em todo o estado do Rio de Janeiro.
-
-Além disso, o **Gráfico B** sugere uma correlação econômica entre o estado do Rio de Janeiro e sua capital. Para aprofundar essa análise, é fundamental expandir a série histórica e realizar comparações mais abrangentes das atividades econômicas em pesquisas futuras.
+**Chart B** further suggests an economic correlation between the state of Rio de Janeiro and its capital. Extending the time series and making broader comparisons of economic activities in future research would sharpen that finding.

--- a/next/blog/en/analisando-instituicoes-financeiras-de-operacoes-de-credito.md
+++ b/next/blog/en/analisando-instituicoes-financeiras-de-operacoes-de-credito.md
@@ -1,0 +1,40 @@
+---
+title: >-
+  Which financial institutions lead credit operations in Brazil?
+description: >-
+  An analysis of the financial institutions with the largest share of credit
+  over the past two decades
+slug: leading-credit-institutions-in-brazil
+date:
+  created: "2023-05-01"
+authors:
+  - name: Gustavo Alcântara
+    role: Analysis
+  - name: Giovane Caruso
+    role: Editing
+thumbnail: /blog/analisando-instituicoes-financeiras-de-operacoes-de-credito/image_0.png
+categories: [analise]
+medium_slug: >-
+  https://medium.com/@basedosdados/quais-s%C3%A3o-as-principais-institui%C3%A7%C3%B5es-financeiras-de-opera%C3%A7%C3%B5es-de-cr%C3%A9dito-no-brasil-87b1a9eba3a5
+published: true
+---
+
+An analysis of the financial institutions with the largest share of credit over the past two decades.
+
+According to Brazil's Institute for Applied Economic Research (IPEA), the total credit balance of the National Financial System stood at 52.9% of GDP in March 2023. Access to credit, in other words, is increasingly central to financing economic activity, investment and consumption in the country.
+
+To get a clearer picture of credit supply, we analysed the Banking Statistics data (ESTBAN), which report the monthly balances of the main line items on the balance sheets of commercial banks and multiple banks with a commercial portfolio, aggregated by branch and updated monthly. You can access these data too, already processed and kept current by Data Basis, for economic analysis, market research, financial planning and other work on the banking sector and economic activity at municipal level.
+
+➡️ See the processed tables [here](/dataset/84bb75ae-5955-4bbe-8bb6-2d644cae0cee?table=14906976-ff12-4210-b08c-45a1c843a76a).
+
+There is a great deal you can do with these data. As one example, we looked at the percentage share of financial institutions in credit operations in Brazil from 2003 to 2022, running a descriptive analysis over time of the institutions holding more than 5% of total credit supply in the period. The chart below shows the result.
+
+<Image src="/blog/analisando-instituicoes-financeiras-de-operacoes-de-credito/image_0.png"/>
+
+The data show that two public banks now account for the largest share of credit — Caixa Econômica Federal and Banco do Brasil — followed by the private banks Bradesco, Itaú and Santander. They also show how institutions were absorbed over the period. ABN AMRO REAL S.A and Unibanco S.A both held shares until 2008 before being acquired: ABN AMRO REAL's share was absorbed by the Santander group and Unibanco's by Itaú.
+
+The same data let you analyse how municipalities figure in the various operations on offer — credit, debit, bank deposits, total assets and more. On credit operations, for instance, the municipality of Osasco recorded the highest value in the country in 2021, carried out mostly through Banco Bradesco S.A: more than 500 billion reais in operations through that institution alone. Another case worth noting is São Paulo in 2022, where banks in the "other" category — those holding less than 5% of these operations individually — together accounted for 22% of the city's credit operations.
+
+Why not use the code behind this analysis to build your own cuts of the data? All the code for the analyses we publish is available on our [GitHub](https://github.com/basedosdados/analises/blob/main/redes_sociais/br_estban_agencia_20230517.py).
+
+This text was published in BDletter, our monthly newsletter with news from Data Basis, analyses and interviews with specialists. Subscribe free [here](https://info.basedosdados.org/newsletter).

--- a/next/blog/en/analisando-o-brasil-nas-olimpiadas-2016.md
+++ b/next/blog/en/analisando-o-brasil-nas-olimpiadas-2016.md
@@ -1,0 +1,138 @@
+---
+title: Brazil at the Olympics
+description: An overview of Brazilian performance at the Olympic Games over the years
+slug: brazil-at-the-olympics
+date:
+  created: "2021-07-23"
+authors:
+  - name: Lucas Nascimento
+    role: Author
+    social: https://github.com/lucasnascm
+thumbnail: /blog/analisando-o-brasil-nas-olimpiadas-2016/image_0.jpg
+categories: [analise]
+medium_slug: https://medium.com/@basedosdados/o-brasil-nas-olimp%C3%ADadas-2a3f9960cc69
+published: true
+---
+
+> **Note**: this article was published in 2021 and drew on a dataset that ran to 2016. We could not find updated data in the same format, so we have published figures through 2021 in a new format in this [new dataset](https://data-basis.org/dataset/62f8cb83-ac37-48be-874b-b94dd92d3e2b?table=567b1ccd-d8c2-4616-bacb-cf5c0e7b8d89).
+
+## TL;DR
+
+Another edition of the Olympics starts today — but did you know the first Games of the modern era were held in 1896? This piece presents historical data on the Olympic Games, already cleaned, processed and available in the public Data Basis datalake. The [Olympics microdata](/dataset/62f8cb83-ac37-48be-874b-b94dd92d3e2b?table=567b1ccd-d8c2-4616-bacb-cf5c0e7b8d89) covers the games, host cities, delegations, athletes and their characteristics, along with the sports, their various events, and medallists.
+
+<Image src="/blog/analisando-o-brasil-nas-olimpiadas-2016/image_0.jpg"/>
+
+The analysis script was run in R using our data package. The aim is to give an overview of Brazilian performance in every edition the delegation took part in. With Data Basis you can also reach this data in Python or directly through BigQuery.
+
+```r
+library("basedosdados")
+library("tidyverse")
+library("gridExtra")
+library("dplyr")
+
+olimpiadas <- basedosdados::read_sql(
+  "SELECT * FROM `basedosdados.mundo_kaggle_olimpiadas.microdados` WHERE delegacao = 'BRA'",
+  billing_project_id = "input-dados"
+)
+```
+## Confirmed attendance
+
+Brazil first took part in the Olympic Games in 1900, in Paris. The delegation's only athlete was Adolphe Klingelhoeffer, who competed in athletics. The next edition with Brazilian representatives was 1920, and we have been present in various events ever since. Below is an overview of Brazilian participation across the editions, showing the number of athletes and events, along with the code that produced the chart.
+
+<Image src="/blog/analisando-o-brasil-nas-olimpiadas-2016/image_1.png"/>
+
+```r
+counts <- olimpiadas %>%
+  filter(edicao == "Summer") %>%
+  group_by(ano) %>%
+  summarize(
+    atletas = length(unique(id_atleta)),
+    eventos = length(unique(evento))
+  )
+
+p1 <- ggplot(counts, aes(x = as.numeric(ano), y = as.numeric(atletas))) +
+  geom_point() +
+  scale_y_continuous(limits = c(0, 470)) +
+  labs(title = "Participação brasileira nos Jogos Olímpicos", y = "Total de atletas") +
+  theme(plot.title = element_text(hjust = 0.5)) +
+  geom_line() +
+  xlab("")
+
+p2 <- ggplot(counts, aes(x = as.numeric(ano), y = as.numeric(eventos))) +
+  geom_point() +
+  scale_y_continuous(limits = c(0, 250)) +
+  labs(x = "Anos", y = "Modalidades") +
+  geom_line()
+
+grid.arrange(p1, p2, ncol = 1)
+```
+The record for Brazilian participation was 2016, competing at home, with 462 athletes across 222 different events. Earlier editions looked very different: the five before 2016 averaged 236 athletes. This year Brazil had 302 athletes in Tokyo, according to the Brazilian Olympic Committee.
+
+## The medal table
+
+Every edition, newspapers and sports channels focus on the best moments of the delegation, and the overall medal table leads the coverage. Across the games it has taken part in, Brazil has accumulated 30 gold medals, 36 silver and 63 bronze. The chart below shows the sports, men's and women's events combined, where those medals were won.
+
+<Image src="/blog/analisando-o-brasil-nas-olimpiadas-2016/image_2.png"/>
+
+On our podium, judo, sailing and athletics lead on total medals with 22, 18 and 16 respectively. The data lets you identify the winning athletes and the events where they took their medals. In judo 🥋, women won 3 bronze medals and 2 gold, while men brought home 12 bronze, 3 silver and 2 gold. The script for the chart is:
+
+```r
+medalha_counts <- olimpiadas %>%
+  filter(!is.na(medalha)) %>%
+  group_by(ano, esporte, evento, medalha) %>%
+  summarize(Count = length(unique(medalha)))
+
+# ordena a tabela
+medalha_counts$medalha <- factor(medalha_counts$medalha, levels = c("Gold", "Silver", "Bronze"))
+
+# total de medalhas por modalidade esportiva ao longo dos anos
+lev <- medalha_counts %>%
+  group_by(esporte) %>%
+  summarize(Total = sum(Count)) %>%
+  arrange(Total) %>%
+  select(esporte)
+
+medalha_counts$esporte <- factor(medalha_counts$esporte, levels = lev$esporte)
+
+# criação do gráfico
+ggplot(medalha_counts, aes(x = esporte, y = Count, fill = medalha)) +
+  geom_col() +
+  coord_flip() +
+  scale_fill_manual(values = c("gold1", "gray70", "gold4")) +
+  ggtitle("Total de medalhas brasileiras por esporte nos Jogos Olímpicos") +
+  theme(plot.title = element_text(hjust = 0.5))
+```
+## Women at the Olympics
+
+Brazilian women first took part in the Games only in 1932 — 36 years after the first edition — and the gap between men and women is stark. Before the 2000s, the ratio of women to men in the delegation averaged 20%: for every woman competing there were five men. Only in the new millennium did that inequality nearly close, at the Brazilian level. In 2016 there were 207 women and 255 men competing across 31 different sports.
+
+<Image src="/blog/analisando-o-brasil-nas-olimpiadas-2016/image_3.png"/>
+
+The code for total participation by sex over the years is straightforward.
+
+```r
+# filtrando para edição de verão dos Jogos
+sexo <- olimpiadas %>% filter(edicao == "Summer")
+
+# série do total de atletas por sexo
+counts_sex <- sexo %>%
+  group_by(ano, sexo) %>%
+  summarize(atletas = length(unique(id_atleta)))
+
+counts_sex$ano <- as.integer(counts_sex$ano)
+
+# criação do gráfico
+ggplot(counts_sex, aes(x = ano, y = atletas, group = sexo, color = sexo)) +
+  geom_point(size = 2) +
+  geom_line() +
+  scale_color_manual(values = c("orange", "darkgreen")) +
+  labs(title = "Participação masculina e feminina nas Olimpíadas") +
+  theme(plot.title = element_text(hjust = 0.5))
+```
+Enjoyed this analysis? The point was to prompt you to analyse more. Many questions can be answered — and many more asked — by digging into this history. We can keep talking about data in our community on [Discord](https://discord.com/invite/huKWpsVYx4).
+
+May the force be with our athletes. Go Brazil!
+
+[Data Basis](/) is a nonprofit, open source initiative that works to make producing knowledge in Brazil easier. Our team works hard to process and publish quality data that makes your analysis simpler. Your support matters in keeping this going.
+
+Support us at [https://apoia.se/basedosdados](https://apoia.se/basedosdados), or with a PIX transfer: 42494318000116

--- a/next/blog/en/analisando-preco-de-imoveis-em-sao-paulo.md
+++ b/next/blog/en/analisando-preco-de-imoveis-em-sao-paulo.md
@@ -1,0 +1,38 @@
+---
+title: How much does the price per square metre vary between São Paulo neighbourhoods?
+description: >-
+  We analysed GeoSampa data to map the disparity in property values across São
+  Paulo
+slug: square-metre-prices-across-sao-paulo
+date:
+  created: "2023-09-07T00:03:07.999Z"
+authors:
+  - name: Gustavo Alcantara
+    role: Data
+  - name: Giovane Caruso
+    role: Editing
+    social: https://www.linkedin.com/in/giovanecaruso/
+  - name: Luiza Vilas Boas
+    role: Art
+thumbnail: /blog/analisando-preco-de-imoveis-em-sao-paulo/image_0.png
+categories: [analise]
+medium_slug: >-
+  https://medium.com/@basedosdados/qual-a-diferen%C3%A7a-de-pre%C3%A7o-do-metro-quadrado-entre-os-bairros-de-s%C3%A3o-paulo-14cad7e4a89d
+published: true
+---
+
+If you have ever looked for a property to buy or rent, you know location moves the price a great deal. Homes in central districts generally cost more than those on the edges of a city, and more so in a metropolis the size of São Paulo. But what does that geography of value actually look like, and where is the most and least expensive square metre in one of the largest cities in the world by population?
+
+To find out, we analysed data from GeoSampa, the official portal of the São Paulo city government, which collects georeferenced data about the city. The dataset is notable for what it can tell you about urban dynamics and the property market: more than 85 million records and 21.5 GB covering property tax values and the price per built square metre, down to the postcode. These data are valuable for examining settlement and planning patterns, tracking how specific areas appreciate, investigating territorial inequality, and grounding public policy in concrete evidence.
+
+This analysis focuses on the price per built square metre — the average cost per square metre of a constructed property — which lets us see geographically where value concentrates. We selected the thousand properties with the highest average construction values and the thousand with the lowest. To do it, we used our Brazilian Directories to place the midpoint of each postcode, and municipal data from geobr to keep only points falling inside the city of São Paulo. The chart below shows the result.
+
+<Image src="/blog/analisando-preco-de-imoveis-em-sao-paulo/image_0.png"/>
+
+The geographic distribution of price per built square metre across São Paulo is strikingly uneven. Jardim Paulistano, in the north of the city, has the lowest figure at R$ 7,960 per square metre, while Itaim Bibi, in the west, has the highest at R$ 39,980. The most expensive square metre in the city is therefore about five times the cheapest, which is the scale of the variation between regions of the São Paulo metropolitan area. The city-wide average is R$ 23,088.
+
+With a DB Pro subscription you can access data updated regularly from the city's tax registry, covering land value, built area, property use and even neighbourhood characteristics. Start your [free trial](https://data-basis.org/dbpro) and explore.
+
+Why not use the code behind this analysis to build your own cuts of the data? All the code for the analyses we publish is available on our [GitHub](https://github.com/basedosdados/analises/blob/main/redes_sociais/br_sp_geosampa_iptu_iptu_20230829.ipynb).
+
+➡️ Access the data [here](/dataset/05f1b96d-883b-4202-a4bd-40379c5d326a?table=bdffc0f4-00da-4437-9ed9-0db7df11d3fa)

--- a/next/blog/en/analisando-relacao-entre-idhm-e-eleicoes.md
+++ b/next/blog/en/analisando-relacao-entre-idhm-e-eleicoes.md
@@ -1,0 +1,140 @@
+---
+title: How does municipal HDI relate to the 2018 presidential vote in São Paulo?
+description: An easier, more practical way to analyse the index data
+slug: municipal-hdi-and-the-2018-presidential-vote
+date:
+  created: "2022-04-28T15:00:00"
+authors:
+  - name: Gustavo Alcântara
+    role: Text
+    social: https://medium.com/@gustavo.geo
+  - name: Giovane Caruso
+    role: Editing
+    social: https://medium.com/@giovanecaruso
+thumbnail: /blog/analisando-relacao-entre-idhm-e-eleicoes/image_0.webp
+categories: [analise]
+medium_slug: >-
+  https://medium.com/basedosdados/qual-a-rela%C3%A7%C3%A3o-entre-o-idhm-e-a-vota%C3%A7%C3%A3o-presidencial-de-2018-em-sp-aa9f1305586f
+published: true
+---
+
+## TL;DR
+
+This short article offers a quick, simple visualisation of how the 2018 presidential vote relates to the Municipal Human Development Index (IDHM) of municipalities in São Paulo state. It shows how to reach and analyse the index data more easily through the public Data Basis *datalake*, and walks through the steps used to build the chart.
+
+<Image src="/blog/analisando-relacao-entre-idhm-e-eleicoes/image_0.webp"/>
+
+## The Municipal Human Development Index (IDHM)
+
+The IDHM is a composite measure of indicators across three dimensions of human development: longevity, education and income. It runs from 0 to 1 — the closer to 1, the higher the human development. While following the same three dimensions, the Brazilian IDHM adapts the global methodology to the Brazilian context and to the national indicators available, which makes it better suited to assessing development in Brazilian municipalities.
+
+Data Basis publishes data from the [Human Development Atlas (ADH)](http://atlasbrasil.org.br/), the site carrying the IDHM and another 200 indicators, already processed and ready for analysis. **The data covers Brazil, states and municipalities** and can be analysed in Python, R, or in BigQuery via SQL. This analysis uses the [Data Basis R package](https://github.com/basedosdados/sdk/tree/master/r-package). Access the dataset [here](/dataset/mundo-onu-adh).
+
+## Analysing the relationship between IDHM and the presidential vote
+
+> For every good question there is a good analysis to be done.
+
+Whenever you set out to work with data, statistics and analysis, the first thing that matters is a good question. It will save you real time in cleaning and manipulating your dataset. So in this short exercise, with presidential elections approaching, I thought about how the IDHM of São Paulo municipalities might relate to the last presidential election. Is there a relationship between whether a candidate won and the HDI of the municipalities?
+
+### How to present that relationship?
+
+Correlating data is not always straightforward. But with a few lines of code and good libraries in your analysis software, showing the trend or correlation graphically is relatively simple.
+
+My mother tongue in programming is R. I started building analyses in 2016 using R base, and today I use RStudio for its interface and quick manipulation. I like R a great deal, and above all its community, which is always willing to help. Data Basis makes its whole datalake available for access and manipulation in R and other languages.
+
+### Building the dataframe
+
+Now for the fun part: coding. The first step is to build the dataframe that answers the question above. I left the notes in the code itself. If anything is unclear, you can find me on the [Data Basis Discord server](https://discord.com/invite/huKWpsVYx4) — my handle is @gustavoalcantara. Here are the first steps:
+
+```r
+# Inicio da Jornada
+# Atribuição do projeto na Base dos dados
+
+con <- bigrquery::dbConnect(
+  bigquery(),
+  billing = "basedosdados-elections",
+  project = "basedosdados"
+)
+
+# indo para o meu projeto no Google DataLake
+basedosdados::set_billing_id("basedosdados-elections")
+
+# query necessária para responder à minha pergunta
+query <- "
+SELECT
+  ano,
+  turno,
+  sigla_uf,
+  sigla_partido,
+  id_municipio,
+  votos,
+  resultado,
+  cargo
+FROM
+  `basedosdados.br_tse_eleicoes.resultados_candidato_municipio`
+WHERE
+  ano = 2018
+  AND sigla_uf = 'SP'
+  AND cargo = 'presidente'
+"
+
+# atribuição do Dataframe
+df <- DBI::dbGetQuery(con, query)
+```
+With the `dataframe` in hand, the next step is to work out each presidential candidate's share of the vote per municipality, so we can look at the relationship with the IDHM. This code creates the new variable:
+
+```r
+# Criação de Variável: Porcentagem das votações
+df <- df |>
+  dplyr::group_by(id_municipio) |>
+  dplyr::mutate(porcentagem = votos / sum(votos) * 100)
+```
+Part of the point of this piece is that you can also work with a table from outside Data Basis. So I imported a `.csv` from my computer holding the IDHM of São Paulo municipalities, and renamed the municipality variable so we could join on it. Since the aim is to look at a possible relationship between IDHM and vote share, it is easier to see graphically with the variables lined up. Here is the code I used:
+
+```r
+# Juntando o IDHM de uma base externa com a base de Eleições
+# Lendo a base Externa
+idhm <- read.csv("idhm_sp.csv")
+# Mudando o nome da variável Cod.IBGE para id_municipio
+# para o futuro join
+idhm <- idhm |>
+  dplyr::rename(id_municipio = "Cod.IBGE")
+# Join entre as tabelas
+df |>
+  dplyr::left_join(idhm,
+    by = "id_municipio"
+  )
+```
+Done — the dataframe is ready. It looks like this:
+
+<Image src="/blog/analisando-relacao-entre-idhm-e-eleicoes/image_1.webp"/>
+
+### Charting the relationship between IDHM and vote share
+
+With the complete dataframe, building a visualisation of our general question is straightforward. Here is the code and the chart:
+
+```r
+# grafico das relacoes
+dplyr::filter(df, turno == 2) |>
+  dplyr::group_by(id_municipio) |>
+  ggplot2::ggplot(aes(
+    x = idhm_2010,
+    y = porcentagem,
+    color = resultado
+  )) +
+  geom_point() +
+  geom_smooth() +
+  scale_color_discrete(labels = c("Bolsonaro", "Fernando Haddad")) +
+  labs(
+    title = "Relação entre IDHM e Porcentagem de Votos em SP",
+    x = "IDHM",
+    y = "Porcentagem de Votos",
+    colour = "Candidato:"
+  ) +
+  theme(legend.position = "bottom")
+```
+<Image src="/blog/analisando-relacao-entre-idhm-e-eleicoes/image_0.webp"/>
+
+And there it is. This gives a first read on the relationship between the IDHM in São Paulo state and the 2018 presidential vote. Each dot is a municipality, positioned on the y axis by the percentage of votes each candidate received — blue dots for Fernando Haddad, red for Bolsonaro. Notice how, in municipalities with a high IDHM (above 0.70), the vote share runs in opposite directions for the two candidates. Haddad took his lowest share in those municipalities, while Bolsonaro took his highest, trending upward as the HDI rises.
+
+Does the same pattern hold in other states? Run your own analysis. If you need a hand, Data Basis has a team ready to help — bring your questions to [our Discord community](https://discord.com/invite/huKWpsVYx4).

--- a/next/blog/en/atualizar-como-funciona-o-sistema-de-insercao-de-dados-na-bd.md
+++ b/next/blog/en/atualizar-como-funciona-o-sistema-de-insercao-de-dados-na-bd.md
@@ -1,0 +1,84 @@
+---
+title: How does the data ingestion system at Data Basis work?
+description: >-
+  A look at our data ingestion infrastructure, and how contributing to it can
+  strengthen your portfolio
+slug: how-our-data-ingestion-system-works
+date:
+  created: "2021-05-28"
+authors:
+  - name: Vinicius
+    social: https://github.com/vncsna
+    role: Author
+  - name: Fernanda
+    social: https://github.com/fernandascovino
+    role: Author
+  - name: Diego
+    social: https://github.com/d116626
+    role: Author
+  - name: João
+    social: https://github.com/JoaoCarabetta
+    role: Author
+  - name: Caio
+    social: https://github.com/Hellcassius
+    role: Author
+  - name: Giovane Caruso
+    social: https://medium.com/@giovanecaruso
+    role: Adaptation and editing
+thumbnail: /blog/como-funciona-o-sistema-de-insercao-de-dados-na-bd/image_0.jpg
+categories: []
+medium_slug: >-
+  https://medium.com/@basedosdados/como-funciona-o-sistema-de-inser%C3%A7%C3%A3o-de-dados-na-bd-61a0fe05c5d5
+published: false
+---
+
+## TL;DR
+
+This article explains how the data ingestion infrastructure at Data Basis works, and how contributing to our mission of universal data access can strengthen your portfolio as a data scientist or developer.
+
+<Image src="/blog/como-funciona-o-sistema-de-insercao-de-dados-na-bd/image_0.jpg" caption="Photo by [Riho Kroll](https://unsplash.com/@rihok) on [Unsplash](https://unsplash.com/)"/>
+
+## The infrastructure
+
+The Data Basis infrastructure team is responsible for the data ingestion tooling — everything from upload through to making data available in production — for data access via the Python and R packages, and for our [website](/). The team currently works across several fronts, including rebuilding the site and putting automated checks and balances in place.
+
+We try to simplify and automate every step, starting with [uploading data](https://basedosdados.org/docs/colab_data) and bringing it into the **Experimentation Environment**. At that point a contributor can add data to their own Google cloud, clean and process it, then create the local tables using the command line interface the infrastructure team built. Finally, the dataset can be submitted for review by opening a pull request on [GitHub](https://github.com/basedosdados/sdk/pulls).
+
+Once the review pull request is open, the checks-and-balances system takes over, with the data team verifying the quality of the data and its metadata. This step is central to maintaining the data quality that sets Data Basis apart. The infrastructure team works to automate as much of that review as possible, validating metadata such as column names and descriptions, and data types such as primary keys.
+
+After those checks pass, the ingestion pull request is approved and the data enters the **Production Environment**. It can then be accessed through any of our tools, such as the Python and R packages, or directly in BigQuery.
+
+<Image src="/blog/como-funciona-o-sistema-de-insercao-de-dados-na-bd/image_1.png"/>
+
+Alongside the ingestion work, the infrastructure team works with the website team on rebuilding our platform to offer a modern interface. We wrote an [article](/blog/um-site-feito-a-varias-maos) on how we organised a collaborative project to build a new platform that makes working with data easier still.
+
+## Contributing data
+
+On the way to becoming a data analyst or developer, breaking into the job market is hard. There is often no balance between study and practical application, or only toy data analysis. Raise your hand if you have never been stuck on datasets like Titanic or Iris. Those datasets are a reasonable way to learn a new method or tool, but the knowledge does not transfer to the real world.
+
+A good alternative for working with real data and improving your portfolio is helping Data Basis with data ingestion. At minimum you will handle data capture, ideally automated, along with architecture and cleaning. You will also work with the everyday tools of a data scientist: command line interfaces, YAML and BigQuery. That experience can make the difference when entering the job market.
+
+We describe the process in detail in [Contributing data to Data Basis](https://basedosdados.org/docs/colab_data). In short it has four parts. First you tell us you are interested. Then you clean and process the data you intend to upload. Next you upload it to your personal BigQuery. Finally, you submit it for review.
+
+## Contributing to the infrastructure
+
+Another way to contribute and build your portfolio, this time as a developer, is working on the Data Basis infrastructure.
+
+It starts with a conversation, either in the infrastructure chat or at the Monday 7pm meetings, both on the infrastructure channels on [Discord](https://discord.gg/huKWpsVYx4). From there we can pick a feature or problem to work on, if you have not already found something among the open [issues](https://github.com/basedosdados/sdk/issues).
+
+How can you help? **Here are some ideas:**
+
+- Adding new datasets
+- Reviewing data submissions
+- Improving the Python package and building new features for it
+- Improving the R package and building new features for it
+- Adding automated data checks
+- Adding automated metadata checks
+- Building new features for the site
+
+**Has our project helped you in some way?** We are a nonprofit organisation that depends on the support of our community. Here is how to contribute:
+
+- [Support the project](https://apoia.se/basedosdados)
+- [Become a data contributor at Data Basis](https://basedosdados.org/docs/colab_data)
+- [Contribute to our packages](https://github.com/basedosdados/mais)
+- Share us on social media!

--- a/next/blog/en/atualizar-intro-ao-pacote-basedosdados-em-python.md
+++ b/next/blog/en/atualizar-intro-ao-pacote-basedosdados-em-python.md
@@ -1,0 +1,101 @@
+---
+title: Introduction to the basedosdados package in Python
+description: Explore the data in our public datalake
+slug: intro-to-the-basedosdados-python-package
+date:
+  created: "2021-04-16"
+authors:
+  - name: Vinicius Aguiar
+    role: Data Basis team 💚
+    social: https://medium.com/u/2af0c71cb64a
+  - name: Fernanda Scovino
+    role: Data Basis team 💚
+    social: https://medium.com/u/444581849446
+thumbnail: /blog/intro-ao-pacote-basedosdados-em-python/image_0.jpg
+categories: [tutorial]
+medium_slug: https://medium.com/@basedosdados/intro-ao-pacote-basedosdados-em-python-4e05439e936d
+published: false
+---
+
+<Image src="/blog/intro-ao-pacote-basedosdados-em-python/image_0.jpg"/>
+
+## TL;DR
+
+This article shows **how to use the Data Basis package in Python.** The package lets you reach and analyse more than 70 datasets in our public *datalake*, get information about tables, load data into pandas, and more.
+
+Based on the [workshop "Playing with Data Basis data in Python"](https://www.youtube.com/watch?v=wI2xEioDPgM).
+
+## Reaching Data Basis from Python
+
+Data Basis Mais is our *datalake* of public data, **cleaned, integrated and kept up to date** by our data team — data ready for analysis.
+
+The *datalake* lives in Google BigQuery and costs practically nothing for every user: you have 1 TB per month available for querying. To make life easier for Pythonistas, we built a package for direct access to the repository: **basedosdados**
+
+```sh
+# rode para instalar no Python/Jupyter
+!pip install basedosdados
+```
+```python
+import basedosdados as bd
+```
+> **Note.** You need to create a project in Google Cloud in order to query the datalake. The first time you run any function from the package, the instructions will appear and you can follow them step by step. Use the **project ID** that gets generated to run the functions below.
+
+The package has many functions, both for reading data and for publishing it to our Google Cloud project or your own — you can use it to build your own data repository too. The complete list of modules is in [our documentation](https://basedosdados.org/docs/api_reference_python), and you can also see how to contribute by [uploading data to the repository](https://basedosdados.org/docs/colab_data).
+
+## Exploring the package functions
+
+As an illustration, you can list every dataset available in the *datalake* with `list_datasets`. The function returns all datasets, and the `filter_by` parameter narrows them to a search term. Below we search for IBGE data. The `with_description` parameter controls whether each dataset's description is shown as well.
+
+```python
+bd.list_datasets(filter_by="ibge", with_description=True)
+```
+In the same way, you can list the tables in a given dataset with `list_dataset_tables`. You can also get a full view of the columns and their types with `get_table_columns` — all without loading any data into your environment yet.
+
+```python
+# Lista as tabelas do conjunto de dados sobre nomes no Brasil
+bd.list_dataset_tables(
+  dataset_id="br_ibge_nomes_brasil",
+  with_description=True
+)
+
+# Consultando as colunas de uma das tabelas do conjunto
+bd.get_table_columns(
+  dataset_id="br_ibge_nomes_brasil",
+  table_id="quantidade_municipio_nome_2010"
+)
+```
+Before loading, you can even check the total size. Some tables in the repository are very large, so we strongly recommend this step.
+
+```python
+bd.get_table_size(
+  dataset_id="br_ibge_nomes_brasil",
+  table_id="quantidade_municipio_nome_2010",
+  billing_project_id="seu-id-projeto"
+)
+```
+Finally, `read_table` loads the data into your Python environment. If the dataset in question is very large, you can use `read_sql` instead, which runs a SQL query and loads only the rows you asked for. Both require you to state your `billing_project_id`, the project you enabled at the start, which is billed if you exceed the free limit.
+
+```python
+df = bd.read_table(
+  dataset_id="br_ibge_nomes_brasil",
+  table_id="quantidade_municipio_nome_2010",
+  billing_project_id="seu-id-projeto"
+)
+```
+In this example we work with [Brazilian names from IBGE's 2010 Demographic Census](/dataset/703f9f0d-caee-4b47-b900-46b1dea2c33c?table=3bc00c7a-28e5-421b-b310-b32bed3dd4d4). According to the Census, Brazil has around 200 million inhabitants carrying more than 130,000 different names. Curious? So were we.
+
+## Building an analysis: what are the most common names in Brazil?
+
+Your guess — Maria or João? Let the data decide.
+
+To answer, we count the frequency of each name in Brazil and sort with the most frequent at the top. Then we build a word cloud to visualise it.
+
+We wrote a `generate_list_sorted_by_freq` function that aggregates the names in the table, counting how often each appears, and sorts the list by frequency. The code follows below.
+
+To create the image we used the `wordcloud` library together with `matplotlib`, both installable via `pip`. `wordcloud` generates an image where the size of each word is set by its frequency, which gives our ranking a nice visual effect.
+
+And the result: **Maria wins.**
+
+<Image src="/blog/intro-ao-pacote-basedosdados-em-python/image_1.jpg" caption="Word cloud of the most frequent names in Brazil. The size of each word corresponds to how common that name is. The largest name in the image is Maria, followed by José, João, Antônio and Francisco."/>
+
+**What do you make of that?** In the next piece we will cover a regional analysis Fred built at the same workshop. See this and other workshops on our [YouTube](https://www.youtube.com/c/BasedosDados).

--- a/next/blog/en/bdletter-36-online-vs-offline.md
+++ b/next/blog/en/bdletter-36-online-vs-offline.md
@@ -1,0 +1,56 @@
+---
+title: Online or offline — which strategy do election candidates prefer?
+description: >-
+  An analysis of how candidate spending on digital advertising has changed
+slug: online-vs-offline-campaign-spending
+date:
+  created: "2024-10-30T18:18:06.419Z"
+thumbnail: 
+categories: [analise]
+authors:
+  - name: Marina Monteiro 
+    role: Analysis and text
+    social: https://www.linkedin.com/in/ma-m-mendonca/
+  - name: Thais Filipi
+    role: Analysis and text
+    social: https://www.linkedin.com/in/thaismdr/
+    avatar: https://media.licdn.com/dms/image/v2/C4E03AQFstxqWabAyUA/profile-displayphoto-shrink_200_200/profile-displayphoto-shrink_200_200/0/1584489568236?e=2147483647&v=beta&t=mol7Kc8PgxgJatgvNYRkyffL8opuIgFgRdiY7vXB1HA
+  - name: Giovane Caruso
+    role: Text editing
+    social: https://www.linkedin.com/in/giovanecaruso/
+  - name: José Félix
+    role: Graphic editing
+    social: https://www.linkedin.com/in/jos%C3%A9-f%C3%A9lix-517b05210/
+medium_slug: >-
+
+published: true
+---
+
+Political campaigns adapt to new technology as it arrives: at one point the novelty was radio, then television, then websites, then social media, and so on. They adapt equally to how those media get used, socioeconomically and culturally. But a new technology does not necessarily void the weight and reach of the older forms of political communication and persuasion.
+
+Running for elected office is not cheap, and the choice of strategy is decisive in whether a candidacy is competitive. To get a clearer picture, we borrowed from political science one of the available ways of classifying campaign expenditure in 2020 and 2024, alongside candidate income and spending data already available in the public Data Basis datalake. Together these let us assess the relative weight of each type of spending since the last municipal election.
+
+To give the data structure, we use the traditional–modern–online classification, with an additional "other" category that also holds organisational expenses. Broadly, traditional spending covers street strategies: printing materials, staff costs and the like. Modern spending covers publicity via radio and television, jingle production and electoral polling. The online campaign covers content promotion and building web pages. Organisational expenditure covers infrastructure, management and the rest.
+
+We also added variation by municipality size, given the scale of the country and the local, specific character of contests for mayor and councillor. We classify small municipalities as those with up to 5,000 voters; small-medium between 5,000 and 10,000; medium between 10,000 and 50,000; medium-large between 50,000 and 200,000; and large those with more than 200,000 voters.
+
+The composition of campaigns varies considerably, by electoral size of the municipality and by region. The largest share of spending concentrates in street strategies in almost every case in 2024, with at least half of resources going there. The exceptions are the large-electorate municipalities of the North and South, at 49.8% and 46.9% respectively. In those cases, modern spending comes close to matching it.
+
+Within traditional campaign spending, the standouts are printed publicity materials, third-party services, campaigning and street mobilisation, staff costs and legal services. Together they come to more than 2 billion reais.
+
+<Image src="/blog/bdletter-36-online-vs-offline/giff-1.gif"/>
+
+Looking only at candidates for mayor, the one item that does not appear in the same "top 5" as overall spending is staff costs. In its place comes the production of radio, television or video programmes, given the resources of the free electoral broadcast slot. See the chart above. For council candidates, sticker publicity takes the place of legal services. See the image below.
+
+<Image src="/blog/bdletter-36-online-vs-offline/giff-2.gif"/>
+
+
+One caveat: expenditure data is updated daily. So far, slightly fewer than half of municipalities have expenditure declarations registered with the TSE — candidates have up to 30 days after the election to enter that information into the electoral accounting system. The results here are therefore preliminary. The data used in this text was captured on 10 October 2024.
+
+The digital presence of campaigns has been drawing attention, both in specialist analysis and in the adaptation of electoral law to shifts in public debate. Spending on content promotion on social media ranks ninth in total expenditure, at R$ 165 million. Among candidates for mayor alone the figure is R$ 98 million, at the same rank. For council candidates the expense weighs more, coming sixth in the spending ranking at around R$ 67 million. That is striking given how recent the category is — paid content promotion was only permitted after 2016. The online campaign still "competes" with another 41 spending categories. Compared with 2020 there is no dramatic increase in the percentage spent on online campaigns relative to the rest (a rise of 6.75%). What we see instead is wider dispersion in the use of this kind of spending in 2024 than in 2020.
+
+The link between investment in online campaigning and electoral success is not always easy to establish. Some studies indicate that mayoral candidates elected in 2010 invested relatively less in this channel than those who lost (see Heiler, Viana and Santos, 2016). On the other hand, elected candidates generally have more resources and greater capacity to diversify their spending. The online campaign may well have mattered to them, but they also had other resources and attributes that proved decisive in winning office.
+
+ _Access the elections data at Data Basis [here](https://data-basis.org/dataset/eef764df-bde8-4905-b115-6fc23b6ba9d6?table=2e204854-e453-4257-9fef-5e10f3ff1f56?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-9Yx4xtu1zd_-mp0_-jUCEk4_wkMtfgaKHYvzv5fHyx85tBqg6-vU4geE7jEMAX-oFjDOd8)_.
+
+Want the code and references behind this analysis? See our [analysis repository on GitHub](https://github.com/basedosdados/analises/commit/3c4a75bc3058e1e1eafd2e194d69d4cb35bb7117?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-9Yx4xtu1zd_-mp0_-jUCEk4_wkMtfgaKHYvzv5fHyx85tBqg6-vU4geE7jEMAX-oFjDOd8).

--- a/next/blog/en/bdletter-38-retrospectiva2024.md
+++ b/next/blog/en/bdletter-38-retrospectiva2024.md
@@ -1,0 +1,66 @@
+---
+title: 2024 in data, a year in review
+description: >-
+   BDletter. To mark the end of the year, we looked back at the analyses and data that stood out at Data Basis in 2024. It was not an ordinary year.
+slug: 2024-in-data-a-year-in-review
+date:
+  created: "2024-12-30T18:18:06.419Z"
+thumbnail: 
+categories: [analise]
+authors:
+  - name: Giovane Caruso 
+    role: Text and design
+published: true
+---
+
+To mark the end of the year, we looked back at the analyses and data that stood out at Data Basis in 2024. It was not an ordinary year. There were municipal elections, the Olympics, extreme weather events and much else that public data lets us observe and analyse. Consider this an invitation to explore that data and build your own analyses.
+
+This is only a selection of the analyses and data we added to the public Data Basis datalake in 2024. A lot had to be left out, so if you miss something, tell us on @basedosdados social media.
+
+Before going on, a happy Christmas and new year to all of you, databasers. You are the ones keeping alive our mission of universal access to quality data in Brazil, and one day perhaps in the world. Thank you for the support and warmth of the whole community 💚
+
+## 2024 in data
+
+Our year began well, with the Sidra tables from the 2022 Census going up in the public Data Basis datalake. We wasted no time building analyses to inspire and help anyone working with that data. We found, for example, that Brazil has around 37,810 centenarians, less than 0.02% of the population. Errors in reported age remain a reality, but the growth in the population at advanced ages relative to the previous Census is clear.
+
+We also used 2022 Census data to split the Brazilian population into generations, using one of our great cultural assets as the yardstick: telenovelas. See [more](https://www.instagram.com/p/C6Y_Y8gOLQD/?img_index=1?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-9eMfjJcJ-ddzfJmoqhExXJv7a6zhVICAprZz8qb5jH9MW1K3-jkboGltBnjEg1QGooJYpT).
+
+...
+
+In April, Brazil watched and grieved as a tragedy struck the people of Rio Grande do Sul. Using [INMET data](https://data-basis.org/dataset/782c5607-9f69-4e12-b0d5-aa0f1a7a94e2?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-9eMfjJcJ-ddzfJmoqhExXJv7a6zhVICAprZz8qb5jH9MW1K3-jkboGltBnjEg1QGooJYpT), we analysed the relationship between the extreme rainfall in the state and climate change, with a special contribution from Karina Lima, a doctoral candidate in climatology and science communicator. Read the full analysis [here](https://medium.com/basedosdados/qual-foi-a-magnitude-das-chuvas-extremas-que-atingiram-porto-alegre-este-ano-e-qual-a-rela%C3%A7%C3%A3o-675265bce50e?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-9eMfjJcJ-ddzfJmoqhExXJv7a6zhVICAprZz8qb5jH9MW1K3-jkboGltBnjEg1QGooJYpT).
+
+<Image src="/blog/bdletter-38-retrospectiva2024/grafico_1.png"/>
+
+Advancing deforestation also remains a serious problem that demands constant monitoring. In 2024 we published [data such as the Rural Environmental Registry](https://data-basis.org/dataset/6b687e32-32bb-4dd6-ac8b-7dfa011ac619?table=0ba51523-2eb6-422c-a1bb-efc9f9e717a1&utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-9eMfjJcJ-ddzfJmoqhExXJv7a6zhVICAprZz8qb5jH9MW1K3-jkboGltBnjEg1QGooJYpT), which records environmental information on rural properties in Brazil, along with the [microdata of the Rural Credit Operations System](https://data-basis.org/dataset/544c9d22-97b7-479a-8eca-94762840b465?table=e2d5dcc5-270e-4a8b-8d55-0227fd46c10f&utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-9eMfjJcJ-ddzfJmoqhExXJv7a6zhVICAprZz8qb5jH9MW1K3-jkboGltBnjEg1QGooJYpT) and Proagro, both updated this year, which support that oversight.
+
+To further improve access to information on the environment, rural production and land occupation in Brazil, we published the [Municipal Agricultural Survey](https://data-basis.org/dataset/fc403b40-a7e1-40e7-9efe-910847b45a69?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-9eMfjJcJ-ddzfJmoqhExXJv7a6zhVICAprZz8qb5jH9MW1K3-jkboGltBnjEg1QGooJYpT) (PAM) and the [Municipal Livestock Survey](https://data-basis.org/dataset/f7df4160-7a6f-4658-a287-3a73d412ed10?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-9eMfjJcJ-ddzfJmoqhExXJv7a6zhVICAprZz8qb5jH9MW1K3-jkboGltBnjEg1QGooJYpT) (PPM).
+
+...
+
+In 2024 Brazil also faced one of the worst dengue epidemics in its history. Roughly 12.5 million cases were recorded in the year, 97,000 of them in pregnant patients. To make life easier for anyone researching this, we published [data on dengue cases](https://data-basis.org/dataset/f51134c2-5ab9-4bbc-882f-f1034603147a?table=9bdbca38-d97f-47fa-b422-84477a6b68c8&utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-9eMfjJcJ-ddzfJmoqhExXJv7a6zhVICAprZz8qb5jH9MW1K3-jkboGltBnjEg1QGooJYpT) from the Ministry of Health's Notifiable Diseases Information System.
+
+To support the development and evaluation of public health policy further, we published several important datasets on the subject: [Hospital Information System data](https://data-basis.org/dataset/ff933265-8b61-4458-877a-173b3f38102b?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-9eMfjJcJ-ddzfJmoqhExXJv7a6zhVICAprZz8qb5jH9MW1K3-jkboGltBnjEg1QGooJYpT), the [microdata of the Food and Nutrition Surveillance System](https://data-basis.org/dataset/d0b61e1c-2ff2-43e7-b32f-5a054ba9b688?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-9eMfjJcJ-ddzfJmoqhExXJv7a6zhVICAprZz8qb5jH9MW1K3-jkboGltBnjEg1QGooJYpT) (SISVAN), and [Outpatient Information System data](https://data-basis.org/dataset/22d1f0d6-9bbc-4653-a841-7734867d2319?table=5613bffd-f741-4f74-a48e-685d6438f354&utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-9eMfjJcJ-ddzfJmoqhExXJv7a6zhVICAprZz8qb5jH9MW1K3-jkboGltBnjEg1QGooJYpT) (SIA).
+
+...
+
+This was the year our athletes shone at the Paris Olympics. We used [historical Olympedia data](https://data-basis.org/dataset/62f8cb83-ac37-48be-874b-b94dd92d3e2b?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-9eMfjJcJ-ddzfJmoqhExXJv7a6zhVICAprZz8qb5jH9MW1K3-jkboGltBnjEg1QGooJYpT) to analyse how the age distribution of Olympic gymnasts has changed over time. See it [here](https://www.instagram.com/p/C-GluHayZF9/?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-9eMfjJcJ-ddzfJmoqhExXJv7a6zhVICAprZz8qb5jH9MW1K3-jkboGltBnjEg1QGooJYpT).
+
+...
+
+Politics made for a busy year too. In the first half we published the [Open Data of the Chamber of Deputies](https://data-basis.org/dataset/3d388daa-2d20-49eb-8f55-6c561bef26b6?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-9eMfjJcJ-ddzfJmoqhExXJv7a6zhVICAprZz8qb5jH9MW1K3-jkboGltBnjEg1QGooJYpT), updated automatically. We launched the #DeOlhoNaCamara campaign, with analyses and tutorials for anyone working with that data. Through it we found that deputies in the current legislature [have already allocated more than R$ 170 million to publicising](https://www.instagram.com/p/C8ZtmUTM3lF/?img_index=1?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-9eMfjJcJ-ddzfJmoqhExXJv7a6zhVICAprZz8qb5jH9MW1K3-jkboGltBnjEg1QGooJYpT) their parliamentary activities, close to 20% of all spending under the parliamentary allowance so far. See more [here](https://data-basis.org/blog/de-olho-na-camara-analisando-dados-abertos-da-camara-dos-deputados-com-a-bd?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-9eMfjJcJ-ddzfJmoqhExXJv7a6zhVICAprZz8qb5jH9MW1K3-jkboGltBnjEg1QGooJYpT).
+
+<Image src="/blog/bdletter-38-retrospectiva2024/grafico_2.png"/>
+
+To bring more transparency and accessibility to information about money in the municipal elections, we built a new version of the [Siga o Dinheiro](https://www.sigaodinheiro.org/?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-9eMfjJcJ-ddzfJmoqhExXJv7a6zhVICAprZz8qb5jH9MW1K3-jkboGltBnjEg1QGooJYpT) dashboard in partnership with JOTA. It lets any voter follow the income and spending of candidates and parties, filtered down to municipality level. See some of the [analyses](https://www.sigaodinheiro.org/artigos?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-9eMfjJcJ-ddzfJmoqhExXJv7a6zhVICAprZz8qb5jH9MW1K3-jkboGltBnjEg1QGooJYpT) we produced over the course of the project.
+
+...
+
+Datasets central to analysing the Brazilian labour market were also updated at Data Basis as soon as they appeared at the original sources, RAIS and CAGED among them. We analysed pay disparity by gender and race using CAGED data, to open up that debate and encourage you, databaser, to explore the data further. Read the full analysis [here](https://medium.com/@basedosdados/como-a-disparidade-salarial-por-g%C3%AAnero-e-ra%C3%A7a-evoluiu-ao-longo-dos-anos-949ea4d121a7?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-9eMfjJcJ-ddzfJmoqhExXJv7a6zhVICAprZz8qb5jH9MW1K3-jkboGltBnjEg1QGooJYpT).
+
+<Image src="/blog/bdletter-38-retrospectiva2024/grafico_3.png"/>
+
+And that is only a sample of all the data and analyses we produced. You can always find our analyses on the Data Basis blog and our social media.
+
+See you next year 💚
+
+<Image src="/blog/bdletter-38-retrospectiva2024/imagem_1.png"/>

--- a/next/blog/en/bdletter-40-qual-e-a-relacao-entre-a-dengue-e-as-mudancas-climaticas.md
+++ b/next/blog/en/bdletter-40-qual-e-a-relacao-entre-a-dengue-e-as-mudancas-climaticas.md
@@ -1,0 +1,62 @@
+---
+title: What is the relationship between dengue and climate change?
+description: >-
+  Temperature and rainfall may be linked to rising case numbers in some cities
+slug: dengue-and-climate-change
+date:
+  created: "2025-05-07T21:02:04.375Z"
+authors:
+  - name: Marina Monteiro
+    role: Analysis and text
+  - name: Giovane Caruso
+    role: Editing and design
+categories: [analise]
+thumbnail: /blog/qual-e-a-relacao-entre-a-dengue-e-as-mudancas-climaticas/grafico_goiania.png
+medum_slug: https://medium.com/@basedosdados/nota-sobre-divulga%C3%A7%C3%A3o-dos-dados-do-inep-9168291dbca0
+published: true
+order: 1
+---
+
+In the previous BDletter we covered the dengue epidemic and its absolute and proportional numbers in the cities where part of our team lives. In this edition we stay with the disease, but look at the relationship between case numbers and two meteorological variables: air temperature and rainfall.
+
+The question is worth asking because the life cycle of *Aedes aegypti* is closely affected by weather. The mosquito acquires the virus when it bites someone infected and becomes infective, able to transmit the disease to others in later bites. High rainfall increases the supply of breeding sites. High temperatures change the development, longevity and fecundity of adult mosquitoes, which prefer between 22ºC and 28ºC. A cycle from egg to adult that usually takes 7 to 10 days can run in 3 to 4 days at higher temperatures.
+
+You would expect, then, that more rain and higher temperatures would mean more mosquitoes, and that more mosquitoes would spread the disease further. Does a rise in temperature and rainfall come with a rise in cases?
+
+To find out, we analysed Brazil's state capitals, using temperature and rainfall measurements from [INMET](/dataset/782c5607-9f69-4e12-b0d5-aa0f1a7a94e2?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-_yEejPUipsc-cW3VKr51TG936EDjUtQ7FsruHM1xnCyYNuLd3b6JK282QA06r9HS1mxt-Q9DeZMt8UNYBdTQa6O4xDAQtBow06gCo-RD2SgZobLk4) automatic stations together with dengue case notifications recorded in [SINAN](/dataset/f51134c2-5ab9-4bbc-882f-f1034603147a?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-_yEejPUipsc-cW3VKr51TG936EDjUtQ7FsruHM1xnCyYNuLd3b6JK282QA06r9HS1mxt-Q9DeZMt8UNYBdTQa6O4xDAQtBow06gCo-RD2SgZobLk4), all of it available in the Data Basis datalake. From the daily meteorological data we calculated average temperature and total rainfall, monthly and weekly by epidemiological week. You can look at the results in detail in an interactive dashboard we built; the link is at the end.
+
+The expected dynamic for case distribution is a rise at the start of the warm period, with cases peaking after some months of heat, a few weeks after the rainiest period. The lowest numbers should fall in the drier, colder months.
+
+In Goiânia that pattern holds quite precisely across the years. See the chart below.
+
+<Image src="/blog/bdletter-40-qual-e-a-relacao-entre-a-dengue-e-as-mudancas-climaticas/grafico_goiania.png"/>
+
+In the capital of Goiás, cases concentrate in the weeks around the peaks of rainfall and temperature. As those two variables fall, case numbers fall with them.
+
+The same dynamic is much less evident in Manaus.
+
+<Image src="/blog/bdletter-40-qual-e-a-relacao-entre-a-dengue-e-as-mudancas-climaticas/grafico_manaus.png"/>
+
+In the Amazonas capital the relationship with rainfall is still visible, though not in the same shape as Goiânia. The relationship with temperature no longer looks so direct. The explanation may be that average temperature there varies between 26ºC and 32ºC — already high, and consistently favourable to the mosquito.
+
+Aracaju offers another example. Unlike the other capitals, which peak between February and April, notification peaks in Aracaju fall in the middle of the year, around June and July, even though that is the city's "coldest" period. But as in Goiânia, that period still has average temperatures above 25ºC. The notification maxima line up instead with the rainfall maxima.
+
+## What does the literature say?
+
+Several studies relate these meteorological variables to notified dengue cases across different regions. Research at Unicamp indicates that a 1ºC rise in average temperature may produce a roughly 20–30% rise in dengue cases in the city of Campinas over the following two months. Other studies point to a rise in local cases when rainfall increases, as in Belém and Ribeirão Preto.
+
+Climate factors matter too. El Niño years, for example, shift rainfall from the north and northeast towards the southeast and south, where cities are more densely populated. Combined with higher temperatures, that can produce years with more cases than La Niña years(\*\*).
+
+Factors of this kind are not the only ones bearing on dengue cases, directly or indirectly. Urbanisation, population density, sanitation and other characteristics of cities, along with public prevention policy, all have to be considered in assessing the total in a given place.
+
+Still, temperature and rainfall play a large part in how the disease spreads and in epidemics. With average temperatures trending upward under climate change, we may see the disease proliferating further, and into places it never previously reached. We discuss that in this month's interview.
+
+We also built a dashboard where you can investigate the data for your own state capital(\*). Look at whether average temperatures are trending up, and whether rainfall patterns have shifted meaningfully. Is there a relationship between those variables and the dengue cases you see?
+
+> [Open the dashboard](https://climadengue.streamlit.app/?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-_yEejPUipsc-cW3VKr51TG936EDjUtQ7FsruHM1xnCyYNuLd3b6JK282QA06r9HS1mxt-Q9DeZMt8UNYBdTQa6O4xDAQtBow06gCo-RD2SgZobLk4)
+
+You can also see the code in our [analysis repository](https://github.com/basedosdados/analises/tree/main/redes_sociais/climadengue?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-_yEejPUipsc-cW3VKr51TG936EDjUtQ7FsruHM1xnCyYNuLd3b6JK282QA06r9HS1mxt-Q9DeZMt8UNYBdTQa6O4xDAQtBow06gCo-RD2SgZobLk4) on GitHub.
+
+(\*) Except Florianópolis. We could not find automatic station meteorological data for that capital.
+
+(\*\*) In La Niña years rainfall in the north and northeast intensifies, which can raise cases in those regions. But since those regions are less densely populated, the rise would be less noticeable in the national case total.

--- a/next/blog/en/como-acessar-dados-da-bd-no-power-bi.md
+++ b/next/blog/en/como-acessar-dados-da-bd-no-power-bi.md
@@ -1,0 +1,123 @@
+---
+title: How to reach Data Basis data in Power BI
+description: How to connect the public Data Basis datalake to Power BI to build charts, visualisations and dashboards.
+slug: how-to-use-data-basis-data-in-power-bi
+date:
+  created: "2021-07-30"
+authors:
+  - name: Victor Viana
+    role: Author
+    social: https://medium.com/@ovictorviana
+thumbnail: /blog/como-acessar-dados-da-bd-no-power-bi/image_11.gif
+categories: [tutorial]
+medium_slug: >
+  https://medium.com/basedosdados/como-acessar-dados-da-bd-no-power-bi-aeeea9a9bdc0
+published: true
+---
+
+## TL;DR
+
+Power BI is one of the most popular tools for building dashboards from relational data, and [Data Basis]() is one of the largest public data lakes in Brazil. Together they make a good environment for analysing and visualising data. This article shows how easy it is to reach Data Basis datasets for use in Power BI, and walks through the steps.
+
+<Image src="/blog/como-acessar-dados-da-bd-no-power-bi/image_0.png"/>
+
+## Connecting to Google BigQuery
+
+[Google BigQuery](https://cloud.google.com/bigquery?hl=pt_br) is Google's cloud database service, where the Data Basis datasets are stored inside a public datalake called `basedosdados`. To reach the data you need a (free) BigQuery project. If you already have one, skip to the next step; if not, we wrote two tutorials to get you there quickly:
+
+1. [Article](https://dev.to/basedosdados/bigquery-101-45pk)
+2. [Video](https://www.youtube.com/watch?v=nGM2OwTUY_M)
+
+## Connecting the data in Power BI
+
+This walkthrough shows how to connect the municipal GDP series (the fact table) and municipality information (the dimension table) in [Power BI](https://powerbi.microsoft.com/pt-br/downloads/) in order to build an analysis. That dataset is only an example — the tutorial works for any other dataset in the *datalake*.
+
+### Finding the data on the site
+
+To reach data in the BigQuery interface we use SQL queries, one of the most basic and useful languages for anyone working with data. On the Data Basis site you can search for any dataset and copy the SQL directly from the table page, under "Access the data via BigQuery", to use in the Google BigQuery SQL editor, as in the example below. To learn more about the language, we recommend the free [Udacity](https://www.udacity.com/course/sql-for-data-analysis--ud198) course, or BigQuery's own [tutorials](https://cloud.google.com/bigquery/docs/tutorials).
+
+### Selecting the data in BigQuery
+
+Still on the site, click "Query in BigQuery" to be taken to the [*datalake*](https://console.cloud.google.com/bigquery?p=basedosdados&page=project). The BigQuery interface differs from the site because it is a Google service; we explain each element of that interface in this article.
+
+Click "Compose new query", paste the copied code into the editor and run it. Note that the code sets `LIMIT 100` to pull only the first 100 rows. You can change that parameter, or remove it, to pull more — just take care with very large datasets (RAIS, Population Census), since pulling everything at once is slow and consumes a lot of processing, which can incur costs.
+
+<Image src="/blog/como-acessar-dados-da-bd-no-power-bi/image_1.png"/>
+
+```sql
+SELECT
+  pib.id_municipio,
+  --selecionar id do municipio
+  pop.ano,
+  -- população do muunicipio
+  pib.PIB / pop.populacao AS pib_per_capita -- calculo do PIB per capita
+FROM
+  `basedosdados.br_ibge_pib.municipio` AS pib -- selecionar base de pib dos municipios
+JOIN
+  `basedosdados.br_ibge_populacao.municipio` AS pop -- join com a base de população
+ON
+  pib.id_municipio = pop.id_municipio
+  AND pib.ano = pop.ano
+LIMIT
+  100
+```
+<Image src="/blog/como-acessar-dados-da-bd-no-power-bi/image_2.png"/>
+
+### Saving the data to a private project
+
+Save the resulting table by clicking **Save**. You can save the query or the view.
+
+<Image src="/blog/como-acessar-dados-da-bd-no-power-bi/image_3.png"/>
+
+BigQuery will ask you to create a dataset to save the table into, if you do not have one. If you already know Power BI, it works much like a Power BI dataset. Give yours a clear name. At Data Basis we organise dataset names by geographic scope, institution and subject; you can read more about our naming rules [here](https://basedosdados.org/docs/style_data/#nomea%C3%A7%C3%A3o-de-bases-e-tabelas). The dataset is essentially a "folder" holding all the tables in your project. In this example we chose the generic name "tutorial".
+
+<Image src="/blog/como-acessar-dados-da-bd-no-power-bi/image_4.png"/>
+
+Then select the dataset you created, choose a name for your table and click Save. That simple 😊.
+
+<Image src="/blog/como-acessar-dados-da-bd-no-power-bi/image_5.png"/>
+
+Your project will now appear in the left sidebar. Click the arrow next to the project name and your dataset will appear with the table you saved. If it does not, refresh the page.
+
+<Image src="/blog/como-acessar-dados-da-bd-no-power-bi/image_6.png"/>
+
+To save another table with municipality information (name, state and so on), repeat the process with the query below. We will call this table `dMunicipio`, saved in the same `tutorial` dataset.
+
+```sql
+SELECT
+  id_municipio,
+  nome,
+  id_uf,
+  sigla_uf,
+  nome_regiao
+FROM `basedosdados.br_bd_diretorios_brasil.municipio`
+```
+### Importing the data into Power BI
+
+- Open Power BI
+- Go to Get Data -> More
+
+<Image src="/blog/como-acessar-dados-da-bd-no-power-bi/image_7.png"/>
+
+- Search for `Google BigQuery` -> Connect
+
+<Image src="/blog/como-acessar-dados-da-bd-no-power-bi/image_8.png"/>
+
+- Sign in with your Google account — the same one you used to query BigQuery. Signing in with a different account will not connect.
+
+<Image src="/blog/como-acessar-dados-da-bd-no-power-bi/image_9.png"/>
+
+- Grant access to Power BI
+- Go back to Power BI and click connect
+- Select the folder named after your dataset
+- Select the tables
+
+<Image src="/blog/como-acessar-dados-da-bd-no-power-bi/image_10.png"/>
+
+- Click load
+- Choose Import
+  - In most cases a direct connection is not necessary, and importing means you do not depend on the database connection.
+
+That is it — you now have your Data Basis datasets available to build your dashboard. :)
+
+<Image src="/blog/como-acessar-dados-da-bd-no-power-bi/image_11.gif"/>

--- a/next/blog/en/como-fazer-uma-analise-geoespacial-com-qgis.md
+++ b/next/blog/en/como-fazer-uma-analise-geoespacial-com-qgis.md
@@ -1,0 +1,78 @@
+---
+title: How to start a geospatial analysis with Data Basis data and QGIS
+description: Learn how to import Data Basis data into QGIS to build maps and visualisations
+slug: geospatial-analysis-with-qgis
+date:
+  created: "2022-10-07"
+authors:
+  - name: Gustavo Alcântara
+    social: https://github.com/gustavoalcantara
+    role: Author
+  - name: Giovane Caruso
+    social: https://medium.com/@giovanecaruso
+    role: Editing
+thumbnail: /blog/como-fazer-uma-analise-geoespacial-com-qgis/image_0.png
+categories: [tutorial]
+medium_slug: https://medium.com/@basedosdados/como-come%C3%A7ar-uma-an%C3%A1lise-geoespacial-com-dados-da-bd-e-o-qgis-4792877950e0
+published: true
+---
+
+<Image src="/blog/como-fazer-uma-analise-geoespacial-com-qgis/image_0.png" caption="Map of cattle numbers by state in Brazil"/>
+
+## TL;DR
+
+This article shows how to use the geobr package data, already processed and available in the public Data Basis *datalake*, together with a Geographic Information System (GIS) to build geospatial analyses more easily. Follow the steps through a worked example: how many cattle there were in each Brazilian state in 2017.
+
+## What is geobr data?
+
+`geobr` is an R package giving easy access to shapefiles from the Brazilian Institute of Geography and Statistics (IBGE) and other Brazilian spatial data. Already processed and available at Data Basis, it supports analysis at various observation levels: biomes, schools, micro-regions, census tract polygons and much more.
+
+We used geobr data, for example, to build the analysis of geolocated results from the 2019 SAEB mathematics exam in Ceará.
+
+<Image src="/blog/como-fazer-uma-analise-geoespacial-com-qgis/image_1.png" caption="Average proficiency by school in Ceará"/>
+
+Besides reaching this data in Python, R and through BigQuery using SQL, you can export it as `.csv` and load it into your GIS of choice.
+
+A GIS is a combination of software and hardware for visualising and analysing geographic data in order to understand relationships, patterns and trends. There are many of them. This article uses [QGIS](https://qgis.org/pt_BR/site/about/index.html), an open source, collaborative and free platform for geospatial analysis.
+
+## Building your analysis with geobr data and QGIS
+
+To show how to start building your own analysis, we use data from the [Agricultural Census](/dataset/55a39c28-58f3-4804-827d-6eee5ed27b6b?table=5366d485-e7db-4367-911a-a6a0198dda13), the main statistical and territorial survey of the country's agricultural production, also processed and standardised at Data Basis.
+
+The process is simple. To find out how many cattle there were in each Brazilian state in 2017, run the query below in BigQuery and download the result as a `.csv`.
+
+```sql
+SELECT censo.sigla_uf, sum(quantidade_bovinos_total) as gado, geometria
+FROM basedosdados.br_ibge_censo_agropecuario.municipio AS censo
+JOIN basedosdados.br_geobr_mapas.uf AS geo
+ON censo.sigla_uf = geo.sigla_uf #join da variável sigla_uf
+WHERE ano = 2017
+GROUP BY censo.sigla_uf, geo.sigla_uf, geometria
+```
+From the query result you can download the `.csv` to your computer.
+
+Now load the `.csv` with the spatial geometry into QGIS. Click `Add Layer`, then `Add Delimited Text Layer`.
+
+<Image src="/blog/como-fazer-uma-analise-geoespacial-com-qgis/image_2.png" caption="Add Layer and Add Delimited Text Layer in QGIS"/>
+
+With the `Data Source Manager` open, find the `.csv` file where you saved it.
+
+<Image src="/blog/como-fazer-uma-analise-geoespacial-com-qgis/image_3.png" caption="The QGIS Data Source Manager"/>
+
+Once the `.csv` is loaded, the **Geometry Definition** must be set to **Well Known Text** *(WKT)*. Then set the geometry variable in the `geometry field`.
+
+<Image src="/blog/como-fazer-uma-analise-geoespacial-com-qgis/image_4.png" caption="Geometry Definition"/>
+
+The output, or **Sample Data**, should match the schema in the image above. Note how the geometry field defines what each row represents. Since we are working with multipolygons, the latitude and longitude of each multipolygon sit in that variable.
+
+<Image src="/blog/como-fazer-uma-analise-geoespacial-com-qgis/image_5.png" caption="Sample Data"/>
+
+After clicking **add**, you get a map of cattle numbers by state for 2017, as below.
+
+<Image src="/blog/como-fazer-uma-analise-geoespacial-com-qgis/image_6.png" caption="Map of cattle numbers by state in Brazil. Source: IBGE, Agricultural Census, 2017."/>
+
+With the map in front of you it is easy to see that Mato Grosso is the state with the most cattle in Brazil. You can export the map as a *.png* or *.tif* file and carry on with your analysis.
+
+Worth remembering: you can also join more than one dataset to the geobr spatial geometry files through Data Basis. The same process works for any dataset with data at the level of municipality, health regions and facilities, micro-regions, meso-regions, schools and much more.
+
+Any questions about using geobr data, or any other Data Basis dataset? We have a team ready to help on our Discord channel. Come and join us.

--- a/next/blog/en/como-usar-os-diretorios-brasileiros.md
+++ b/next/blog/en/como-usar-os-diretorios-brasileiros.md
@@ -1,0 +1,96 @@
+---
+title: "Brazilian Directories: how this dataset makes your analysis easier"
+description: >-
+  A dataset that works as a complete profile of units such as municipality,
+  school, state and more.
+slug: how-to-use-the-brazilian-directories
+date:
+  created: "2021-08-16"
+authors:
+  - name: Crislane Alves
+    role: Data Basis team
+    social: https://medium.com/@s.alvescrislane
+thumbnail: /blog/como-usar-os-diretorios-brasileiros/image_0.jpg
+categories: [tutorial]
+medium_slug: >-
+  https://medium.com/@basedosdados/diret%C3%B3rios-brasileiros-como-essa-base-facilita-sua-an%C3%A1lise-40dc8ce2ca2
+published: true
+---
+
+A dataset that works as a complete profile of units such as municipality, school, state and more.
+
+<Image src="/blog/como-usar-os-diretorios-brasileiros/image_0.jpg"/>
+
+## TL;DR
+
+This article introduces our [Brazilian Directories](/dataset/33b49786-fb5f-496f-bb7c-9811c985af8e?table=0a2d8187-f936-437d-89db-b4eb3a7e1735) dataset, available in our public datalake alongside many other public datasets already processed, organised and integrated for analysis. It also shows how the dataset makes it easier to join tables from different collections, and how to apply it in your own work, with a practical example.
+
+## The Brazilian Directories dataset
+
+This dataset centralises information about the basic units used in analysis, working as a complete profile of entities such as municipality, school, state, census tracts and more. Its tables link together institutional codes and information from a range of Brazilian bodies.
+
+That matters because Brazilian institutions have no single shared identifier for municipalities. The dataset also resolves IDs and names that change or carry typos across years and institutions, along with new municipality IDs created over time.
+
+For municipalities, for instance, it links records from organisations such as IBGE, the Federal Revenue Service, the Superior Electoral Court (TSE), the Central Bank of Brazil, judicial districts, health regions and others.
+
+Each table in the dataset represents an entity in our public datalake: `UF` (state), `municipio`, `escola`, `distrito`, `setor_censitario`, the `CID-10` and `CID-9` categories, `CBO-2002` and `CBO-1992`, among others.
+
+The directories create relationships between those entities naturally. The municipality table has a `sigla_uf` column, for example, which tells you which state a municipality belongs to. The same applies to `escola`, where you can identify the municipality a given school sits in.
+
+To show how the Brazilian Directories make joining different collections easier, here are two worked examples of how to use it in your analysis, each with a single SQL query in BigQuery.
+
+## Worked examples
+
+### Mobility and transport indicators
+
+In the first example, we join the `municipio` table from the Brazilian Directories with the `tempo_deslocamento_casa_trabalho` table from the [Mobility and Transport Indicators](/dataset/e3edf621-c491-4d74-a03a-15a759f6e638?table=01114371-3b1b-4574-a3ea-3d7d2125b4f2) dataset produced by [Mobilidados](https://mobilidados.org.br/), which holds data on average home-to-work travel time and the percentage of people spending more than an hour on that journey in 2010.
+
+The `id_municipio` column serves as the key. The aim is to add the `regiao` and `municipio` columns to the new dataset, so that beyond the municipality names you can also group by city, macro-region or state and see which have longer or shorter average travel times.
+
+Here is the query:
+
+```sql
+SELECT
+  t1.ano,
+  t2.nome_uf AS estado,
+  t2.nome AS municipio,
+  t1.tempo_medio_deslocamento
+FROM
+  `basedosdados.br_mobilidados_indicadores.tempo_deslocamento_casa_trabalho` AS t1
+JOIN
+  `basedosdados.br_bd_diretorios_brasil.municipio` AS t2
+ON
+  t1.id_municipio = t2.id_municipio
+```
+### Brazilian import and export data
+
+In the second example, we use the `pais` table from the Directories with the `municipio_importacao` table from [Comex Stat](/dataset/74827951-3f2c-4f9f-b3d0-56e3aa7aeb39?table=f4b08023-5530-4dc9-bced-3321e8928fd7), which holds detailed Brazilian export and import data drawn from [SISCOMEX](http://www.siscomex.gov.br/). That particular table covers import data broken down by municipality and importing company.
+
+Here the `id_pais` column is the key, used to pull the country **name** from the Directories. Running the query returns the **country name** alongside the **country ID** and **import value** — in other words, where Brazil's imports came from in 2020.
+
+You can use the query below to see the origin of Brazil's imports in 2020:
+
+```sql
+SELECT
+  t1.ano,
+  t1.sigla_uf,
+  t2.nome AS pais,
+  SUM(valor_fob_dolar) AS importacao
+FROM
+  `basedosdados.br_me_comex_stat.municipio_importacao` AS t1
+JOIN
+  `basedosdados.br_bd_diretorios_brasil.pais` AS t2
+ON
+  t1.id_pais = t2.id_pais
+WHERE
+  ano = 2020
+GROUP BY
+  1,
+  2,
+  3
+ORDER BY
+  3 DESC
+```
+Access the Brazilian Directories dataset [here](/dataset/33b49786-fb5f-496f-bb7c-9811c985af8e?table=0a2d8187-f936-437d-89db-b4eb3a7e1735).
+
+Worth remembering: joining datasets is not possible only because the Directories work as a kind of dictionary. Behind that sits the **Data Basis quality standard** — we make all the data compatible so that it can be joined across tables. Cleaning the datasets in our public datalake involves a rigorous process of standardisation and reconciliation.

--- a/next/blog/en/curso-qgis.md
+++ b/next/blog/en/curso-qgis.md
@@ -1,0 +1,84 @@
+---
+title: Data Basis' Complete, Free QGIS Course
+description: Six free lessons on how to start building analyses with QGIS and Data Basis data
+slug: free-qgis-course
+date:
+  created: '2026-03-30'
+authors:
+  - name: Thais Filipi
+    role: Instructor
+  - name: Marina Monteiro
+    role: Instructor
+thumbnail: /blog/curso-qgis/curso-qgis-thumb.png
+categories: [tutorial]
+medium_slug:
+published: true
+---
+
+<Image src="/blog/curso-qgis/curso-qgis-thumb.png" caption=""/>
+
+Have you ever thought about turning data into interactive maps and geospatial analysis? QGIS, an open source, free and collaborative Geographic Information System (GIS), is the right tool for it. And the good news is that we have put together a complete, entirely free course to help you start or sharpen your journey in this field.
+
+The course is designed to take you from the fundamentals of cartography through to building complex animations and applying QGIS in investigative reporting. Across six practical lessons, you will learn to work with data, produce striking visualisations and draw out useful findings.
+
+## Lesson 1: Getting started with QGIS
+
+This first lesson introduces the essential concepts of cartography, walks through the QGIS interface, explains what a GIS is, covers the different types of geospatial data, and finishes with you building your first map. It is the right starting point for anyone who has never touched the tool.
+
+<Embed>
+<iframe width="1905" height="772" src="https://www.youtube.com/embed/nNXTYm06Wck" title="Como analisar Dados Georreferenciados com o QIGS - Aula Aberta" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" allowFullScreen></iframe>
+</Embed>
+
+## Lesson 2: Wildfire data
+
+This lesson goes deep on a subject of real consequence: analysing wildfire data. It covers INPE's monitoring programme, discusses what these data can and cannot tell you, and works through the environmental legislation that bears on geospatial analysis. A chance to see how QGIS applies to pressing social and environmental questions.
+
+<Embed>
+<iframe width="1905" height="772" src="https://www.youtube.com/embed/WdHgqz59mPo" title="Como analisar Dados de Queimadas com o QGIS - Aula Aberta" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" allowFullScreen></iframe>
+</Embed>
+
+> **You have just found your main source of processed, up-to-date data.**
+>
+> _DB Pro is the subscription that helps sustain our project and gives you access to the most current version of strategic datasets such as Sicor, meteorological data, company registration data, CAGED and much more._
+>
+> **[Learn more](https://data-basis.org/dbpro)** and support Data Basis with your subscription.
+
+## Lesson 3: Data Basis data in QGIS
+
+Find out how to bring the Data Basis collection into QGIS. You will learn to import wildfire data straight from Data Basis and work with it inside QGIS, which opens up a wide range of analysis using public, processed data.
+
+<Embed>
+<iframe width="1905" height="772" src="https://www.youtube.com/embed/oCsAaZKjyvM" title="Como Importar Dados Públicos no QGIS utilizando o datalake da Base dos Dados - Aula Aberta" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" allowFullScreen></iframe>
+</Embed>
+
+## Lesson 4: Building heat maps in QGIS
+
+Heat maps are a powerful way to see patterns and concentrations. This lesson covers the concepts behind them and then puts you to work building your own heat maps in QGIS, turning raw data into visualisations that read at a glance.
+
+<Embed>
+<iframe width="1905" height="772" src="https://www.youtube.com/embed/7JJOaf4NNnc" title="Como criar mapas de calor com o QGIS - Aula Aberta" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" allowFullScreen></iframe>
+</Embed>
+
+## Lesson 5: Animating time series
+
+Take your analysis further with time series animations. This lesson teaches you to build dynamic animations in QGIS so you can show how something changes over time and tell a more engaging story with your data.
+
+<Embed>
+<iframe width="1905" height="772" src="https://www.youtube.com/embed/lKZKdwZfO30" title="Crie Mapas Animados de Séries Históricas no QGIS - Aula Aberta" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" allowFullScreen></iframe>
+</Embed>
+
+## Special lesson: QGIS in investigative reporting
+
+Closing the course, a special lesson with guest Fabio Bispo, a reporter at Info.Amazônia. He shares his experience and shows how QGIS can be central to investigative reporting, and how geospatial analysis opens new angles in data journalism.
+
+<Embed>
+<iframe width="1905" height="772" src="https://www.youtube.com/embed/6eLzwmeLpqQ" title="Como Analisar Dados Geoespaciais Usando o QGIS - Aula Especial" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" allowFullScreen></iframe>
+</Embed>
+
+---
+
+**NEW georeferenced data at Data Basis**
+
+The microdata of the Rural Credit Operations System (Sicor) is now updated automatically at Data Basis, with georeferenced information for your analyses.
+
+Subscribe to DB Pro for continuous access to the latest version of datasets that update automatically in our datalake, such as Sicor, INMET, company registration data and more. [Take a look and start a free trial](https://data-basis.org/dbpro)

--- a/next/blog/en/entrevista-bdletter-35-karina-lima.md
+++ b/next/blog/en/entrevista-bdletter-35-karina-lima.md
@@ -1,0 +1,46 @@
+---
+title: "Interview: did climate change contribute to the extreme rainfall in Rio Grande do Sul?"
+description: >-
+  Karina Lima on the challenges of analysing meteorological data, the possible links between global warming and extreme events in Rio Grande do Sul, and more.
+slug: interview-climate-change-and-rainfall-in-rio-grande-do-sul
+date:
+  created: "2024-08-30T18:18:06.419Z"
+thumbnail: 
+categories: [analise]
+authors:
+  - name: Marina Monteiro 
+    role: Questions
+    social: https://www.linkedin.com/in/ma-m-mendonca/
+  - name: Giovane Caruso
+    role: Text and editing
+    social: https://www.linkedin.com/in/giovanecaruso/
+medium_slug: >-
+  https://medium.com/basedosdados/como-os-casos-de-dengue-evolu%C3%ADram-nos-%C3%BAltimos-10-anos-54a8145f2de7
+published: true
+---
+
+Alongside contributing to our analysis of climate change and rainfall in Rio Grande do Sul, which you can read [here](https://data-basis.org/blog/analisando-chuvas-no-rio-grande-do-sul), Karina Lima spoke to us at greater length about the challenges of analysing meteorological data and about her research.
+
+<Image src="/blog/entrevista-bdletter-35-karina-lima/foto_karina-1.png"/>
+
+Karina is a doctoral candidate in Geography, specialising in Climatology, at the Federal University of Rio Grande do Sul (UFRGS), where she also completed a master's in Geography with an emphasis on environmental analysis and a bachelor's in Geography. She works in Climatology and Meteorology, researching storms, extreme events, disasters and climate change. She is part of research groups studying the effects of extreme events on human health, and of the outreach project "What Would You Do If You Knew What I Know?", which communicates the climate crisis and pushes back against denialism.
+
+**Your current research covers storms, extreme events and disasters, and you also do science communication on climate change. Could you tell us about the role meteorological data plays in understanding climate change and its effects?**
+
+Weather is the state of atmospheric conditions at a given moment and place, whereas climate describes typical conditions — so a large volume of meteorological data is needed to know how the climate usually behaves in a region. Studying climate change therefore means analysing a great deal of meteorological data in order to establish what has changed: the anomalies relative to a past average.
+
+**What are the main challenges you face, or have faced, in collecting and analysing data for your research? Are the data available today sufficient and of the quality needed for precision in climate change research?**
+
+I think it depends a lot on the field of study, but broadly speaking, climate-related databases in Brazil are disconnected and often insufficient. Brazilian researchers have to be creative and, quite frequently, spend longer than they should to complete a piece of research.
+
+**How do you identify whether global warming — and the climate change already under way — is interfering with the weather phenomena we experience? And can that be linked to the warming caused by the excess CO2 that human activity puts into the atmosphere?**
+
+In our present situation, with a hotter system because of our emissions, and therefore with the atmosphere, ocean and land surface all warming, it is very hard for a phenomenon not to be influenced to some degree. To measure that, there are attribution studies, which analyse how much anthropogenic climate change made a given event more likely and more intense. In the case of the April–May 2023 disaster in Rio Grande do Sul, an attribution study analysed two event windows covering the whole period of heavy rainfall accumulation over the state and concluded that human influence made both extreme events more than twice as likely and between 6% and 9% more intense. That is before counting the human contribution in other respects, such as reduced investment in prevention, a failing alert system, environmental legislation not being respected, and lack of maintenance on the flood protection system in Porto Alegre.
+
+**Could you tell us about your research in climatology, particularly on storms and extreme events? And how do you see the importance of science communication in building public awareness of climate change and its effects?**
+
+My research is on extreme rainfall events and disasters. I think it matters a great deal, because we need more studies to improve predictability at the mesoscale, especially in a warmer world where patterns are shifting.
+
+Like research itself, science communication is essential for academic knowledge to be democratised and to reach everyone. Once people have access to good information, they make better decisions and change the world. I see science communication about the climate crisis as a moral question: people need to understand what is happening, and to know that only with broad public support will we get through this crisis and keep the planet habitable for ourselves, for future generations, and for every other species we share our common home with.
+
+_This interview was originally published in our monthly newsletter, BDletter. [Subscribe free to keep up with the next ones](https://info.basedosdados.org/newsletter?_gl=1*11cufe3*_gcl_au*ODc4NTYyMTUxLjE3NDAzOTk0ODk.)._

--- a/next/blog/en/ferramenta-traz-mais-acessibilidade-aos-dados-de-impulsionamento-eleitoral-nas-redes.md
+++ b/next/blog/en/ferramenta-traz-mais-acessibilidade-aos-dados-de-impulsionamento-eleitoral-nas-redes.md
@@ -1,0 +1,52 @@
+---
+title: A tool that makes election ad-spend data more accessible
+description: >-
+  An interview with Sérgio Spagnuolo about the Electoral Content Promotion Observatory
+slug: making-election-ad-spend-data-accessible
+date:
+  created: "2024-10-30"
+thumbnail: /blog/ferramenta-traz-mais-acessibilidade-aos-dados-de-impulsionamento-eleitoral-nas-redes.md/image_1.png
+categories: [institucional]
+authors:
+  - name: Giovane Caruso
+    role: Text and interview
+    social: https://www.linkedin.com/in/GiovaneCaruso/
+    avatar: 
+
+---
+
+_This interview was published in the October BDletter. Subscribe free to keep up with analyses and interviews about Data Basis and the open data community in Brazil._
+
+This election month is full of news for anyone who likes analysing campaign, finance and electoral results data. At Data Basis alone we launched [Siga o Dinheiro](https://www.sigaodinheiro.org/), an interactive dashboard for following election income and spending, ran an [open class](https://www.youtube.com/watch?v=FGboC_4szhc&t=584s) on investigating candidate data, and of course updated the TSE data, already processed and ready for analysis in the largest public datalake in Brazil.
+
+In this interview we look at another tool built to bring transparency and accessibility to campaign finance data. We spoke with Sérgio Spagnuolo about the [Content Promotion Observatory](https://nucleo.jor.br/observatorio-de-impulsionamento-eleitoral/?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz--K7d9YHXkRUu4u9_geagEUzW0JY63mOmg3Sreqf91-uz-5xVzSnqOMg4CY24Ngvw7dIqcCy4v9h0_YYiTCrm9fclqimIKN_X2A_kD4EaFPRl-Q9Rs), an application built by Núcleo Jornalismo to monitor what election campaigns spend on promoting content on social media.
+
+Through the application, anyone can see how much candidates spend promoting content on social media, and filter by geography, party, office, and even by the name of the social network.
+
+<Image src="/blog/ferramenta-traz-mais-acessibilidade-aos-dados-de-impulsionamento-eleitoral-nas-redes/image_1.webp.webp" caption="The filter mechanism of the Electoral Promotion Observatory"/>
+
+The result is a set of visualisations and a data table, extracted automatically from the TSE website. You can also download the data as .csv or .xls files.
+
+<Image src="/blog/ferramenta-traz-mais-acessibilidade-aos-dados-de-impulsionamento-eleitoral-nas-redes/image_2.webp.webp" caption="Example visualisation from the Content Promotion Observatory."/>
+
+Sérgio is a journalist and director of Núcleo Jornalismo, an initiative that analyses and reports on how digital technology affects people's lives, with the aim of helping build a better internet. In 2014 he founded the newstech agency Volt Data Lab; he has been a Knight Fellow at ICFJ and a director at Abraji, and has worked with a range of Brazilian and international outlets.
+
+<Image src="/blog/ferramenta-traz-mais-acessibilidade-aos-dados-de-impulsionamento-eleitoral-nas-redes/image_3.webp.webp" caption="Photograph of Sérgio Spagnuolo"/>
+
+## Interview
+
+**In this election, nearly R$ 180 million has so far been declared as spending on promoting candidates' content on social media. The Electoral Promotion Observatory makes those figures easy to follow. How did the idea come about, and what were the main challenges in building it?**
+
+The Observatory started at the 2022 elections, out of a need we identified to map the use of the specific budget line for promoting posts on social media, which was created in 2019. It was the first time that line had been used, and we thought it was worth surveying this new form of political advertising.
+
+**The Observatory uses TSE data to monitor campaign promotion on social media. Could you say something about why that data matters for electoral transparency, and whether there are limitations that still make precise analysis of candidate content promotion difficult?**
+
+The data matters because online campaigning is increasingly central during elections. Social media is very fertile ground for political advertising, and it is worth watching how money is being spent on it. Promotion on social media is also cheap compared with TV advertising, for instance, so you can get a lot of efficiency at a good cost-benefit ratio. One problem with the data is that it is self-declared, and sometimes the social networks used as the vector are not properly declared, which muddies the aggregation somewhat.
+
+**The Observatory's dashboard offers an interactive interface with filters and visualisations that make this information more accessible. How do you assess the impact it has had on monitoring election spending? Is there an interesting example you could mention?**
+
+The Observatory has been used by other publications and organisations to map promotion spending in different places and areas of public life. It has also been used in academic research, such as a final-year dissertation at the Federal University of Pernambuco. Our aim is to supply information that other people and organisations can use.
+
+**One notable feature is being able to filter promotion spending by social network, a particularly hard cut to make with data self-declared by candidates. Could you say something about the solution behind it?**
+
+The solution is fairly rudimentary, because there is not much information to infer anything from. We scan several columns for keywords in order to associate a given expense with a social network, where such a reference exists. We also group by economic group — Meta covering Facebook and Instagram, for example — since social networks can trade under different corporate names.

--- a/next/blog/en/nota-risco-de-retrocessos-na-lei-de-acesso-a-informacao.md
+++ b/next/blog/en/nota-risco-de-retrocessos-na-lei-de-acesso-a-informacao.md
@@ -1,0 +1,50 @@
+---
+title: "Statement: the risk of rollback in Brazil's Access to Information Law"
+description: >-
+  On 13 February, Data Basis signed the open letter of the Forum on the Right of Access to Public Information, opposing the bill to amend the Access to Information Law being sent to Congress.
+slug: statement-risk-of-rollback-in-the-access-to-information-law
+date:
+  created: "2025-02-21T13:58:09.699Z"
+authors:
+  - name: Giovane Caruso
+    role: Writing
+thumbnail:
+categories: [institucional]
+medium_slug: >-
+  https://medium.com/@giovanecaruso/f362df78913f
+published: true
+---
+
+On 13 February, Data Basis signed the [open letter of the Forum on the Right of Access to Public Information](https://informacaopublica.org.br/leia/organizacoes-de-transparencia-sao-contrarias-ao-envio-do-pl-para-alterar-a-lai-ao-congresso/), opposing the bill to amend Brazil's Access to Information Law (LAI) being sent to Congress.
+
+We think it matters to state our concern about the proposed amendment, which could mean a serious rollback for public transparency in Brazil.
+
+## The background
+
+The federal government recently announced a bill to amend Article 31 of the LAI, which governs the protection of personal information. The proposal includes:
+
+* Reducing the confidentiality period from 100 years to 5 years after the death of the person concerned.
+* Introducing a generic "harm test" to justify restricting information.
+
+The government says the changes are meant to modernise the LAI, but specialists and civil society organisations point to three central risks:
+
+* *Opening the door to rollback in Congress*: putting the LAI through a legislative process may allow amendments that weaken public transparency, creating room for opportunistic measures that undermine access to information.
+
+* *Lack of clarity about the "100-year confidentiality"*: the problem is not the period itself but the inconsistent application of the law. The current proposal does not resolve that and may generate further legal uncertainty.
+
+* *A process without effective civil society participation*: although the government defends social participation, the bill was drafted without adequate dialogue with the Council for Transparency, Integrity and the Fight against Corruption (CTICC) and other specialist bodies. Civil society contributions were disregarded, and the text was finalised without transparency.
+
+The LAI is a foundation of Brazilian democracy. In recent years it has secured:
+
+* Access to information about public policy.
+* Exposure of irregularities and action against corruption.
+* Stronger public oversight of government.
+
+Any change to the LAI should widen rights, not create the risk of rollback. We therefore join the many civil society organisations and the Forum on the Right of Access to Public Information in asking the Chief of Staff's Office of the Presidency to reconsider sending the bill to Congress and to open a broad, transparent debate with society.
+
+Transparency is not negotiable. Defending the LAI is defending democracy.
+
+---
+## About Data Basis
+
+Data Basis is a platform dedicated to promoting the use of open data and strengthening transparency in Brazil. We believe access to information is essential to a fairer, more participatory society.

--- a/next/blog/en/nota-sobre-divulgacao-dos-dados-do-inep.md
+++ b/next/blog/en/nota-sobre-divulgacao-dos-dados-do-inep.md
@@ -1,0 +1,37 @@
+---
+title: Statement on Inep's publication of its data
+description: >-
+  The institute has taken School Census and Enem data offline, citing
+  compliance with Brazil's data protection law
+slug: statement-on-inep-data-publication
+date:
+  created: "2022-03-09T21:02:04.375Z"
+authors:
+  - name: Data Basis
+    role: Data Basis team
+categories: [institucional]
+thumbnail: 
+medum_slug: https://medium.com/@basedosdados/nota-sobre-divulga%C3%A7%C3%A3o-dos-dados-do-inep-9168291dbca0
+published: true
+order: 1
+---
+
+Last Saturday the 19th, the Anísio Teixeira National Institute for Educational Studies and Research (Inep) took historical microdata from the Basic Education School Census and from Enem offline, without notice or prior consultation, and published the 2021 edition with a considerably reduced volume of information. Where the 2020 data ran to almost 17 GB, the 2021 file is only 164 MB.
+
+The files were removed on the grounds of [compliance with the General Personal Data Protection Law (LGPD)](https://www.gov.br/inep/pt-br/assuntos/noticias/institucional/nota-de-esclarecimento-divulgacao-dos-microdados), to reduce the potential risk of identifying the people the statistics refer to. According to the institute, the data control was carried out through analysis conducted with the Federal University of Minas Gerais (UFMG). The [university's study](https://download.inep.gov.br/microdados/TED_8750-UFMG.pdf) is available, and indicates that individuals can be identified through the combined use of Basic Education School Census indicators, with a high success rate. The agency did not say when, or whether, the data will be made available again.
+
+Removing the data set off a wide debate about the boundary between the LGPD and public transparency, involving several organisations working in the field, among them [Open Knowledge Brasil](https://ok.org.br/noticia/nota-alerta-para-uso-equivocado-da-lgpd-pelo-inep-ao-suprimir-microdados/) and [Fiquem Sabendo](https://fiquemsabendo.com.br/). The Forum on the Right of Access to Public Information, made up of those initiatives and 23 other organisations, issued an [official statement on Inep's decision](http://informacaopublica.org.br/?p=4315). Other education initiatives also opposed the removal in official statements, including [Iede](https://www.portaliede.com.br/nova-forma-de-divulgar-dados-do-enem-e-do-censo-escolar-pelo-inep-contraria-interesse-publico-e-inviabiliza-diversas-pesquisas/) (Interdisciplinarity and Evidence in Educational Debate) and the [Association of Education Journalists](https://jeduca.org.br/noticia/nota-sobre-a-retirada-de-microdados-do-site-do-inep) (Jeduca).
+
+## Data Basis and the School Census
+
+Data Basis is already a reference point for access to quality open data in Brazil. We defend transparency of information by publishing and processing public data, opening access to thousands of people by removing the technical barriers to producing analysis and evidence. We take the legal questions around our work seriously and limit ourselves to reproducing data that carries an open licence.
+
+In 2021 we published the Basic Education School Census microdata, processed and standardised, in our public datalake. We recognise that the situation around Inep's microdata is new and still very recent for everyone. We are studying the technical notes and references published by Inep and its partners in the privacy assessment of the microdata, along with studies from organisations that defend transparency and open data.
+
+We understand the importance of respecting everyone's privacy. Enacting and implementing the LGPD in Brazil was a significant step towards guaranteeing rights to liberty and security. People produce data constantly on digital platforms and still have little control over who stores and processes it, how and when it is used, and other questions that matter in a hyperconnected and increasingly digital world.
+
+At the same time, a culture of open data matters enormously for producing and promoting public policy, for research, for open science and related work. This information had been published for years, and we are not aware of any complaint of privacy violation or risk to anyone's safety arising from Inep's microdata. We understand the concern and the need to review how the data is processed, but the cold, abrupt removal of the entire history surprises us, carried out without communication with society or with the organisations that build services and educational evidence on it. Done this way, the removal of this dataset has damaged the development of quality research and analysis in an area that is fundamental for our country: education. Being able to follow and properly understand the effectiveness of education policy is essential if we are to reach what Article 205 and those following it in the Federal Constitution guarantee us.
+
+We continue to defend public data that is open and accessible to everyone, while respecting, where necessary, the legal questions of confidentiality and privacy involved in publishing information. We therefore state that, for now, we will keep the data as it was published, under an open data licence and minimally standardised in [open code](https://github.com/basedosdados/sdk/tree/master/bases). We are, however, entirely available to any government body to discuss and assess the situation, and to understand how we can follow and assist the process of processing and reopening the microdata.
+
+We stress the importance of Inep publishing data that meets the needs of researchers and specialists for comprehensive information on education in Brazil without breaching the parameters the LGPD establishes; of establishing a secure virtual environment for access to that information; and of guaranteeing full transparency and civil society oversight throughout the process of bringing this data into compliance.

--- a/next/blog/en/patchnotes_dez.md
+++ b/next/blog/en/patchnotes_dez.md
@@ -1,0 +1,85 @@
+---
+title: Patch Notes - December 🎲
+description: Keep up with the technical updates at Data Basis this month
+slug: patch-notes-december
+date:
+  created: "2025-12-07T15:00:00"
+authors:
+thumbnail: /blog/patchnotes_dez/thumb_patchnotes.png
+categories: [institucional]
+medium_slug: >-
+published: true
+order: 0
+---
+
+
+Hello, databaser!
+
+We are reaching the end of the year with some interesting updates — including the debut of this new Patch Notes format, which we will publish periodically to stay transparent with our community and share technical news about our public datalake, data, services and more. Here we go.
+
+<Image src="/blog/patchnotes_dez/patchnotes_dez.png" />
+
+## Pipeline fixes
+
+We fixed problems that were blocking the automatic update of **7 datasets**, covering **23 tables**. Some of the highlights:
+
+*   **Inflation data ([IPCA](https://data-basis.org/dataset/ea4d07ca-e779-4d77-bcfa-b0fd5ebea828?table=f1fd2eb7-467a-403b-8f1c-2de8eff354e6), [INPC](https://data-basis.org/dataset/92945390-3b20-40e7-b71b-f6b58f3dc754), [IPCA-15](https://data-basis.org/dataset/a7d9442f-a591-477e-82a1-bcf780ccd0dc))**
+    *   Datasets updated: `br_ibge_ipca`, `br_ibge_ipca_br_ibge_inpc` and `"br_ibge_ipca15`
+    *   Tables updated:
+        * Month Brazil;
+        * Month Category Brazil;
+        * Month Category Municipality;
+        * Metropolitan Region.
+    *   Changes:
+        *   Filled in the last-checked, last-updated-at-source and last-updated-at-Data-Basis metadata for every table;
+        * Enabled schedules;
+        * Monitored the first pipeline run after the PR merged.
+
+*   **[National Construction Registry](https://data-basis.org/dataset/062621e9-5aa0-4903-852d-619ae54393d2) (CNO)**
+    *   Dataset: ``br_rf_cno``
+    *   Changes:
+        *   Tested different resource allocations on the pod running the flow in Kubernetes;
+        * Monitored the first pipeline run after the PR merged.
+*   **[Investment Funds](https://data-basis.org/dataset/9c5a820f-09dd-4519-adfd-611819163ae0) (CVM)**
+    *   Dataset: ``br_cvm_fi``
+    *   Changes:
+        *   Debugged the problem preventing the Flow from registering;
+        * Monitored the first pipeline run after the PR merged.
+
+
+**Why this matters.**
+When a pipeline runs into trouble, data can go stale. These fixes are part of our continuous work to keep the datalake as current as possible.
+
+
+## RAIS update
+
+Partial data from RAIS Establishments [2024](https://data-basis.org/dataset/3e7c4d58-96ba-448e-b053-d385a829ef00?table=86b69f96-0bfe-45da-833b-6edc9a0af213) is now live. That means access to the most recent establishment data on Brazil's formal labour market, covering employment relationships, pay, sectors and much more. If you had an analysis built on the previous RAIS, it is time to refresh the charts.
+
+## Education Indicators data update
+
+We updated INEP's [Education Indicators](https://data-basis.org/dataset/63f1218f-c446-4835-b746-f109a338e3a1?table=cd65b1d2-45e8-432b-afe8-c3a706addbe8) dataset, filling in the last-checked, last-updated-at-source and last-updated-at-Data-Basis metadata for every table.
+
+Tables updated:
+
+* Brazil (2024);
+* State (2024);
+* Region (2024);
+* Brazil Transition Rate (2022);
+* State Transition Rate (2022);
+* Municipality Transition Rate (2022);
+* Region Transition Rate (2022).
+
+
+Education indicators are central to research, public policy and regional analysis. With the 2024 data now available, you can follow recent developments in Brazilian education at national, state and regional level, with clear metadata so you always know the provenance and the date of the last update.
+
+
+## Refactored DBT logs
+
+We refactored the execution logs of DBT (our data transformation tool) to be cleaner, more structured and more informative. We can now identify errors faster, without digging through several platforms or reproducing failures locally.
+
+**Why this matters.**
+For our engineering team it means less time debugging and more time building new pipelines. For you, databaser, it means more reliable pipelines and a consistently sound database.
+
+- - - 
+
+Want to keep up with our analyses, interviews, classes and tutorials too? Subscribe to [BDletter](https://info.basedosdados.org/newsletter) — it arrives free in your inbox.

--- a/next/blog/en/patchnotes_janeiro.md
+++ b/next/blog/en/patchnotes_janeiro.md
@@ -1,0 +1,110 @@
+---
+title: Patch Notes - January/February 🎲
+description: Keep up with the technical updates at Data Basis
+slug: patch-notes-january-february
+date:
+  created: "2026-02-07T15:00:00"
+authors:
+thumbnail: /blog/patchnotes_dez/thumb_patchnotes.png
+categories: [institucional]
+medium_slug: >-
+published: true
+order: 0
+---
+
+
+Hello, *databaser*!
+
+We start the year with a run of updates aimed at the quality and availability of Data Basis data. Here is what we shipped for you in January and February.
+
+<Image src="/blog/patchnotes_janeiro/patchnotes_janeiro.png" />
+
+## Datasets and tables updated
+
+### [Population data](https://data-basis.org/dataset/d30222ad-7a5c-4778-a1ec-f0785371d1ca)
+
+IBGE's most recent data on the Brazilian population is now at Data Basis: municipality-level data with the institute's population estimates. You can join it against many other indicators to build comparisons.
+
+### [Greenhouse gas emissions in Brazil](https://data-basis.org/dataset/9a22474f-a763-4431-8e3d-667908a1c7ab)
+
+The latest version of the Greenhouse Gas Emission and Removal Estimation System (SEEG) is now at Data Basis: municipality-level data covering emissions by emitting sector, economic activity and more, now running through 2024.
+
+### [SAEB microdata](https://data-basis.org/dataset/e083c9a2-1cee-4342-bedc-535cbad6f3cd)
+
+The latest update of the Basic Education Assessment System (Saeb) is at Data Basis, processed and ready for analysis. These are the individual, anonymised records of the assessments INEP applies to students, teachers and head teachers at public and private schools across Brazil.
+
+### [Ministry of Health population data](https://data-basis.org/dataset/1e2b9a88-9dc7-4f0e-a3a5-e8d2a13869bf)
+
+The Ministry of Health also publishes annual population estimates for municipalities, broken down by sex and age group. The most recent data, for 2025, is now available through Data Basis.
+
+### [Literacy Assessment microdata](https://data-basis.org/dataset/073a39d4-89cf-4068-b1e8-34ed0d9c0b72)
+
+Inep has defined a national literacy standard based on the Alfabetiza Brasil survey (2023). The indicator is calculated from the results of assessments run by state and municipal systems, in technical cooperation with Inep, and standardised on the Saeb scale.
+
+The data covers 2023 and 2024, with results and targets for states and municipalities, along with public-network literacy rates by municipality and network.
+
+### [Pnad-C education microdata](https://data-basis.org/dataset/9fa532fb-5681-4903-b99d-01dc45fd527a?table=18fbf773-f43f-4876-8511-8b3b2f0d42a6)
+
+The 2024 education data from the Annual Supplementary Survey is ready for analysis at Data Basis. Collected quarterly by IBGE, it complements the School Census with information on school attendance, illiteracy, educational attainment and access to education, including outside the formal system.
+
+## Metadata fixes and the update metric
+
+**What changed in practice?**
+
+We eliminated the false positives in the monitoring dashboard, so alerts about stale tables now reflect reality.
+
+**Technical detail:**
+
+*   **Before:** the discrepancy between the "update frequency" metadata and the date of the last load into the database generated incorrect alerts for tables that were in perfect order.
+*   **After:** the metadata was adjusted to match the actual behaviour of the pipelines.
+*   **Technical impact:** the calculation (frequency vs. last update) now runs on correct parameters, cleaning up the monitoring metric.
+
+**Why we did it**
+
+To restore trust in the data quality dashboards, with accurate observability of update status.
+
+## Routine pipeline maintenance
+
+**What changed in practice?**
+
+We restored pipelines that failed over the end-of-year break, including modelling fixes, extraction adjustments (particularly around the year rollover) and the resolution of errors in automated tests.
+
+**Technical detail:**
+
+*   **Before:** execution failures were blocking updates to several datasets because of test errors, model build problems and incorrect metadata.
+*   **After:**
+    *   **Fixes applied (PRs #1355 and #1357):** adjustments to the professionals model (CNES), a fix to the extraction of dengue microdata (SINAN) and a fix to the NCM IDs (Comex Stat).
+    *   **Investigation and adjustments:** resolution of test errors (Estban, Cafir), metadata updates (CVM) and duplicate/string-matching analysis (Denatran).
+    *   **Mapping:** identification of new breakages for the backlog (Bolsa Família, BDMEP and others).
+*   **Technical impact:** pipeline integrity restored and the daily ingestion flow back to normal.
+
+**Why we did it**
+
+To prioritise and resolve the service interruptions that accumulated over the year rollover, keeping the most-used data available.
+
+## Updating and fixing the Education Indicators tables
+
+**What changed in practice?**
+
+Data updated and fixed, including the removal of duplicate rows in the education indicators tables.
+
+**Technical detail:**
+
+*   **Before:** education indicator tables with stale and duplicated data.
+*   **After:** data updated and duplicates removed, restoring the integrity of the information.
+
+## Refactoring and stabilising flows (new architecture)
+
+**What changed in practice?**
+
+We migrated the data flows to the new architecture with assisted monitoring and immediate correction of failures on the first run, making the system more robust.
+
+**Technical detail:**
+
+*   **Before:** flows adapted only preliminarily, or still on the old architecture, and prone to implementation errors.
+*   **After:** flows refactored, validated in production, with runtime fixes applied in the same PR.
+*   **Technical impact:** adherence to the new architecture process, and stability in pipeline execution.
+
+**Why we did it**
+
+To reduce the incidence of incorrect data in production and ensure the public datalake stays reliable.

--- a/next/blog/en/relembrando-o-datathon-bd-2021.md
+++ b/next/blog/en/relembrando-o-datathon-bd-2021.md
@@ -1,0 +1,51 @@
+---
+title: Looking back at Datathon BD 2021 🎲
+description: How can open data contribute to more equal development in Brazil?
+slug: looking-back-at-datathon-2021
+date:
+  created: "2021-03-06T15:00:00"
+authors:
+  - name: Giovane Caruso
+    role: Text
+    social: https://medium.com/@giovanecaruso
+categories: [institucional]
+medium_slug: >-
+  https://medium.com/basedosdados/relembrando-o-datathon-bd-2021-ee46fe00ccc0
+published: true
+---
+
+Publishing public data puts numbers on inequality across different parts of society, and that is where the work of building solutions and initiatives for more democratic development begins.
+
+Taking our cue from the theme of Open Data Day 2021, we opened up space for programmers, journalists, researchers and data enthusiasts to think with us about how public data can be used to identify or address inequality in Brazil.
+
+Where to start? We supplied the starting point: the more than 30 public datasets we make available, processed and integrated for public use, in our public *datalake*. We received over 30 entries from a range of backgrounds — thank you to everyone who took part.
+
+> **Note: none of these analyses aims to present rigorously tested evidence on the subjects covered. They explore the questions and open up possible ways of thinking about them.**
+
+## And the winners were…
+
+### UFRJ Analytica
+
+Team: Erica Ferreira, Pedro Boechat, Pedro Borges and Rafael Ribeiro (undergraduates and data analysts/scientists)
+
+> **Analysis: how do differences in access to quality education show up across regions of the country?**
+
+To get at this and other questions about teaching quality and investment in education, they used four datasets published at Data Basis: the [Human Development Atlas (ADH)](/dataset/cbfc7253-089b-44e2-8825-755e1419efc8?table=2b704f11-2b3a-485d-a492-71f86c7ea21a), the [Basic Education Development Index (Ideb)](/dataset/96eab476-5d30-459b-82be-f888d4d0d6b9?table=bc84dea9-1126-4423-86d2-8835e6b19a72), [Brazilian Public Finances (Finbra)](/dataset/br-tesouro-finbra), and our [Brazilian directories](/dataset/33b49786-fb5f-496f-bb7c-9811c985af8e?table=0a2d8187-f936-437d-89db-b4eb3a7e1735) dataset, which links different identifiers for municipalities, states and regions.
+
+[➡️ Read the full analysis here](/ufrj-analytica/datathon-open-data-day-base-dos-dados-86079c93945f)
+
+[💻 See the code](https://github.com/UFRJ-Analytica/odd2021)
+
+### Felipe Macedo Dias (Economics undergraduate at USP)
+
+> **Analysis: was inflation higher in municipalities that received more emergency aid?**
+
+Emergency aid was a major socioeconomic issue during the pandemic in Brazil, and the debate carried on into the period that followed. Felipe explored the question starting with the state capitals: is there a correlation between rising prices, with higher consumption, and the incidence of the aid in those cities? He used [IBGE estimated population](/dataset/d30222ad-7a5c-4778-a1ec-f0785371d1ca?table=2440d076-8934-471f-8cbe-51faae387c66), [Gross Domestic Product (GDP)](/dataset/fcf025ca-8b19-4131-8e2d-5ddb12492347?table=fbbbe77e-d234-4113-8af5-98724a956943) and [emergency aid data by municipality](/dataset/1e768395-e834-4495-a80c-f96f6db57efb?table=5f29077d-6712-491c-9450-cc6bc1939cda).
+
+[➡️ Read the full analysis here](https://datastudio.google.com/s/lrVkgDD_URc)
+
+[💻 See the code](https://github.com/UFRJ-Analytica/odd2021)
+
+## What is Open Data Day?
+
+[Open Data Day](https://opendataday.org/pt_br/) is an annual celebration of open data around the world. Groups everywhere create local events on the day, using open data in their communities. It is a chance to show what open data makes possible and to encourage the adoption of open data policies in government, business and civil society. All the results are open for anyone to use and reuse.

--- a/next/blog/es/analisando-atividade-economica-do-rio-de-janeiro.md
+++ b/next/blog/es/analisando-atividade-economica-do-rio-de-janeiro.md
@@ -1,6 +1,7 @@
 ---
-title: Análise da Atividade Econômica do Estado do Rio de Janeiro e da influência da capital
-description: Explorando dados da RAIS para analisar as principais atividades econômicas do estado e sua relação com a capital
+title: La actividad económica del estado de Río de Janeiro y la influencia de su capital
+description: Exploramos los datos de la RAIS para analizar las principales actividades económicas del estado y su relación con la capital
+slug: actividad-economica-en-rio-de-janeiro
 date:
   created: "2024-04-10T15:00:00"
 authors:
@@ -16,35 +17,35 @@ published: true
 
 ## TL;DR
 
-Este relatório apresenta uma investigação detalhada sobre os dados relacionados às principais atividades econômicas do Estado do Rio de Janeiro, focando na relação com sua capital.
+Este informe investiga las principales actividades económicas del estado de Río de Janeiro, centrándose en su relación con la capital.
 
-O estudo também avalia a dinâmica da geração dos empregos ativos ao longo de um período determinado. Utilizando dados da [Relação Anual de Informações Sociais](/dataset/3e7c4d58-96ba-448e-b053-d385a829ef00?table=c3a5121e-f00d-41ff-b46f-bd26be8d4af3) (RAIS), o trabalho emprega análises estatísticas para compreender a evolução desses padrões e suas implicações na relação com os demais municípios do estado do Rio de Janeiro.
+También examina la dinámica de generación de empleo activo a lo largo de un período determinado. A partir de los datos de la [Relación Anual de Informaciones Sociales](/dataset/3e7c4d58-96ba-448e-b053-d385a829ef00?table=c3a5121e-f00d-41ff-b46f-bd26be8d4af3) (RAIS), aplica análisis estadístico para comprender cómo evolucionaron esos patrones y qué implican para los demás municipios del estado.
 
-> Este artigo foi produzido como Projeto Final do Curso de Análise de Dados Públicos com SQl e Sheets, da Base dos Dados. Para saber mais sobre o curso, acesse [aqui](https://info.basedosdados.org/bd-edu-cursos)
+> Este artículo fue producido como Proyecto Final del Curso de Análisis de Datos Públicos con SQL y Sheets, de Base de los Datos. Para saber más sobre el curso, acceda [aquí](https://info.basedosdados.org/bd-edu-cursos)
 
-## Introdução
+## Introducción
 
-Segundo a [Pesquisa Mensal de Emprego](https://www.data.rio/documents/4e6901873b314e2bacce25f8645046bd/explore) (PME), do IBGE, em 2016 o grupamento _Educação, Saúde e Administração Pública_ ocupava 23,3% dos empregos na cidade do Rio de Janeiro (680 mil); _Outros Serviços_ empregavam 19,9% (581 mil); os _Serviços Prestados às Empresas_, 18,7% (548 mil); o _Comércio_, 17,0% (496 mil); a Indústria,11,2% (328 mil); a _Construção_, 5,7% (166 mil) e os _Serviços Domésticos_, 3,7% (108 mil).
+Según la [Encuesta Mensual de Empleo](https://www.data.rio/documents/4e6901873b314e2bacce25f8645046bd/explore) (PME) del IBGE, en 2016 la agrupación _Educación, Salud y Administración Pública_ ocupaba el 23,3% de los empleos en la ciudad de Río de Janeiro (680 mil); _Otros Servicios_ el 19,9% (581 mil); los _Servicios Prestados a las Empresas_ el 18,7% (548 mil); el _Comercio_ el 17,0% (496 mil); la Industria el 11,2% (328 mil); la _Construcción_ el 5,7% (166 mil) y los _Servicios Domésticos_ el 3,7% (108 mil).
 
-Segundo o IBGE, em fevereiro de 2016 haviam 5 milhões e 910 mil pessoas em idade ativa (PIA) no Município do Rio de Janeiro. Essa população ficou ligeiramente estável durante o ano. Desse total de pessoas em idade ativa, 49,4% encontravam-se ocupadas (nível de ocupação), 2,7% desocupadas e 47,8% não estavam economicamente ativas. O rendimento médio real da população ocupada no município foi estimado em R$ 3.038,40, o que traduzia a renda per capita do carioca.
+El IBGE registró 5.910.000 personas en edad activa en el municipio de Río de Janeiro en febrero de 2016, cifra que se mantuvo prácticamente estable durante el año. De ese total, el 49,4% estaba ocupado, el 2,7% desocupado y el 47,8% no era económicamente activo. El ingreso medio real de la población ocupada del municipio se estimó en R$ 3.038,40, lo que equivalía al ingreso per cápita del carioca.
 
-Em relação à população ocupada, os empregados com carteira assinada no setor privado representaram 47,0% (1.373 mil), os empregados sem carteira assinada no setor privado, 7,2% (210 mil), os trabalhadores por conta própria, 21,8% (636 mil) e os Militares ou funcionários públicos estatutários, 13,5% (395 mil).
+Dentro de la población ocupada, los empleados formales del sector privado representaron el 47,0% (1.373 mil), los empleados sin registro del sector privado el 7,2% (210 mil), los trabajadores por cuenta propia el 21,8% (636 mil) y los militares o funcionarios públicos estatutarios el 13,5% (395 mil).
 
-Os CNAEs foram oficializados através da Resolução do IBGE/CONCLA (Figura 1), do dia 4 de setembro de 2006. Direcionada tecnicamente pelo IBGE (Instituto Brasileiro de Geografia e Estatística), o CNAE é coordenado pela Secretaria da Receita Federal. Formado por uma combinação de 7 números, eles representam a junção de seções, grupos, divisões, classes e subclasses.
+Los CNAE se oficializaron mediante una resolución del IBGE/CONCLA (Figura 1) del 4 de septiembre de 2006. Con dirección técnica del IBGE, el Instituto Brasileño de Geografía y Estadística, el CNAE está coordinado por la Secretaría de Ingresos Federales. Cada código combina siete dígitos que representan secciones, grupos, divisiones, clases y subclases.
 
-A primeira versão do detalhamento das subclasses CNAE foi definida em 1998, com a denominação CNAE-Fiscal. Passou por ajustes em 2001 (versão CNAE-Fiscal 1.0) e em 2002 (versão CNAE-Fiscal 1.1), esta última acompanhando alterações pontuais na estrutura da CNAE (versão CNAE 1.0) em função de ajustes na classificação internacional versão ISIC/CIIU 3.1 (Figura 2).
+La primera versión detallada de las subclases CNAE se definió en 1998 con la denominación CNAE-Fiscal. Recibió ajustes en 2001 (CNAE-Fiscal 1.0) y en 2002 (CNAE-Fiscal 1.1), esta última acompañando cambios puntuales en la estructura del CNAE (CNAE 1.0) derivados de ajustes en la clasificación internacional ISIC/CIIU 3.1 (Figura 2).
 
 <Image src="/blog/analisando-atividade-economica-do-rio-de-janeiro/image_0.webp"/>
 
-## Metodologia
+## Metodología
 
-Este estudo baseia-se na análise de dados provenientes da base [Relação Anual de Informações Sociais](https://ftp.ibge.gov.br/Trabalho_e_Rendimento/Pesquisa_Mensal_de_Emprego/Municipio_RJ/Comentarios/2016/pme-rj_201602comentarios.pdf) (RAIS), que é um relatório de informações socioeconômicas solicitado pela Secretaria de Trabalho do Ministério da Economia brasileiro às pessoas jurídicas e outros empregadores anualmente. O relatório possui periodicidade anual e apresenta informações sobre todos os estabelecimentos formais e vínculos celetistas e estatutários no Brasil. A geração das estatísticas da RAIS 2021 contou, portanto, com duas fontes de captação de dados: o eSocial e o GDRAIS, com as seguintes definições:
+Este estudio analiza los datos de la [Relación Anual de Informaciones Sociales](https://ftp.ibge.gov.br/Trabalho_e_Rendimento/Pesquisa_Mensal_de_Emprego/Municipio_RJ/Comentarios/2016/pme-rj_201602comentarios.pdf) (RAIS), una declaración socioeconómica que la Secretaría de Trabajo del Ministerio de Economía de Brasil exige anualmente a las personas jurídicas y otros empleadores. Es de periodicidad anual y cubre todos los establecimientos formales y todos los vínculos contractuales y estatutarios en Brasil. Las estadísticas de la RAIS 2021 se apoyaron en dos fuentes de captación, eSocial y GDRAIS, con las siguientes definiciones:
 
-- **Estoque de empregos formais**: Diz respeito ao número de vínculos ativos em 31/12 do ano anterior, ou seja, um retrato do mercado de trabalho.
-- **Estabelecimentos**: A obrigatoriedade de declaração da RAIS é por cada estabelecimento, permitindo análise de suas principais características como: setor de atividade econômica, natureza jurídica e localização geográfica. Desde 1995, os estabelecimentos sem empregados passaram a ser obrigados a enviar a chamada RAIS negativa.
-- **Grupamento de Atividades Econômicas**: Classificação derivada da agregação das Seções da Classificação Nacional de Atividades Econômicas (CNAE2.0).
+- **Stock de empleos formales**: el número de vínculos activos al 31 de diciembre del año anterior, es decir, un retrato del mercado laboral.
+- **Establecimientos**: la RAIS debe declararse por establecimiento, lo que permite analizar características como el sector de actividad económica, la naturaleza jurídica y la ubicación geográfica. Desde 1995, los establecimientos sin empleados están obligados a enviar la llamada RAIS negativa.
+- **Agrupación de Actividades Económicas**: clasificación derivada de la agregación de las Secciones de la Clasificación Nacional de Actividades Económicas (CNAE 2.0).
 
-Foram utilizadas consultas SQL e o datalake público da Base dos Dados, que pode ser acessado pela plataforma BigQuery para coletar e visualizar os dados relevantes. A consulta SQL específica utilizada para extrair os dados necessários para a análise básica, que trata dos vínculos ativos no período de 2018 a 2022 para cada CNAE no estado do Rio de Janeiro, está apresentada abaixo:
+Utilizamos consultas SQL sobre el datalake público de Base de los Datos, accesible mediante BigQuery, para recopilar y visualizar los datos relevantes. La consulta empleada para extraer los datos del análisis básico, vínculos activos entre 2018 y 2022 para cada CNAE en el estado de Río de Janeiro, se presenta a continuación:
 
 **Consulta A**
 
@@ -91,8 +92,7 @@ GROUP BY
 ORDER BY
   CNAE DESC;
 ```
-
-<Image src="/blog/analisando-atividade-economica-do-rio-de-janeiro/image_1.webp" caption="Tabela A1: Empregos por CNAEs, estado do Rio de Janeiro, 2018 a 2022"/>
+<Image src="/blog/analisando-atividade-economica-do-rio-de-janeiro/image_1.webp" caption="Tabla A1: Empleos por CNAE, estado de Río de Janeiro, 2018 a 2022"/>
 
 **Consulta B**
 
@@ -142,41 +142,40 @@ GROUP BY
 ORDER BY
   CNAE DESC;
 ```
+## Desarrollo y resultados
 
-## Desenvolvimento e resultados
+La economía de una región condiciona cuántos empleos genera. La ciudad de Río de Janeiro tiene una gran región metropolitana y una influencia considerable sobre otras ciudades del estado.
 
-A economia de uma região geográfica influencia a quantidade de empregos gerados. A cidade do Rio de Janeiro possui uma grande região metropolitana e uma grande influência em outras cidades do estado.
+Uno de los objetivos de la **Consulta A** fue identificar las actividades económicas que representan más del 50% de los empleos generados en el estado de Río de Janeiro. A tal efecto, el estudio estableció un corte de 35 CNAE de un total de 1.318, que reúnen el 52,82% del stock total de empleos a comienzos de 2022, según la **Tabla A1**.
 
-Um dos objetivos da **Consulta A** foi identificar as atividades econômicas que representam mais de 50% dos empregados gerados no estado do Rio de Janeiro. A pesquisa estabeleceu como uma linha de corte para efeitos dessa pesquisa 35 CNAEs, de um total de 1.318, com 52,82% do estoque total de empregos no início de 2022 conforme a **Tabela A1**.
+A partir de ahí se generó el **Gráfico A** para identificar las principales actividades económicas generadoras de empleo en el estado, con base en la **Tabla A2**, que presenta las agrupaciones de esas actividades.
 
-Dessa forma, o **Gráfico A** foi gerado para identificar as principais atividades econômicas geradoras de empregos no estado do Rio de Janeiro a partir da **Tabela A2,** que apresenta os grupamentos das principais atividades econômicas.
+<Image src="/blog/analisando-atividade-economica-do-rio-de-janeiro/image_2.webp" caption="Gráfico A: Principales actividades económicas con más del 50% de los empleos"/>
 
-<Image src="/blog/analisando-atividade-economica-do-rio-de-janeiro/image_2.webp" caption="Gráfico A: Principais atividades econômicas com mais de 50% dos empregos"/>
+<Image src="/blog/analisando-atividade-economica-do-rio-de-janeiro/image_3.webp" caption="Tabla A2: Empleos por agrupaciones, estado de Río de Janeiro"/>
 
-<Image src="/blog/analisando-atividade-economica-do-rio-de-janeiro/image_3.webp" caption="Tabela A2: Empregos por Grupamentos, estado do Rio de Janeiro"/>
+Uno de los objetivos de la **Consulta B** fue identificar las principales actividades económicas que generaron más empleos en la ciudad de Río de Janeiro, como se observa en la **Tabla B**. Sumando el total de empleos generados en el estado y en la ciudad entre 2018 y 2022 fue posible elaborar el **Gráfico B** para identificar su relación dinámica.
 
-Um dos objetivos da **Consulta B** foi identificar as principais atividades econômicas que geraram mais empregos na cidade do Rio de Janeiro, conforme é possível observar na **Tabela B**. Com o somatório do total de empregos gerados no estado e na cidade ao longo do período 2018 a 2022, foi possível elaborar o **Gráfico B** para identificar sua relação dinâmica.
+DataMPE Brasil, un servicio de producción y difusión de datos relevantes para el desarrollo de los pequeños negocios creado por SEBRAE Río de Janeiro, utilizó los datos de la RAIS para establecer que el número de empleados registrados en el estado fue de 3.938.871 en 2021, una variación del 4,56% respecto al año anterior. La remuneración media del trabajador en 2021 fue de R$ 2.333,58, y el número de establecimientos registrados fue de 560.871, una variación del 2,84% respecto al año anterior.
 
-O DataMPE Brasil, serviço para a produção e disseminação de dados e informações relevantes para o desenvolvimento dos pequenos negócios criado pelo SEBRAE Rio de Janeiro, utilizando os dados da Relação Anual de Informações Sociais (RAIS), identificou que o número de empregados cadastrados no estado foi 3.938.871 em 2021, o que representa uma variação de 4.56% em relação ao ano anterior. A remuneração média do trabalhador no ano de 2021 foi de R$ 2.333,58, e o número de estabelecimentos cadastrados foi 560.871, o que representa uma variação de 2.84% em relação ao ano anterior.
+En el estado de Río de Janeiro, los sectores económicos que reunieron más trabajadores en 2021 fueron la _Administración Pública, Defensa y Seguridad Social_ (730.013), el _Comercio Minorista_ (598.989) y la _Educación_ (231.811).
 
-No Estado de Rio De Janeiro, os setores econômicos que mais reuniram trabalhadores em 2021 foram a _Administração Pública_, _Defesa e Seguridade Social_ (730.013), o _Comércio Varejista_ (598.989), e _Educação_ (231.811).
+Ese mismo año, el 42,9% de los trabajadores eran mujeres, con una remuneración media de R$ 3.186,91, y el 57,1% eran hombres, con una remuneración media de R$ 3.780,99.
 
-No mesmo ano, 42.9% dos trabalhadores eram mulheres, com uma remuneração média por pessoa de R$ 3186,91; 57.1% correspondiam a homens, com remuneração média de R$ 3780,99.
+Según los datos de la Receita Federal de Brasil, del total de establecimientos registrados hasta 2023, el 10,3% corresponde a _Otros_ (214.564 establecimientos), el 62,8% a _Microemprendedor Individual (MEI)_ (1.312.029), el 22,5% a _Microempresa (ME)_ (470.895) y el 4,44% a _Empresa de Pequeño Porte (EPP)_ (92.755).
 
-De acordo com os dados da Receita Federal do Brasil (RFB), do total de estabelecimentos com registro até 2023, 10.3% correspondem a _Outros_ (214.564 estabelecimentos), 62.8% correspondem a _Micro Empresário Individual_ _(MEI)_ (1.312.029 estabelecimentos), 22.5% correspondem a _Microempresa (ME)_ (470.895 estabelecimentos), e 4.44% correspondem a _Empresa de Pequeno Porte (EPP)_ (92.755 estabelecimentos).
+Cerca de 13,2 millones de personas trabajaban como microemprendedores individuales (MEI) en Brasil en 2021, el equivalente al 69,7% del total de empresas y otras organizaciones y al 19,2% del total de ocupados formales. De las 673 clases del CNAE 2.0, el MEI estuvo presente en 206 en 2021. Más de la mitad de los MEI (55,7%) se concentran en las 15 primeras clases y casi el 75% en las 30 primeras. Cerca de la mitad (50,2%) estaba en el sector Servicios en 2021. El Comercio y la reparación de vehículos automotores y motocicletas respondieron por el 29,3%, y esa actividad presentó el mayor número de empleados de MEI (48,3%).
 
-Cerca de 13,2 milhões de pessoas trabalhavam como microempreendedores individuais (MEIs) no Brasil em 2021, o equivalente a 69,7% do total de empresas e outras organizações e 19,2% do total de ocupados formais. Em 2021, do total de 673 classes da CNAE 2.0, o MEI esteve presente em 206. Mais da metade dos MEIs (55,7%) estão presentes nas 15 primeiras classes e quase 75% nas 30 primeiras. Cerca de metade dos MEIs (50,2%) estava presente no setor de Serviços em 2021. O Comércio ‘reparação de veículo automotores e motocicletas’ respondeu por 29,3%, sendo essa atividade a que apresentou o maior quantitativo de empregados dos MEIs (48,3%).
+Río de Janeiro fue la unidad de la federación con mayor proporción de MEI respecto al total de ocupados formales (26%), seguida por Espírito Santo (24,8%).
 
-O Rio de Janeiro foi a unidade da federação com maior proporção de MEIs em relação ao total de ocupados formais (26%), seguida pelo Espírito Santo (24,8%).
+Consultamos el sitio de la [Receita Federal](https://www8.receita.fazenda.gov.br/simplesnacional/aplicacoes/atbhe/estatisticassinac.app/EstatisticasOptantesPorCNAE.aspx?tipoConsulta=2&optanteSimei=&anoConsulta=MjAyMg%3D%3D), que contiene información sobre la cantidad de MEI por CNAE. La búsqueda encontró 35 CNAE con el 67,42% del total de microemprendedores individuales al 18 de noviembre de 2023.
 
-Consultamos o site da [Receita federal](https://www8.receita.fazenda.gov.br/simplesnacional/aplicacoes/atbhe/estatisticassinac.app/EstatisticasOptantesPorCNAE.aspx?tipoConsulta=2&optanteSimei=&anoConsulta=MjAyMg%3D%3D) que contém informações sobre a quantidade de MEIs por CNAE. A pesquisa encontrou 35 CNAEs com 67,42% do total de microempresários individuais em 18/11/2023.
+<Image src="/blog/analisando-atividade-economica-do-rio-de-janeiro/image_4.webp" caption="Gráfico B: Relación de empleo ciudad/estado de Río de Janeiro"/>
 
-<Image src="/blog/analisando-atividade-economica-do-rio-de-janeiro/image_4.webp" caption="Gráfico B: Relação de emprego cidade/estado do Rio de Janeiro"/>
+## Conclusión
 
-## Conclusão
+El análisis revela el peso considerable de las actividades económicas ligadas a la Administración Pública en el panorama económico del estado de Río de Janeiro, como evidencia el **Gráfico A**. Es plausible que muchas de esas actividades las realicen empresas que prestan servicios técnicos o administrativos complementarios a entidades estatales, organizaciones públicas y gobiernos municipales y estatales.
 
-A análise revela a significativa influência das atividades econômicas ligadas à Administração Pública no panorama econômico do Estado do Rio de Janeiro, evidenciada pelo **Gráfico A**. É plausível que muitas dessas atividades sejam conduzidas por empresas que oferecem serviços técnicos ou administrativos complementares às entidades estatais, organizações públicas e governos municipais e estaduais.
+Para avanzar en la comprensión de ese escenario, futuras investigaciones pueden centrarse en identificar los centros de influencia de las actividades económicas públicas, lo que permitiría compararlos con los patrones de distribución salarial en todo el estado de Río de Janeiro.
 
-Para avançar no entendimento desse cenário, futuras pesquisas podem se concentrar na identificação dos centros de influência das atividades econômicas públicas, possibilitando comparações com os padrões de distribuição salarial em todo o estado do Rio de Janeiro.
-
-Além disso, o **Gráfico B** sugere uma correlação econômica entre o estado do Rio de Janeiro e sua capital. Para aprofundar essa análise, é fundamental expandir a série histórica e realizar comparações mais abrangentes das atividades econômicas em pesquisas futuras.
+Además, el **Gráfico B** sugiere una correlación económica entre el estado de Río de Janeiro y su capital. Para profundizar ese análisis es fundamental ampliar la serie histórica y realizar comparaciones más amplias de las actividades económicas en investigaciones futuras.

--- a/next/blog/es/analisando-instituicoes-financeiras-de-operacoes-de-credito.md
+++ b/next/blog/es/analisando-instituicoes-financeiras-de-operacoes-de-credito.md
@@ -1,0 +1,41 @@
+---
+title: >-
+  ¿Cuáles son las principales instituciones financieras de operaciones de
+  crédito en Brasil?
+description: >-
+  Un análisis de las instituciones financieras con mayor participación en el
+  crédito durante las últimas dos décadas
+slug: principales-instituciones-de-credito-en-brasil
+date:
+  created: "2023-05-01"
+authors:
+  - name: Gustavo Alcântara
+    role: Análisis
+  - name: Giovane Caruso
+    role: Edición
+thumbnail: /blog/analisando-instituicoes-financeiras-de-operacoes-de-credito/image_0.png
+categories: [analise]
+medium_slug: >-
+  https://medium.com/@basedosdados/quais-s%C3%A3o-as-principais-institui%C3%A7%C3%B5es-financeiras-de-opera%C3%A7%C3%B5es-de-cr%C3%A9dito-no-brasil-87b1a9eba3a5
+published: true
+---
+
+Un análisis de las instituciones financieras con mayor participación en el crédito durante las últimas dos décadas.
+
+Según el Instituto de Investigación Económica Aplicada de Brasil (IPEA), en marzo de 2023 el saldo total de crédito del Sistema Financiero Nacional fue del 52,9% del PIB. Es decir, el acceso al crédito es cada vez más central para financiar la actividad económica, la inversión y el consumo en el país.
+
+Para entender mejor el panorama de la oferta de crédito, analizamos los datos de Estadísticas Bancarias (ESTBAN), que informan la posición mensual de los saldos de las principales partidas de los balances de los bancos comerciales y de los bancos múltiples con cartera comercial, agregados por sucursal y actualizados mensualmente. Usted también puede acceder a estos datos, ya tratados y actualizados por Base de los Datos, para análisis económicos, estudios de mercado, planificación financiera y otros trabajos sobre el sector bancario y la actividad económica a nivel municipal.
+
+➡️ Consulte las tablas tratadas [aquí](/dataset/84bb75ae-5955-4bbe-8bb6-2d644cae0cee?table=14906976-ff12-4210-b08c-45a1c843a76a).
+
+Las posibilidades de análisis con estos datos son muchas. Como ejemplo, observamos la participación porcentual de las instituciones financieras en las operaciones de crédito en Brasil entre 2003 y 2022, mediante un análisis temporal descriptivo de las instituciones que superaron el 5% de participación en los valores totales de oferta de crédito en el período. El gráfico siguiente muestra el resultado.
+
+<Image src="/blog/analisando-instituicoes-financeiras-de-operacoes-de-credito/image_0.png"/>
+
+Los datos muestran que hoy son dos bancos públicos los que concentran el mayor porcentaje del crédito, Caixa Econômica Federal y Banco do Brasil, seguidos por los bancos privados Bradesco, Itaú y Santander. También muestran la dinámica de incorporación de instituciones a lo largo del período: ABN AMRO REAL S.A y Unibanco S.A tuvieron participación hasta 2008 y luego fueron adquiridos. Tras las adquisiciones, la participación de ABN AMRO REAL pasó al grupo Santander y la de Unibanco a Itaú.
+
+Con estos datos también se puede analizar la participación de los municipios en las diversas operaciones existentes: crédito, débito, depósitos bancarios, total de activos y muchas otras. En cuanto a las operaciones de crédito, por ejemplo, en 2021 el municipio de Osasco registró el mayor valor de todo el país, realizado mayoritariamente a través del Banco Bradesco S.A: más de 500 mil millones de reales en operaciones por medio de esa institución. Otro caso destacable ocurre en 2022, en el municipio de São Paulo, cuando los bancos de la categoría "otros" — que agrupa a los que tienen menos del 5% de participación en estas operaciones — sumaron el 22% de las operaciones de crédito de la metrópolis.
+
+¿Y si usa el código de este análisis para crear sus propios recortes? Todo el código de los análisis que publicamos está disponible en nuestro [GitHub](https://github.com/basedosdados/analises/blob/main/redes_sociais/br_estban_agencia_20230517.py).
+
+Este texto fue publicado en BDletter, nuestro boletín mensual con novedades de BD, análisis y entrevistas con especialistas. Suscríbase gratuitamente [aquí](https://info.basedosdados.org/newsletter).

--- a/next/blog/es/analisando-o-brasil-nas-olimpiadas-2016.md
+++ b/next/blog/es/analisando-o-brasil-nas-olimpiadas-2016.md
@@ -1,0 +1,138 @@
+---
+title: Brasil en los Juegos Olímpicos
+description: Un panorama del desempeño brasileño en los Juegos Olímpicos a lo largo de los años
+slug: brasil-en-los-juegos-olimpicos
+date:
+  created: "2021-07-23"
+authors:
+  - name: Lucas Nascimento
+    role: Autor
+    social: https://github.com/lucasnascm
+thumbnail: /blog/analisando-o-brasil-nas-olimpiadas-2016/image_0.jpg
+categories: [analise]
+medium_slug: https://medium.com/@basedosdados/o-brasil-nas-olimp%C3%ADadas-2a3f9960cc69
+published: true
+---
+
+> **Atención**: este artículo se publicó en 2021 y se basó en un conjunto de datos que llegaba hasta 2016. No encontramos datos actualizados en el mismo formato, por lo que incluimos cifras hasta 2021 en un formato nuevo en este [nuevo conjunto de datos](https://basedelosdatos.org/dataset/62f8cb83-ac37-48be-874b-b94dd92d3e2b?table=567b1ccd-d8c2-4616-bacb-cf5c0e7b8d89).
+
+## TL;DR
+
+Hoy comienza una nueva edición de los Juegos Olímpicos, pero ¿sabía que los juegos de la Era Moderna tuvieron su primera edición en 1896? En este texto presentamos datos históricos de los Juegos Olímpicos, ya limpios, tratados y disponibles en el datalake público de Base de los Datos. Los [microdatos de los Juegos Olímpicos](/dataset/62f8cb83-ac37-48be-874b-b94dd92d3e2b?table=567b1ccd-d8c2-4616-bacb-cf5c0e7b8d89) contienen información sobre los juegos, la ciudad sede, las delegaciones, los atletas y sus características, además de los deportes, sus distintas modalidades y los medallistas.
+
+<Image src="/blog/analisando-o-brasil-nas-olimpiadas-2016/image_0.jpg"/>
+
+El script de análisis se ejecutó en R usando nuestro paquete de datos. La idea es mostrar un panorama del desempeño brasileño en las ediciones en que la delegación estuvo presente. Conviene recordar que, con Base de los Datos, también puede acceder a estos datos en Python o directamente por BigQuery.
+
+```r
+library("basedosdados")
+library("tidyverse")
+library("gridExtra")
+library("dplyr")
+
+olimpiadas <- basedosdados::read_sql(
+  "SELECT * FROM `basedosdados.mundo_kaggle_olimpiadas.microdados` WHERE delegacao = 'BRA'",
+  billing_project_id = "input-dados"
+)
+```
+## Presencia confirmada
+
+Brasil participó por primera vez en unos Juegos Olímpicos en 1900, en París. El único atleta de la delegación era Adolphe Klingelhoeffer, que competía en atletismo. La siguiente edición con representantes brasileños fue en 1920 y, desde entonces, hemos estado presentes en distintas pruebas. A continuación puede ver el panorama de la participación brasileña a lo largo de las ediciones, con el número de atletas y modalidades, junto con el código utilizado para producir esa visualización.
+
+<Image src="/blog/analisando-o-brasil-nas-olimpiadas-2016/image_1.png"/>
+
+```r
+counts <- olimpiadas %>%
+  filter(edicao == "Summer") %>%
+  group_by(ano) %>%
+  summarize(
+    atletas = length(unique(id_atleta)),
+    eventos = length(unique(evento))
+  )
+
+p1 <- ggplot(counts, aes(x = as.numeric(ano), y = as.numeric(atletas))) +
+  geom_point() +
+  scale_y_continuous(limits = c(0, 470)) +
+  labs(title = "Participação brasileira nos Jogos Olímpicos", y = "Total de atletas") +
+  theme(plot.title = element_text(hjust = 0.5)) +
+  geom_line() +
+  xlab("")
+
+p2 <- ggplot(counts, aes(x = as.numeric(ano), y = as.numeric(eventos))) +
+  geom_point() +
+  scale_y_continuous(limits = c(0, 250)) +
+  labs(x = "Anos", y = "Modalidades") +
+  geom_line()
+
+grid.arrange(p1, p2, ncol = 1)
+```
+El récord de participación brasileña fue en 2016, compitiendo en casa, con 462 atletas en 222 pruebas distintas. Las ediciones anteriores fueron muy diferentes: la media de las cinco previas a 2016 fue de 236 atletas. Ese año Brasil contó con 302 atletas en Tokio, según datos del Comité Olímpico Brasileño.
+
+## El medallero
+
+En todas las ediciones, los periódicos y los canales deportivos se concentran en los mejores momentos de nuestra delegación, y el medallero general destaca en las noticias. Analizando el desempeño de los atletas en los juegos en que participó, Brasil acumula 30 medallas de oro, 36 de plata y 63 de bronce. El gráfico siguiente muestra los deportes, sumadas las modalidades masculina y femenina, en los que Brasil reparte sus conquistas.
+
+<Image src="/blog/analisando-o-brasil-nas-olimpiadas-2016/image_2.png"/>
+
+En nuestro podio, judo, vela y atletismo son los que más medallas acumulan, con 22, 18 y 16 respectivamente. Los datos permiten identificar quiénes son los atletas campeones y las pruebas en que lograron la victoria. En judo 🥋, las mujeres ganaron 3 medallas de bronce y 2 de oro, mientras que los hombres se llevaron 12 bronces, 3 platas y 2 oros. El script para elaborar el gráfico es:
+
+```r
+medalha_counts <- olimpiadas %>%
+  filter(!is.na(medalha)) %>%
+  group_by(ano, esporte, evento, medalha) %>%
+  summarize(Count = length(unique(medalha)))
+
+# ordena a tabela
+medalha_counts$medalha <- factor(medalha_counts$medalha, levels = c("Gold", "Silver", "Bronze"))
+
+# total de medalhas por modalidade esportiva ao longo dos anos
+lev <- medalha_counts %>%
+  group_by(esporte) %>%
+  summarize(Total = sum(Count)) %>%
+  arrange(Total) %>%
+  select(esporte)
+
+medalha_counts$esporte <- factor(medalha_counts$esporte, levels = lev$esporte)
+
+# criação do gráfico
+ggplot(medalha_counts, aes(x = esporte, y = Count, fill = medalha)) +
+  geom_col() +
+  coord_flip() +
+  scale_fill_manual(values = c("gold1", "gray70", "gold4")) +
+  ggtitle("Total de medalhas brasileiras por esporte nos Jogos Olímpicos") +
+  theme(plot.title = element_text(hjust = 0.5))
+```
+## Mujeres en los Juegos Olímpicos
+
+La participación femenina brasileña en los juegos ocurre por primera vez solo en 1932 —36 años después de la primera edición— y la brecha entre hombres y mujeres es notoria. Antes de los años 2000, la razón de mujeres a hombres en los juegos era del 20% en promedio: por cada mujer compitiendo en la delegación había otros cinco hombres. Solo en el nuevo milenio esa desigualdad casi se anula, a nivel de Brasil. En 2016 compitieron 207 mujeres y 255 hombres en 31 deportes diferentes.
+
+<Image src="/blog/analisando-o-brasil-nas-olimpiadas-2016/image_3.png"/>
+
+El código de análisis del total de participación por sexo a lo largo de los años es sencillo.
+
+```r
+# filtrando para edição de verão dos Jogos
+sexo <- olimpiadas %>% filter(edicao == "Summer")
+
+# série do total de atletas por sexo
+counts_sex <- sexo %>%
+  group_by(ano, sexo) %>%
+  summarize(atletas = length(unique(id_atleta)))
+
+counts_sex$ano <- as.integer(counts_sex$ano)
+
+# criação do gráfico
+ggplot(counts_sex, aes(x = ano, y = atletas, group = sexo, color = sexo)) +
+  geom_point(size = 2) +
+  geom_line() +
+  scale_color_manual(values = c("orange", "darkgreen")) +
+  labs(title = "Participação masculina e feminina nas Olimpíadas") +
+  theme(plot.title = element_text(hjust = 0.5))
+```
+¿Le gustó este análisis? Nuestra intención fue animarle a analizar más. Se pueden responder muchas preguntas —y plantear otras tantas— examinando esta historia. Podemos seguir conversando sobre datos en nuestra comunidad de [Discord](https://discord.com/invite/huKWpsVYx4).
+
+¡Que la fuerza esté con nuestros atletas! ¡Vamos Brasil!
+
+[Base de los Datos](/) es una iniciativa sin fines de lucro y de código abierto que busca facilitar y fomentar la producción de conocimiento en Brasil. Nuestro equipo trabaja duro para tratar y publicar datos de calidad que faciliten su análisis. Su apoyo es importante para mantener esta iniciativa.
+
+Apoye en [https://apoia.se/basedosdados](https://apoia.se/basedosdados), o con un PIX: 42494318000116

--- a/next/blog/es/analisando-preco-de-imoveis-em-sao-paulo.md
+++ b/next/blog/es/analisando-preco-de-imoveis-em-sao-paulo.md
@@ -1,0 +1,38 @@
+---
+title: ¿Cuánta diferencia de precio hay en el metro cuadrado entre los barrios de São Paulo?
+description: >-
+  Analizamos los datos de GeoSampa para mapear la disparidad de valores en São
+  Paulo
+slug: precio-del-metro-cuadrado-en-sao-paulo
+date:
+  created: "2023-09-07T00:03:07.999Z"
+authors:
+  - name: Gustavo Alcantara
+    role: Datos
+  - name: Giovane Caruso
+    role: Edición
+    social: https://www.linkedin.com/in/giovanecaruso/
+  - name: Luiza Vilas Boas
+    role: Arte
+thumbnail: /blog/analisando-preco-de-imoveis-em-sao-paulo/image_0.png
+categories: [analise]
+medium_slug: >-
+  https://medium.com/@basedosdados/qual-a-diferen%C3%A7a-de-pre%C3%A7o-do-metro-quadrado-entre-os-bairros-de-s%C3%A3o-paulo-14cad7e4a89d
+published: true
+---
+
+Si alguna vez ha buscado un inmueble para comprar o alquilar, sabe que la ubicación influye mucho en el precio. Por lo general, los inmuebles en zonas centrales cuestan más que los de la periferia, y más aún en una metrópolis del tamaño de São Paulo. Pero ¿cómo es esa geografía de valores y dónde está el metro cuadrado más caro, o más barato, de una de las mayores ciudades del mundo en población?
+
+Para averiguarlo, analizamos los datos de GeoSampa, el portal oficial del ayuntamiento de São Paulo, que reúne datos georreferenciados sobre la ciudad. Esta base es notable por lo que revela sobre la dinámica urbana y el mercado inmobiliario: más de 85 millones de registros y 21,5 GB con información como el valor del impuesto predial y el precio del metro cuadrado construido, a nivel de código postal. Son datos valiosos para examinar patrones de ocupación y planificación urbana, evaluar la valorización de zonas concretas, investigar desigualdades territoriales y fundamentar políticas públicas en evidencia concreta.
+
+Este análisis se centra en el valor del metro cuadrado construido, es decir, el costo medio por metro cuadrado de un inmueble construido, lo que permite ver geográficamente dónde se concentra el valor. Seleccionamos los mil inmuebles con los mayores valores medios de construcción y los mil con los menores. Para ello usamos nuestros Directorios Brasileños para marcar el punto medio de cada código postal y los datos municipales de geobr para quedarnos con los puntos situados dentro de la ciudad de São Paulo. El gráfico siguiente muestra el resultado.
+
+<Image src="/blog/analisando-preco-de-imoveis-em-sao-paulo/image_0.png"/>
+
+La distribución geográfica del valor del metro cuadrado construido en São Paulo es marcadamente desigual. El barrio de Jardim Paulistano, en la zona norte, registra el valor más bajo, R$ 7.960 por metro cuadrado, mientras que Itaim Bibi, en la zona oeste, alcanza el más alto, R$ 39.980. El metro cuadrado más caro de la ciudad es, por tanto, unas cinco veces el más barato, que es la escala de la variación entre regiones de la metrópolis paulista. El valor medio de la ciudad es R$ 23.088.
+
+Con una suscripción a BD Pro puede acceder a datos actualizados periódicamente por el registro fiscal del ayuntamiento, con información como el valor del terreno, el área construida, el uso del inmueble e incluso características del barrio. Comience su [prueba gratuita](https://basedelosdatos.org/bdpro) y explore.
+
+¿Y si usa el código de este análisis para crear sus propios recortes? Todo el código de los análisis que publicamos está disponible en nuestro [GitHub](https://github.com/basedosdados/analises/blob/main/redes_sociais/br_sp_geosampa_iptu_iptu_20230829.ipynb).
+
+➡️ Acceda a los datos [aquí](/dataset/05f1b96d-883b-4202-a4bd-40379c5d326a?table=bdffc0f4-00da-4437-9ed9-0db7df11d3fa)

--- a/next/blog/es/analisando-relacao-entre-idhm-e-eleicoes.md
+++ b/next/blog/es/analisando-relacao-entre-idhm-e-eleicoes.md
@@ -1,0 +1,140 @@
+---
+title: ¿Qué relación hay entre el IDHM y la votación presidencial de 2018 en São Paulo?
+description: Vea cómo analizar los datos del índice de forma más fácil y práctica
+slug: idhm-y-la-votacion-presidencial-de-2018
+date:
+  created: "2022-04-28T15:00:00"
+authors:
+  - name: Gustavo Alcântara
+    role: Texto
+    social: https://medium.com/@gustavo.geo
+  - name: Giovane Caruso
+    role: Edición
+    social: https://medium.com/@giovanecaruso
+thumbnail: /blog/analisando-relacao-entre-idhm-e-eleicoes/image_0.webp
+categories: [analise]
+medium_slug: >-
+  https://medium.com/basedosdados/qual-a-rela%C3%A7%C3%A3o-entre-o-idhm-e-a-vota%C3%A7%C3%A3o-presidencial-de-2018-em-sp-aa9f1305586f
+published: true
+---
+
+## TL;DR
+
+En este breve artículo propongo una visualización sencilla y rápida de cómo la votación presidencial de 2018 se relaciona con el Índice de Desarrollo Humano Municipal (IDHM) de los municipios paulistas. Verá cómo acceder y analizar los datos del índice de forma más fácil y práctica a través del *datalake* público de Base de los Datos, además de los pasos seguidos para construir esa visualización.
+
+<Image src="/blog/analisando-relacao-entre-idhm-e-eleicoes/image_0.webp"/>
+
+## El Índice de Desarrollo Humano Municipal (IDHM)
+
+El IDHM es una medida compuesta de indicadores de tres dimensiones del desarrollo humano: longevidad, educación y renta. El índice varía de 0 a 1: cuanto más cerca de 1, mayor el desarrollo humano. Además de seguir esas mismas tres dimensiones, el IDHM brasileño adecúa la metodología global al contexto brasileño y a la disponibilidad de indicadores nacionales, lo que lo hace más adecuado para evaluar el desarrollo de los municipios de Brasil.
+
+Base de los Datos publica los datos del [Atlas del Desarrollo Humano (ADH)](http://atlasbrasil.org.br/), el sitio que reúne el IDHM y otros 200 indicadores, ya tratados y listos para el análisis. **Son datos a nivel de Brasil, estado y municipio** que pueden analizarse en Python, R o en el propio BigQuery vía SQL. Para este análisis usamos el [paquete de R de BD](https://github.com/basedosdados/sdk/tree/master/r-package). Acceda a esta base [aquí](/dataset/mundo-onu-adh).
+
+## Analizando la relación entre el IDHM y la votación presidencial
+
+> Para toda buena pregunta existirá un buen análisis por hacer.
+
+Siempre que pensemos en trabajar con datos, estadísticas y análisis, lo primero que importa es definir una buena pregunta. Eso le ahorrará un tiempo precioso en la limpieza y manipulación de su base de datos. En este breve ejercicio, con las elecciones presidenciales acercándose, reflexioné sobre cómo el IDHM de los municipios paulistas puede relacionarse con la última elección presidencial. ¿Existe una relación entre el candidato electo o no y el IDH de los municipios?
+
+### ¿Cómo presentar esa relación?
+
+Correlacionar datos no siempre es tarea fácil. Pero con algunas líneas de código y buenas bibliotecas en su software de análisis resulta relativamente simple indicar la tendencia o correlación entre los datos mediante una representación gráfica.
+
+Mi lengua materna en programación es R. Empecé a desarrollar análisis en 2016 usando R base y hoy uso RStudio por su interfaz gráfica y su rápida manipulación. Me gusta mucho R y sobre todo su comunidad, siempre dispuesta a colaborar. BD pone todo su datalake a disposición para acceso y manipulación en R y en otros lenguajes.
+
+### Creando el dataframe
+
+Ahora viene la parte más entretenida: ¡a programar! El primer paso es crear el dataframe que responda a la pregunta anterior. Dejé las anotaciones en el propio código. Si tiene alguna duda, puede encontrarme en el servidor de [Base de los Datos en Discord](https://discord.com/invite/huKWpsVYx4); mi usuario es @gustavoalcantara. Estos son los primeros pasos:
+
+```r
+# Inicio da Jornada
+# Atribuição do projeto na Base dos dados
+
+con <- bigrquery::dbConnect(
+  bigquery(),
+  billing = "basedosdados-elections",
+  project = "basedosdados"
+)
+
+# indo para o meu projeto no Google DataLake
+basedosdados::set_billing_id("basedosdados-elections")
+
+# query necessária para responder à minha pergunta
+query <- "
+SELECT
+  ano,
+  turno,
+  sigla_uf,
+  sigla_partido,
+  id_municipio,
+  votos,
+  resultado,
+  cargo
+FROM
+  `basedosdados.br_tse_eleicoes.resultados_candidato_municipio`
+WHERE
+  ano = 2018
+  AND sigla_uf = 'SP'
+  AND cargo = 'presidente'
+"
+
+# atribuição do Dataframe
+df <- DBI::dbGetQuery(con, query)
+```
+Con el `dataframe` en mano, toca calcular la proporción de votos de los candidatos presidenciales por municipio para verificar la relación con el IDHM. Para ello usamos el código siguiente, que crea una nueva variable:
+
+```r
+# Criação de Variável: Porcentagem das votações
+df <- df |>
+  dplyr::group_by(id_municipio) |>
+  dplyr::mutate(porcentagem = votos / sum(votos) * 100)
+```
+Parte del propósito de este material es que también pueda trabajar con una tabla externa a BD. Por eso importé un `.csv` de mi computadora, el IDHM de los municipios paulistas, y cambié el nombre de la variable de municipio para poder hacer un join. Como la idea es analizar una posible relación entre el IDHM y el porcentaje de votación, es más fácil visualizarla gráficamente con las variables ordenadas. El código que usé fue este:
+
+```r
+# Juntando o IDHM de uma base externa com a base de Eleições
+# Lendo a base Externa
+idhm <- read.csv("idhm_sp.csv")
+# Mudando o nome da variável Cod.IBGE para id_municipio
+# para o futuro join
+idhm <- idhm |>
+  dplyr::rename(id_municipio = "Cod.IBGE")
+# Join entre as tabelas
+df |>
+  dplyr::left_join(idhm,
+    by = "id_municipio"
+  )
+```
+¡Listo! Nuestro dataframe está preparado. Tiene este aspecto:
+
+<Image src="/blog/analisando-relacao-entre-idhm-e-eleicoes/image_1.webp"/>
+
+### Analizando gráficamente las relaciones entre IDHM y porcentaje de votos
+
+Con el dataframe completo resulta sencillo elaborar una visualización gráfica de nuestra pregunta general. Vea el código y la visualización:
+
+```r
+# grafico das relacoes
+dplyr::filter(df, turno == 2) |>
+  dplyr::group_by(id_municipio) |>
+  ggplot2::ggplot(aes(
+    x = idhm_2010,
+    y = porcentagem,
+    color = resultado
+  )) +
+  geom_point() +
+  geom_smooth() +
+  scale_color_discrete(labels = c("Bolsonaro", "Fernando Haddad")) +
+  labs(
+    title = "Relação entre IDHM e Porcentagem de Votos em SP",
+    x = "IDHM",
+    y = "Porcentagem de Votos",
+    colour = "Candidato:"
+  ) +
+  theme(legend.position = "bottom")
+```
+<Image src="/blog/analisando-relacao-entre-idhm-e-eleicoes/image_0.webp"/>
+
+Y listo. Con esta visualización tenemos una primera lectura de la relación entre el IDHM en el estado de São Paulo y la votación presidencial de 2018. Cada punto es un municipio y representa en el eje y el porcentaje de votos que recibió cada candidato: en azul para Fernando Haddad y en rojo para Bolsonaro. Observe cómo, en los municipios con IDHM alto (mayor que 0,70), el porcentaje de votos se comporta de forma inversa entre los dos candidatos. Haddad obtuvo allí su menor porcentaje, mientras que Bolsonaro obtuvo el mayor, con una tendencia creciente cuanto mayor es el IDH.
+
+¿Se repite ese escenario en otros estados? Haga también su análisis. Si necesita una mano, Base de los Datos tiene un equipo preparado para ayudarle. Traiga sus dudas a [nuestra comunidad en Discord](https://discord.com/invite/huKWpsVYx4).

--- a/next/blog/es/atualizar-como-funciona-o-sistema-de-insercao-de-dados-na-bd.md
+++ b/next/blog/es/atualizar-como-funciona-o-sistema-de-insercao-de-dados-na-bd.md
@@ -1,0 +1,84 @@
+---
+title: ¿Cómo funciona el sistema de inserción de datos en BD?
+description: >-
+  Conozca nuestra infraestructura de inserción de datos y vea cómo contribuir
+  puede mejorar su portafolio
+slug: como-funciona-la-insercion-de-datos
+date:
+  created: "2021-05-28"
+authors:
+  - name: Vinicius
+    social: https://github.com/vncsna
+    role: Autor
+  - name: Fernanda
+    social: https://github.com/fernandascovino
+    role: Autor
+  - name: Diego
+    social: https://github.com/d116626
+    role: Autor
+  - name: João
+    social: https://github.com/JoaoCarabetta
+    role: Autor
+  - name: Caio
+    social: https://github.com/Hellcassius
+    role: Autor
+  - name: Giovane Caruso
+    social: https://medium.com/@giovanecaruso
+    role: Adaptación y edición
+thumbnail: /blog/como-funciona-o-sistema-de-insercao-de-dados-na-bd/image_0.jpg
+categories: []
+medium_slug: >-
+  https://medium.com/@basedosdados/como-funciona-o-sistema-de-inser%C3%A7%C3%A3o-de-dados-na-bd-61a0fe05c5d5
+published: false
+---
+
+## TL;DR
+
+Este artículo explica cómo funciona la infraestructura de inserción de datos de Base de los Datos y cómo contribuir a nuestra misión de universalizar el acceso a los datos puede mejorar su portafolio como científico de datos o desarrollador.
+
+<Image src="/blog/como-funciona-o-sistema-de-insercao-de-dados-na-bd/image_0.jpg" caption="Photo by [Riho Kroll](https://unsplash.com/@rihok) on [Unsplash](https://unsplash.com/)"/>
+
+## La infraestructura
+
+El equipo de infraestructura de Base de los Datos se encarga de las herramientas de ingesta de datos —desde la carga hasta la disponibilización en el entorno de producción—, del acceso a los datos mediante los paquetes de Python y R, y de nuestro [sitio web](/). El equipo trabaja actualmente en varios frentes, entre ellos la renovación del sitio y la implementación de controles automatizados.
+
+Buscamos simplificar y automatizar cada paso, empezando por la [carga de datos](https://basedosdados.org/docs/colab_data) y su inserción en el **Entorno de Experimentación**. En ese punto, quien colabora puede añadir datos en su nube de Google, limpiarlos y tratarlos, y luego crear las tablas locales con la interfaz de línea de comandos desarrollada por el equipo de infraestructura. Por último, puede enviar el conjunto de datos a revisión abriendo un pull request en [GitHub](https://github.com/basedosdados/sdk/pulls).
+
+Tras el pull request de revisión entra en acción el sistema de controles, con el equipo de datos verificando la calidad de los datos y de los metadatos. Este paso es central para mantener la calidad que distingue a Base de los Datos. El equipo de infraestructura procura automatizar al máximo esa revisión, validando metadatos como nombres y descripciones de columnas, y tipos de datos como las claves primarias.
+
+Superadas las verificaciones, el pull request de inserción se aprueba y los datos entran en el **Entorno de Producción**. A partir de ahí se puede acceder a ellos con cualquiera de nuestras herramientas, como los paquetes de Python y R, o directamente en BigQuery.
+
+<Image src="/blog/como-funciona-o-sistema-de-insercao-de-dados-na-bd/image_1.png"/>
+
+En paralelo al proceso de inserción, el equipo de infraestructura trabaja con el equipo del sitio en la renovación de nuestra plataforma para ofrecer una interfaz moderna. Escribimos un [artículo](/blog/um-site-feito-a-varias-maos) sobre cómo organizamos un proyecto colaborativo para construir una nueva plataforma que facilita aún más su trabajo con datos.
+
+## Contribuir con datos
+
+En el camino para convertirse en analista de datos o desarrollador, entrar en el mercado laboral resulta difícil. A menudo no hay equilibrio entre el estudio y la aplicación práctica, o solo se hace análisis de datos de juguete. Que levante la mano quien no haya estado atascado en conjuntos como Titanic o Iris. Esos conjuntos sirven para aprender un método o una herramienta nueva, pero el conocimiento no se transfiere al mundo real.
+
+Una buena alternativa para trabajar con datos reales y mejorar su portafolio es ayudar a Base de los Datos con la ingesta de datos. Como mínimo se ocupará de la captura de datos, preferiblemente automatizada, junto con su arquitectura y limpieza. También usará las herramientas del día a día de un científico de datos: interfaces de línea de comandos, YAML y BigQuery. Esa experiencia puede marcar la diferencia al entrar en el mercado laboral.
+
+Describimos el proceso en detalle en [Colaborando con datos en BD](https://basedosdados.org/docs/colab_data). En resumen tiene cuatro partes. Primero nos comunica su interés. Después limpia y trata los datos que pretende subir. A continuación los carga en su BigQuery personal. Y, por último, los envía a revisión.
+
+## Contribuir con la infraestructura
+
+Otra forma de contribuir y mejorar su portafolio, esta vez como desarrollador, es colaborar con la infraestructura de BD.
+
+Empieza por hablar con nosotros, en el chat de infraestructura o en las reuniones de los lunes a las 19h, ambos en los canales de infraestructura de [Discord](https://discord.gg/huKWpsVYx4). A partir de ahí podemos elegir una función o un problema para desarrollar, si no ha encontrado ya algo entre las [issues](https://github.com/basedosdados/sdk/issues) abiertas.
+
+¿Cómo puede colaborar? **Aquí van algunas ideas:**
+
+- Añadiendo nuevos conjuntos de datos
+- Revisando envíos de datos
+- Mejorando el paquete de Python y creando nuevas funcionalidades
+- Mejorando el paquete de R y creando nuevas funcionalidades
+- Añadiendo verificaciones automáticas de datos
+- Añadiendo verificaciones automáticas de metadatos
+- Desarrollando nuevas funcionalidades para el sitio
+
+**¿Le ha servido de algo nuestro proyecto?** Somos una organización sin fines de lucro que depende del apoyo de su comunidad. Así puede contribuir:
+
+- [Apoye el proyecto](https://apoia.se/basedosdados)
+- [Sea colaborador(a) de datos en BD](https://basedosdados.org/docs/colab_data)
+- [Colabore con nuestros paquetes](https://github.com/basedosdados/mais)
+- ¡Compártanos en redes sociales!

--- a/next/blog/es/atualizar-intro-ao-pacote-basedosdados-em-python.md
+++ b/next/blog/es/atualizar-intro-ao-pacote-basedosdados-em-python.md
@@ -1,0 +1,101 @@
+---
+title: Introducción al paquete basedosdados en Python
+description: Explore los datos de nuestro datalake público
+slug: intro-al-paquete-basedosdados-en-python
+date:
+  created: "2021-04-16"
+authors:
+  - name: Vinicius Aguiar
+    role: Equipo Base de los Datos 💚
+    social: https://medium.com/u/2af0c71cb64a
+  - name: Fernanda Scovino
+    role: Equipo Base de los Datos 💚
+    social: https://medium.com/u/444581849446
+thumbnail: /blog/intro-ao-pacote-basedosdados-em-python/image_0.jpg
+categories: [tutorial]
+medium_slug: https://medium.com/@basedosdados/intro-ao-pacote-basedosdados-em-python-4e05439e936d
+published: false
+---
+
+<Image src="/blog/intro-ao-pacote-basedosdados-em-python/image_0.jpg"/>
+
+## TL;DR
+
+Vamos a mostrar **cómo usar el paquete de Base de los Datos en Python.** El paquete permite acceder y analizar más de 70 conjuntos de datos de nuestro *datalake* público, obtener información sobre las tablas, cargar datos en pandas y más.
+
+Contenido basado en el [taller "Jugando con datos de BD en Python"](https://www.youtube.com/watch?v=wI2xEioDPgM).
+
+## Cómo acceder a BD desde Python
+
+Base dos Dados Mais es nuestro *datalake* de datos públicos **limpios, integrados y actualizados** por nuestro equipo de datos: datos listos para el análisis.
+
+El *datalake* se mantiene en Google BigQuery y tiene un costo prácticamente nulo para todos los usuarios: dispone de 1 TB al mes para consultar los datos. Para facilitar aún más la vida de los pythonistas, creamos un paquete de acceso directo al repositorio: **basedosdados**
+
+```sh
+# rode para instalar no Python/Jupyter
+!pip install basedosdados
+```
+```python
+import basedosdados as bd
+```
+> **Atención.** Es necesario crear un proyecto en Google Cloud para consultar los datos del datalake. La primera vez que ejecute cualquier función del paquete aparecerán las instrucciones y bastará con seguir el paso a paso. Utilice el **ID del proyecto** generado para ejecutar las funciones que siguen.
+
+El paquete tiene muchas funciones, tanto de acceso como de publicación de datos en nuestro proyecto de Google Cloud o en el suyo: también puede usarlo para construir su propio repositorio de datos. La lista completa de módulos está en [nuestra documentación](https://basedosdados.org/docs/api_reference_python), y vea también cómo colaborar [subiendo datos al repositorio](https://basedosdados.org/docs/colab_data).
+
+## Explorando las funciones del paquete
+
+Como ilustración, puede consultar todos los conjuntos de datos disponibles en el *datalake* con la función `list_datasets`. Esta función devuelve todos los conjuntos, que pueden filtrarse por un término concreto con el parámetro `filter_by`. Abajo mostramos cómo hacerlo buscando datos del IBGE. El parámetro `with_description` indica si queremos ver también la descripción de cada conjunto.
+
+```python
+bd.list_datasets(filter_by="ibge", with_description=True)
+```
+Del mismo modo, se pueden listar las tablas de un conjunto concreto con la función `list_dataset_tables`. Además, se puede tener una visión completa de las columnas y sus tipos con `get_table_columns`, todo ello sin cargar aún los datos en el entorno.
+
+```python
+# Lista as tabelas do conjunto de dados sobre nomes no Brasil
+bd.list_dataset_tables(
+  dataset_id="br_ibge_nomes_brasil",
+  with_description=True
+)
+
+# Consultando as colunas de uma das tabelas do conjunto
+bd.get_table_columns(
+  dataset_id="br_ibge_nomes_brasil",
+  table_id="quantidade_municipio_nome_2010"
+)
+```
+Antes de cargar los datos conviene comprobar su tamaño total: hay tablas muy grandes en el repositorio, así que recomendamos encarecidamente este paso.
+
+```python
+bd.get_table_size(
+  dataset_id="br_ibge_nomes_brasil",
+  table_id="quantidade_municipio_nome_2010",
+  billing_project_id="seu-id-projeto"
+)
+```
+Por último, la función `read_table` carga los datos en el entorno de Python. Si la base en cuestión es muy grande, puede optar por `read_sql`, que permite ejecutar una consulta SQL y cargar solo los datos solicitados. En ambos casos es necesario indicar su `billing_project_id`, el proyecto habilitado al principio, que se cobrará si supera el límite gratuito.
+
+```python
+df = bd.read_table(
+  dataset_id="br_ibge_nomes_brasil",
+  table_id="quantidade_municipio_nome_2010",
+  billing_project_id="seu-id-projeto"
+)
+```
+En este ejemplo trabajamos con los datos de [nombres brasileños del Censo Demográfico 2010 del IBGE](/dataset/703f9f0d-caee-4b47-b900-46b1dea2c33c?table=3bc00c7a-28e5-421b-b310-b32bed3dd4d4). Según el Censo, Brasil tiene unos 200 millones de habitantes con más de 130 mil nombres distintos. ¿Curioso? Nosotros también.
+
+## Construyendo un análisis: ¿cuáles son los nombres más comunes en Brasil?
+
+¿Su apuesta, María o João? Vamos a descubrirlo con los datos.
+
+Para responder, contamos la frecuencia de cada nombre en Brasil y ordenamos poniendo los más frecuentes arriba. Después creamos una nube de palabras para visualizar esa información.
+
+Escribimos la función `generate_list_sorted_by_freq`, que agrega los nombres de la tabla contando cuántas veces aparece cada uno, y ordena la lista por frecuencia. El código va más abajo.
+
+Para crear la imagen usamos la biblioteca `wordcloud` junto con `matplotlib`, ambas instalables vía `pip`. `wordcloud` genera una imagen en la que el tamaño de cada palabra viene dado por su frecuencia, lo que da un buen efecto visual a nuestro ranking.
+
+Y el resultado: **María es la ganadora.**
+
+<Image src="/blog/intro-ao-pacote-basedosdados-em-python/image_1.jpg" caption="Nube de palabras con los nombres más frecuentes en Brasil. El tamaño de cada palabra corresponde a lo común que es ese nombre. El mayor de la imagen es Maria, seguido de José, João, Antônio y Francisco."/>
+
+**¿Qué le pareció este hallazgo?** En el próximo texto traeremos un análisis regional que Fred construyó en el mismo taller. Vea este y otros talleres en nuestro [YouTube](https://www.youtube.com/c/BasedosDados).

--- a/next/blog/es/bdletter-36-online-vs-offline.md
+++ b/next/blog/es/bdletter-36-online-vs-offline.md
@@ -1,0 +1,56 @@
+---
+title: Online vs offline. ¿Qué estrategia prefieren los candidatos en las elecciones?
+description: >-
+  Un análisis muestra la evolución del gasto de los candidatos en publicidad en medios digitales
+slug: online-vs-offline-gasto-de-campana
+date:
+  created: "2024-10-30T18:18:06.419Z"
+thumbnail: 
+categories: [analise]
+authors:
+  - name: Marina Monteiro 
+    role: Análisis y texto
+    social: https://www.linkedin.com/in/ma-m-mendonca/
+  - name: Thais Filipi
+    role: Análisis y texto
+    social: https://www.linkedin.com/in/thaismdr/
+    avatar: https://media.licdn.com/dms/image/v2/C4E03AQFstxqWabAyUA/profile-displayphoto-shrink_200_200/profile-displayphoto-shrink_200_200/0/1584489568236?e=2147483647&v=beta&t=mol7Kc8PgxgJatgvNYRkyffL8opuIgFgRdiY7vXB1HA
+  - name: Giovane Caruso
+    role: Edición de texto
+    social: https://www.linkedin.com/in/giovanecaruso/
+  - name: José Félix
+    role: Edición gráfica
+    social: https://www.linkedin.com/in/jos%C3%A9-f%C3%A9lix-517b05210/
+medium_slug: >-
+
+published: true
+---
+
+Las campañas políticas se adaptan a la aparición de nuevas tecnologías: en algún momento la novedad fue la radio, después la televisión, los sitios web, las redes sociales y así sucesivamente. Del mismo modo, las campañas se adecuan a las formas de uso de esos medios, tanto desde el punto de vista socioeconómico como cultural. Pero la aparición de una nueva tecnología no invalida necesariamente la importancia y el impacto de las demás formas de comunicación y persuasión política.
+
+Competir por cargos electivos no es barato, y la decisión sobre qué estrategia adoptar es crucial para que las candidaturas sean competitivas. Para entender mejor este escenario tomamos prestada de la ciencia política una de las formas posibles de clasificar los gastos de las campañas de 2020 y 2024, junto con los datos de gastos e ingresos de los candidatos, ya disponibles en el datalake público de BD. Esta información nos ayuda a evaluar la importancia relativa de cada tipo de gasto desde la última elección municipal.
+
+Para ordenar los datos usamos la clasificación tradicional–moderna–online, con un elemento adicional, "otros", que incluye también los gastos organizativos. En general, los gastos tradicionales implican estrategias de calle (impresión de materiales, gastos de personal y similares). Los de tipo moderno implican estrategias de difusión por radio, televisión, creación de jingles y gastos en encuestas electorales. La campaña online abarca gastos en impulsión de contenido y creación de páginas en internet. El gasto organizativo comprende infraestructura, gestión y otros.
+
+También añadimos las variaciones por tamaño de municipio, dada la dimensión continental del país y el carácter local y específico de las disputas por los cargos de alcalde y concejal. Clasificamos como municipios pequeños los que tienen hasta 5 mil votantes; medianos pequeños los que están entre 5 y 10 mil; medianos entre 10 y 50 mil; medianos grandes entre 50 y 200 mil; y grandes los de más de 200 mil votantes.
+
+La composición de las campañas varía bastante, tanto por tamaño electoral de los municipios como por región. El mayor monto de los gastos se concentra en estrategias de calle en casi todos los casos en 2024, con al menos la mitad de los recursos destinados a ellas. Las excepciones son los municipios de gran tamaño electoral del Norte y del Sur, con un 49,8% y un 46,9% respectivamente. En esos casos, el otro tipo de gasto que casi se equipara es el de tipo moderno.
+
+Dentro de los gastos de campaña tradicionales destacan los destinados a publicidad con materiales impresos, servicios prestados por terceros, actividades de militancia y movilización de calle, gastos de personal y servicios jurídicos. Juntos suman más de 2 mil millones de reales.
+
+<Image src="/blog/bdletter-36-online-vs-offline/giff-1.gif"/>
+
+Considerando solo a quienes compiten por la alcaldía, el único gasto que no aparece en el mismo "top 5" de los gastos generales es el de personal. En su lugar aparece la producción de programas de radio, televisión o video (teniendo en cuenta los recursos del Horario Gratuito de Propaganda Electoral). Vea el gráfico anterior. Para los candidatos a concejal, la publicidad con pegatinas ocupa el lugar de los servicios jurídicos. Vea la imagen siguiente.
+
+<Image src="/blog/bdletter-36-online-vs-offline/giff-2.gif"/>
+
+
+Conviene subrayar que los datos de gastos se actualizan diariamente. Hasta el momento, algo menos de la mitad de los municipios tiene declaración de gastos registrada en el TSE (los candidatos tienen hasta 30 días después de las elecciones para incluir esa información en el sistema de rendición de cuentas electorales). Por eso los resultados presentados aquí son preliminares. Los datos utilizados en el texto se capturaron el 10 de octubre de 2024.
+
+La presencia digital de las campañas viene ganando protagonismo, tanto en los análisis especializados como en las adaptaciones de la legislación electoral para acompañar las transformaciones del debate público. Los gastos en impulsión de contenido en redes sociales quedan en noveno lugar del total, con R$ 165 millones invertidos. Considerando solo a los candidatos a la alcaldía, el valor pasa a ser de R$ 98 millones, con el mismo lugar en el ranking. Para los candidatos a concejal el gasto tiene más peso, quedando en sexto lugar (cerca de R$ 67 millones). El dato es más llamativo aún considerando lo reciente de este tipo de gasto: la impulsión pagada de contenido se permitió recién después de 2016. La campaña online todavía "compite" con otras 41 categorías de gasto. Respecto a 2020 no se percibe un aumento drástico en el porcentaje de los gastos en campañas online frente a los demás (un aumento del 6,75%). Lo que vemos, en cambio, es una mayor dispersión en el uso de este tipo de gasto en 2024 que en 2020.
+
+La asociación entre la inversión en campañas online y el éxito electoral no siempre es fácil de establecer. Algunos estudios indican que los candidatos a alcalde electos en 2010 invirtieron relativamente menos en ese medio que los no electos (ver Heiler, Viana y Santos, 2016). Por otro lado, los candidatos electos suelen tener más recursos y mayor capacidad de diversificar sus gastos. Es decir, la campaña online pudo ser bastante relevante para ellos, pero también disponían de otros recursos y atributos que acabaron siendo fundamentales para conquistar el cargo.
+
+ _Acceda a los datos de elecciones en BD [aquí](https://basedelosdatos.org/dataset/eef764df-bde8-4905-b115-6fc23b6ba9d6?table=2e204854-e453-4257-9fef-5e10f3ff1f56?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-9Yx4xtu1zd_-mp0_-jUCEk4_wkMtfgaKHYvzv5fHyx85tBqg6-vU4geE7jEMAX-oFjDOd8)_.
+
+¿Quiere ver el código y las referencias utilizadas en este análisis? Acceda a nuestro [repositorio de análisis en GitHub](https://github.com/basedosdados/analises/commit/3c4a75bc3058e1e1eafd2e194d69d4cb35bb7117?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-9Yx4xtu1zd_-mp0_-jUCEk4_wkMtfgaKHYvzv5fHyx85tBqg6-vU4geE7jEMAX-oFjDOd8).

--- a/next/blog/es/bdletter-38-retrospectiva2024.md
+++ b/next/blog/es/bdletter-38-retrospectiva2024.md
@@ -1,0 +1,66 @@
+---
+title: 2024 en datos, una retrospectiva
+description: >-
+   BDletter. Para celebrar el clima de fin de año, hicimos una retrospectiva de los análisis y datos más interesantes de este año en BD. No fue un año cualquiera.
+slug: 2024-en-datos-una-retrospectiva
+date:
+  created: "2024-12-30T18:18:06.419Z"
+thumbnail: 
+categories: [analise]
+authors:
+  - name: Giovane Caruso 
+    role: Texto y diseño
+published: true
+---
+
+Para celebrar el clima de fin de año, hicimos una retrospectiva de los análisis y datos más interesantes de este año en BD. No fue un año cualquiera. Hubo elecciones municipales, Juegos Olímpicos, eventos climáticos extremos y otros acontecimientos que podemos observar y analizar con datos públicos. Esta es nuestra invitación para que explore esos datos y cree sus propios análisis.
+
+Conviene recordar que esto es solo una selección de los análisis y datos que subimos al datalake público de BD en 2024. Mucho quedó fuera, así que si echa algo en falta, cuéntenoslo por las redes sociales de @basedosdados.
+
+Antes de continuar, aprovechamos para desear una feliz Navidad y un buen año nuevo a todos ustedes, databasers. Son ustedes quienes mantienen viva nuestra misión de universalizar el acceso a datos de calidad en Brasil (y, quién sabe, algún día en el mundo). Agradecemos el apoyo y el cariño de toda la comunidad 💚
+
+## 2024 en datos
+
+Nuestro año empezó muy bien con la publicación de los datos de las tablas Sidra del Censo 2022 en el datalake público de BD. No perdimos tiempo y creamos algunos análisis interesantes para inspirar y ayudar a quienes van a trabajar con esos datos. Descubrimos, por ejemplo, que Brasil cuenta con unos 37.810 habitantes centenarios, menos del 0,02% de la población. Aunque los errores en la declaración de edad siguen siendo una realidad, el aumento de la población en edades avanzadas respecto al Censo anterior es evidente.
+
+También usamos los datos del Censo 2022 para dividir a la población brasileña en generaciones, usando uno de nuestros grandes patrimonios culturales como parámetro: las telenovelas. Vea [más](https://www.instagram.com/p/C6Y_Y8gOLQD/?img_index=1?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-9eMfjJcJ-ddzfJmoqhExXJv7a6zhVICAprZz8qb5jH9MW1K3-jkboGltBnjEg1QGooJYpT).
+
+...
+
+En abril, Brasil miró y se solidarizó mientras una tragedia azotaba a la población de Rio Grande do Sul. Con los [datos del INMET](https://basedelosdatos.org/dataset/782c5607-9f69-4e12-b0d5-aa0f1a7a94e2?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-9eMfjJcJ-ddzfJmoqhExXJv7a6zhVICAprZz8qb5jH9MW1K3-jkboGltBnjEg1QGooJYpT) analizamos la relación entre las lluvias extremas en el estado y el cambio climático, con la participación especial de Karina Lima, doctoranda en climatología y divulgadora científica. Vea el análisis completo [aquí](https://medium.com/basedosdados/qual-foi-a-magnitude-das-chuvas-extremas-que-atingiram-porto-alegre-este-ano-e-qual-a-rela%C3%A7%C3%A3o-675265bce50e?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-9eMfjJcJ-ddzfJmoqhExXJv7a6zhVICAprZz8qb5jH9MW1K3-jkboGltBnjEg1QGooJYpT).
+
+<Image src="/blog/bdletter-38-retrospectiva2024/grafico_1.png"/>
+
+El avance de la deforestación sigue siendo un problema muy grave que exige un monitoreo constante. En 2024 publicamos [datos como el Catastro Ambiental Rural](https://basedelosdatos.org/dataset/6b687e32-32bb-4dd6-ac8b-7dfa011ac619?table=0ba51523-2eb6-422c-a1bb-efc9f9e717a1&utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-9eMfjJcJ-ddzfJmoqhExXJv7a6zhVICAprZz8qb5jH9MW1K3-jkboGltBnjEg1QGooJYpT), que registra información ambiental de propiedades rurales en Brasil, junto con los [microdatos del Sistema de Operaciones de Crédito Rural](https://basedelosdatos.org/dataset/544c9d22-97b7-479a-8eca-94762840b465?table=e2d5dcc5-270e-4a8b-8d55-0227fd46c10f&utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-9eMfjJcJ-ddzfJmoqhExXJv7a6zhVICAprZz8qb5jH9MW1K3-jkboGltBnjEg1QGooJYpT) y de Proagro, actualizados este año, que apoyan esa fiscalización.
+
+Para contribuir aún más al acceso a información sobre medio ambiente, producción rural y ocupación de la tierra en Brasil, publicamos los datos de la [Encuesta Agrícola Municipal](https://basedelosdatos.org/dataset/fc403b40-a7e1-40e7-9efe-910847b45a69?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-9eMfjJcJ-ddzfJmoqhExXJv7a6zhVICAprZz8qb5jH9MW1K3-jkboGltBnjEg1QGooJYpT) (PAM) y de la [Encuesta Pecuaria Municipal](https://basedelosdatos.org/dataset/f7df4160-7a6f-4658-a287-3a73d412ed10?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-9eMfjJcJ-ddzfJmoqhExXJv7a6zhVICAprZz8qb5jH9MW1K3-jkboGltBnjEg1QGooJYpT) (PPM).
+
+...
+
+En 2024, Brasil también enfrentó una de las peores epidemias de dengue de su historia. Solo este año se registraron aproximadamente 12,5 millones de casos, de los cuales 97 mil correspondieron a pacientes gestantes. Para facilitar la vida de quien investiga este escenario, publicamos los [datos sobre casos de dengue](https://basedelosdatos.org/dataset/f51134c2-5ab9-4bbc-882f-f1034603147a?table=9bdbca38-d97f-47fa-b422-84477a6b68c8&utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-9eMfjJcJ-ddzfJmoqhExXJv7a6zhVICAprZz8qb5jH9MW1K3-jkboGltBnjEg1QGooJYpT) del Sistema de Información de Agravios y Notificación del Ministerio de Salud.
+
+Con el objetivo de contribuir todavía más al desarrollo y la evaluación de políticas de salud pública, publicamos varias bases de datos importantes sobre el tema, como los [datos del Sistema de Informaciones Hospitalarias](https://basedelosdatos.org/dataset/ff933265-8b61-4458-877a-173b3f38102b?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-9eMfjJcJ-ddzfJmoqhExXJv7a6zhVICAprZz8qb5jH9MW1K3-jkboGltBnjEg1QGooJYpT), los [microdatos del Sistema de Vigilancia Alimentaria y Nutricional](https://basedelosdatos.org/dataset/d0b61e1c-2ff2-43e7-b32f-5a054ba9b688?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-9eMfjJcJ-ddzfJmoqhExXJv7a6zhVICAprZz8qb5jH9MW1K3-jkboGltBnjEg1QGooJYpT) (SISVAN) y los [datos del Sistema de Informaciones Ambulatorias](https://basedelosdatos.org/dataset/22d1f0d6-9bbc-4653-a841-7734867d2319?table=5613bffd-f741-4f74-a48e-685d6438f354&utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-9eMfjJcJ-ddzfJmoqhExXJv7a6zhVICAprZz8qb5jH9MW1K3-jkboGltBnjEg1QGooJYpT) (SIA).
+
+...
+
+Este fue el año en que nuestras atletas brillaron en los Juegos Olímpicos de París. Aprovechamos los [datos históricos de Olympedia](https://basedelosdatos.org/dataset/62f8cb83-ac37-48be-874b-b94dd92d3e2b?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-9eMfjJcJ-ddzfJmoqhExXJv7a6zhVICAprZz8qb5jH9MW1K3-jkboGltBnjEg1QGooJYpT) para analizar la distribución de edad de las gimnastas olímpicas a lo largo del tiempo. Véalo [aquí](https://www.instagram.com/p/C-GluHayZF9/?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-9eMfjJcJ-ddzfJmoqhExXJv7a6zhVICAprZz8qb5jH9MW1K3-jkboGltBnjEg1QGooJYpT).
+
+...
+
+En política también fue un año bastante agitado. En el primer semestre publicamos los [Datos Abiertos de la Cámara de Diputados](https://basedelosdatos.org/dataset/3d388daa-2d20-49eb-8f55-6c561bef26b6?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-9eMfjJcJ-ddzfJmoqhExXJv7a6zhVICAprZz8qb5jH9MW1K3-jkboGltBnjEg1QGooJYpT), actualizados automáticamente. Creamos la campaña #DeOlhoNaCamara, con análisis y tutoriales para ayudar a quien trabaja con esos datos. En ella descubrimos que los diputados de la legislatura actual [ya destinaron más de R$ 170 millones a divulgar](https://www.instagram.com/p/C8ZtmUTM3lF/?img_index=1?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-9eMfjJcJ-ddzfJmoqhExXJv7a6zhVICAprZz8qb5jH9MW1K3-jkboGltBnjEg1QGooJYpT) sus actividades parlamentarias, casi el 20% del total de gastos de la Cuota Parlamentaria hasta el momento. Vea más [aquí](https://basedelosdatos.org/blog/de-olho-na-camara-analisando-dados-abertos-da-camara-dos-deputados-com-a-bd?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-9eMfjJcJ-ddzfJmoqhExXJv7a6zhVICAprZz8qb5jH9MW1K3-jkboGltBnjEg1QGooJYpT).
+
+<Image src="/blog/bdletter-38-retrospectiva2024/grafico_2.png"/>
+
+Para dar más transparencia y accesibilidad a la información sobre el dinero de las elecciones municipales, creamos una nueva versión del panel [Siga o Dinheiro](https://www.sigaodinheiro.org/?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-9eMfjJcJ-ddzfJmoqhExXJv7a6zhVICAprZz8qb5jH9MW1K3-jkboGltBnjEg1QGooJYpT) en alianza con JOTA. El panel permite que cualquier votante siga los ingresos y gastos de candidatos y partidos, con filtros a nivel de municipio. Vea algunos de los [análisis](https://www.sigaodinheiro.org/artigos?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-9eMfjJcJ-ddzfJmoqhExXJv7a6zhVICAprZz8qb5jH9MW1K3-jkboGltBnjEg1QGooJYpT) que produjimos a lo largo del proyecto.
+
+...
+
+Conviene recordar que bases importantísimas para analizar el mercado laboral en Brasil también se fueron actualizando en BD apenas estuvieron disponibles en las fuentes originales, como la RAIS y el CAGED. Analizamos la disparidad salarial por género y raza usando datos del CAGED para abrir ese debate importante e incentivarle, databaser, a explorar aún más esos datos. Vea el análisis completo [aquí](https://medium.com/@basedosdados/como-a-disparidade-salarial-por-g%C3%AAnero-e-ra%C3%A7a-evoluiu-ao-longo-dos-anos-949ea4d121a7?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-9eMfjJcJ-ddzfJmoqhExXJv7a6zhVICAprZz8qb5jH9MW1K3-jkboGltBnjEg1QGooJYpT).
+
+<Image src="/blog/bdletter-38-retrospectiva2024/grafico_3.png"/>
+
+Y eso es solo una muestra de todos los datos y análisis que creamos. Puede consultar siempre nuestros análisis en el blog de BD y en nuestras redes sociales.
+
+Nos vemos el año que viene 💚
+
+<Image src="/blog/bdletter-38-retrospectiva2024/imagem_1.png"/>

--- a/next/blog/es/bdletter-40-qual-e-a-relacao-entre-a-dengue-e-as-mudancas-climaticas.md
+++ b/next/blog/es/bdletter-40-qual-e-a-relacao-entre-a-dengue-e-as-mudancas-climaticas.md
@@ -1,0 +1,62 @@
+---
+title: ¿Cuál es la relación entre el dengue y el cambio climático?
+description: >-
+  La temperatura y las lluvias pueden estar relacionadas con el aumento de casos en algunas ciudades
+slug: dengue-y-cambio-climatico
+date:
+  created: "2025-05-07T21:02:04.375Z"
+authors:
+  - name: Marina Monteiro
+    role: Análisis y texto
+  - name: Giovane Caruso
+    role: Edición y diseño
+categories: [analise]
+thumbnail: /blog/qual-e-a-relacao-entre-a-dengue-e-as-mudancas-climaticas/grafico_goiania.png
+medum_slug: https://medium.com/@basedosdados/nota-sobre-divulga%C3%A7%C3%A3o-dos-dados-do-inep-9168291dbca0
+published: true
+order: 1
+---
+
+En la edición anterior de la BDletter hablamos de la epidemia de dengue y de sus números absolutos y proporcionales en las ciudades donde vive parte de nuestro equipo. En esta edición seguimos con la enfermedad, pero evaluando la relación entre el número de casos y dos variables meteorológicas: la temperatura del aire y la precipitación.
+
+La pregunta es interesante porque el ciclo de vida del *Aedes aegypti* está estrechamente afectado por variables meteorológicas. El mosquito adquiere el virus cuando pica a alguien infectado y se vuelve infectivo, pudiendo transmitir la enfermedad a otras personas en picaduras posteriores. Con altos niveles de precipitación aumenta la oferta de criaderos. Con temperaturas altas se altera el desarrollo, la longevidad y la fecundidad de los mosquitos adultos, que prefieren temperaturas entre 22ºC y 28ºC. Un ciclo de huevo a fase adulta que suele tardar entre 7 y 10 días puede pasar a ocurrir en 3 o 4 días con temperaturas más altas.
+
+Cabría esperar, entonces, que con mayor precipitación y mayor temperatura tuviéramos más mosquitos y que, con más mosquitos, la enfermedad se extendiera más. ¿El aumento de la temperatura y de la precipitación viene acompañado de un aumento de los casos?
+
+Para entenderlo mejor analizamos las capitales del país observando las mediciones de temperatura y precipitación de las estaciones automáticas del [INMET](/dataset/782c5607-9f69-4e12-b0d5-aa0f1a7a94e2?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-_yEejPUipsc-cW3VKr51TG936EDjUtQ7FsruHM1xnCyYNuLd3b6JK282QA06r9HS1mxt-Q9DeZMt8UNYBdTQa6O4xDAQtBow06gCo-RD2SgZobLk4) junto con los registros de notificaciones de casos de dengue del [SINAN](/dataset/f51134c2-5ab9-4bbc-882f-f1034603147a?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-_yEejPUipsc-cW3VKr51TG936EDjUtQ7FsruHM1xnCyYNuLd3b6JK282QA06r9HS1mxt-Q9DeZMt8UNYBdTQa6O4xDAQtBow06gCo-RD2SgZobLk4), todos ellos disponibles en el datalake de Base de los Datos. Con los datos meteorológicos diarios pudimos calcular la temperatura media y el total de precipitación (mensuales y semanales, por semana epidemiológica). Puede consultar después los resultados en detalle en un dashboard interactivo que creamos; el enlace está al final del análisis.
+
+La dinámica esperada para la distribución de casos es: elevación al inicio del período cálido, con pico de casos tras algunos meses de calor, coincidiendo con algunas semanas después del período más lluvioso. Los números más bajos deberían darse en los meses más secos y fríos.
+
+En Goiânia ese patrón se cumple con bastante precisión a lo largo de los años. Vea la imagen siguiente.
+
+<Image src="/blog/bdletter-40-qual-e-a-relacao-entre-a-dengue-e-as-mudancas-climaticas/grafico_goiania.png"/>
+
+Para la capital de Goiás, los casos se concentran en algunas semanas de los picos de precipitación y temperatura. Cuando esas dos variables empiezan a bajar, el número de casos también cae.
+
+Pero la misma dinámica no es tan evidente en la ciudad de Manaos, por ejemplo.
+
+<Image src="/blog/bdletter-40-qual-e-a-relacao-entre-a-dengue-e-as-mudancas-climaticas/grafico_manaus.png"/>
+
+En la capital amazonense, la relación con la precipitación aún se percibe, aunque no de la misma forma que en el ejemplo de Goiânia. La relación con la temperatura ya no parece tan directa. La explicación puede estar en que la variación de la temperatura media se sitúa entre 26ºC y 32ºC, temperaturas ya consideradas altas y siempre propicias para la proliferación del mosquito.
+
+Otro ejemplo de este fenómeno está en la ciudad de Aracaju. A diferencia de las otras capitales, que presentan picos de casos entre febrero y abril, los picos de notificaciones en Aracaju ocurren a mitad de año, hacia junio y julio, aun siendo ese el período más "frío" de la ciudad. Pero, igual que en Goiânia, ese período todavía tiene temperaturas medias por encima de 25ºC. Los máximos de notificaciones se alinean, entonces, con los máximos de precipitación.
+
+## ¿Qué dice la literatura?
+
+Varias investigaciones relacionan estas variables meteorológicas con el número de casos notificados de dengue en diversas regiones. Una investigación desarrollada en la Unicamp indica que un aumento de 1ºC en la temperatura media puede tener como consecuencia un aumento aproximado del 20% al 30% en los casos de dengue en la ciudad de Campinas en los dos meses siguientes. Otros estudios apuntan a una relación con el aumento de casos locales cuando crece la pluviosidad (como en las ciudades de Belém y Ribeirão Preto).
+
+Los factores climáticos también deben tenerse en cuenta. Los años de El Niño, por ejemplo, desplazan las lluvias del norte y el nordeste hacia el sudeste y el sur del país, donde las ciudades son más densas desde el punto de vista poblacional. Sumado a temperaturas más elevadas, eso puede producir años con más casos que los años de La Niña(\*\*).
+
+Por supuesto, no son solo factores como los citados los que están directa o indirectamente relacionados con los casos de dengue. La urbanización, la densidad demográfica, el saneamiento básico y otras características de las ciudades, así como las políticas públicas de prevención, deben considerarse para evaluar el total de casos en una localidad.
+
+Pero, sin duda, la temperatura y la precipitación tienen un papel importante en la propagación de la enfermedad y en las epidemias. Con la tendencia al aumento de las temperaturas medias provocada por el cambio climático podremos ver esta enfermedad proliferando cada vez más, y por lugares antes ni siquiera alcanzados. Hablamos de ello en la entrevista de este mes.
+
+Además, preparamos un dashboard donde puede investigar los datos de la capital de su estado(\*). Evalúe si hay una tendencia de aumento en las temperaturas medias y si hay algún cambio significativo en el patrón de lluvias. ¿Hay relación entre esas variables y los casos de dengue observados?
+
+> [Acceda al dashboard](https://climadengue.streamlit.app/?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-_yEejPUipsc-cW3VKr51TG936EDjUtQ7FsruHM1xnCyYNuLd3b6JK282QA06r9HS1mxt-Q9DeZMt8UNYBdTQa6O4xDAQtBow06gCo-RD2SgZobLk4)
+
+También puede consultar el código utilizado en nuestro [repositorio de análisis](https://github.com/basedosdados/analises/tree/main/redes_sociais/climadengue?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz-_yEejPUipsc-cW3VKr51TG936EDjUtQ7FsruHM1xnCyYNuLd3b6JK282QA06r9HS1mxt-Q9DeZMt8UNYBdTQa6O4xDAQtBow06gCo-RD2SgZobLk4) en GitHub.
+
+(\*) Excepto Florianópolis. No encontramos datos meteorológicos de estaciones automáticas para esa capital.
+
+(\*\*) En los años de La Niña las lluvias en el norte y el nordeste se intensifican, lo que puede llevar a un aumento de casos en esas regiones. Pero al tratarse de regiones con menor densidad poblacional, el aumento no sería tan perceptible al mirar el número total de casos del país.

--- a/next/blog/es/como-acessar-dados-da-bd-no-power-bi.md
+++ b/next/blog/es/como-acessar-dados-da-bd-no-power-bi.md
@@ -1,0 +1,123 @@
+---
+title: Cómo acceder a los datos de BD en Power BI
+description: Vea cómo acceder al datalake público de Base de los Datos en Power BI para crear gráficos, visualizaciones y dashboards.
+slug: como-usar-datos-de-bd-en-power-bi
+date:
+  created: "2021-07-30"
+authors:
+  - name: Victor Viana
+    role: Autor
+    social: https://medium.com/@ovictorviana
+thumbnail: /blog/como-acessar-dados-da-bd-no-power-bi/image_11.gif
+categories: [tutorial]
+medium_slug: >
+  https://medium.com/basedosdados/como-acessar-dados-da-bd-no-power-bi-aeeea9a9bdc0
+published: true
+---
+
+## TL;DR
+
+Power BI es una de las tecnologías más populares para desarrollar dashboards con datos relacionales, y [Base de los Datos]() es uno de los mayores data lakes públicos de Brasil. Esa combinación es un entorno idóneo para el análisis y la visualización de datos. En este artículo mostramos lo fácil que es acceder a las bases de BD para usarlas en Power BI, con el paso a paso.
+
+<Image src="/blog/como-acessar-dados-da-bd-no-power-bi/image_0.png"/>
+
+## Conectar a Google BigQuery
+
+[Google BigQuery](https://cloud.google.com/bigquery?hl=pt_br) es el servicio de base de datos en la nube de Google, donde los conjuntos de Base de los Datos están almacenados dentro de un datalake público llamado `basedosdados`. Para acceder a los datos hace falta crear un proyecto (gratuito) en BigQuery. Si ya tiene uno, pase al siguiente paso; si no, preparamos dos tutoriales para ayudarle de forma rápida y sencilla:
+
+1. [Artículo](https://dev.to/basedosdados/bigquery-101-45pk)
+2. [Video](https://www.youtube.com/watch?v=nGM2OwTUY_M)
+
+## Conectar los datos en Power BI
+
+En este recorrido mostramos cómo conectar los datos de la evolución del PIB de los municipios (tabla de hechos) y la información sobre los municipios (tabla de dimensión) en [Power BI](https://powerbi.microsoft.com/pt-br/downloads/) para elaborar análisis. Esa base se usa como ejemplo, pero el tutorial sirve para cualquier otra base del *datalake*.
+
+### Buscar los datos en el sitio
+
+Para acceder a los datos en la interfaz de BigQuery usamos consultas en SQL, uno de los lenguajes más básicos y útiles para quien trabaja con datos. En el sitio de Base de los Datos puede buscar cualquier base y copiar directamente el código SQL, disponible en la página de la tabla seleccionada bajo "Acceda a los datos vía BigQuery", para usarlo en el editor de SQL de Google BigQuery, como muestra el ejemplo siguiente. Para aprender más sobre el lenguaje recomendamos el curso gratuito de [Udacity](https://www.udacity.com/course/sql-for-data-analysis--ud198), o los propios [tutoriales](https://cloud.google.com/bigquery/docs/tutorials) de BigQuery.
+
+### Seleccionar los datos en BigQuery
+
+Todavía en el sitio, puede hacer clic en "Consultar en BigQuery" para ser redirigido al [*datalake*](https://console.cloud.google.com/bigquery?p=basedosdados&page=project). La interfaz de BigQuery es distinta a la del sitio porque es un servicio del propio Google; explicamos más sobre cada elemento de esa interfaz en este artículo.
+
+Haga clic en "Crear nueva consulta", pegue el código copiado en el editor que aparece y ejecútelo. Note que el código indica `LIMIT 100` para traer solo las 100 primeras filas. Puede cambiar ese parámetro (o quitarlo) para traer más filas; solo le pedimos que tenga cuidado con bases muy grandes (RAIS, Censo Poblacional), porque traer todos los datos de una vez no solo es lento sino que consume bastante procesamiento, lo que puede generar costos.
+
+<Image src="/blog/como-acessar-dados-da-bd-no-power-bi/image_1.png"/>
+
+```sql
+SELECT
+  pib.id_municipio,
+  --selecionar id do municipio
+  pop.ano,
+  -- população do muunicipio
+  pib.PIB / pop.populacao AS pib_per_capita -- calculo do PIB per capita
+FROM
+  `basedosdados.br_ibge_pib.municipio` AS pib -- selecionar base de pib dos municipios
+JOIN
+  `basedosdados.br_ibge_populacao.municipio` AS pop -- join com a base de população
+ON
+  pib.id_municipio = pop.id_municipio
+  AND pib.ano = pop.ano
+LIMIT
+  100
+```
+<Image src="/blog/como-acessar-dados-da-bd-no-power-bi/image_2.png"/>
+
+### Guardar los datos en un proyecto privado
+
+Guarde la tabla obtenida haciendo clic en **Guardar**. Puede guardar la consulta o la vista.
+
+<Image src="/blog/como-acessar-dados-da-bd-no-power-bi/image_3.png"/>
+
+BigQuery le pedirá crear un conjunto de datos donde guardar esa tabla (si no tiene uno). Si ya conoce Power BI, funciona de forma muy similar a sus conjuntos de datos. Dele un nombre claro. En Base de los Datos organizamos los nombres de conjuntos por alcance geográfico, institución y tema del dato; puede ver más sobre nuestras reglas de nomenclatura [aquí](https://basedosdados.org/docs/style_data/#nomea%C3%A7%C3%A3o-de-bases-e-tabelas). El conjunto es esencialmente una "carpeta" donde estarán todas las tablas de su proyecto. En este ejemplo elegimos el nombre genérico "tutorial".
+
+<Image src="/blog/como-acessar-dados-da-bd-no-power-bi/image_4.png"/>
+
+Después seleccione el conjunto creado para guardar la base, elija un nombre para su tabla y haga clic en Guardar. Así de simple 😊.
+
+<Image src="/blog/como-acessar-dados-da-bd-no-power-bi/image_5.png"/>
+
+Ahora su proyecto aparecerá en la barra lateral izquierda. Haga clic en la flecha junto al nombre del proyecto y aparecerá su conjunto de datos con la tabla que guardó. Si no aparece, actualice la página.
+
+<Image src="/blog/como-acessar-dados-da-bd-no-power-bi/image_6.png"/>
+
+Para guardar otra tabla con la información de los municipios (nombre, estado, etc.), repita el proceso con la consulta siguiente. Llamaremos a esa tabla `dMunicipio`, que se guardará en el mismo conjunto llamado `tutorial`.
+
+```sql
+SELECT
+  id_municipio,
+  nome,
+  id_uf,
+  sigla_uf,
+  nome_regiao
+FROM `basedosdados.br_bd_diretorios_brasil.municipio`
+```
+### Importar los datos a Power BI
+
+- Abra Power BI
+- Vaya a Obtener datos -> Más
+
+<Image src="/blog/como-acessar-dados-da-bd-no-power-bi/image_7.png"/>
+
+- Busque `Google BigQuery` -> Conectar
+
+<Image src="/blog/como-acessar-dados-da-bd-no-power-bi/image_8.png"/>
+
+- Inicie sesión con su cuenta de Google, la misma con la que hizo las consultas en BigQuery. Si entra con otra cuenta no será posible conectar.
+
+<Image src="/blog/como-acessar-dados-da-bd-no-power-bi/image_9.png"/>
+
+- Permita el acceso a Power BI
+- Vuelva a Power BI y haga clic en conectar
+- Seleccione la carpeta con el nombre de su conjunto de datos
+- Seleccione las tablas
+
+<Image src="/blog/como-acessar-dados-da-bd-no-power-bi/image_10.png"/>
+
+- Haga clic en cargar
+- Seleccione Importar
+  - En la mayoría de los casos no es necesario estar conectado directamente y, además, así no queda dependiente de la conexión con la base.
+
+Listo, ya tiene acceso a sus bases de BD para crear su dashboard. :)
+
+<Image src="/blog/como-acessar-dados-da-bd-no-power-bi/image_11.gif"/>

--- a/next/blog/es/como-fazer-uma-analise-geoespacial-com-qgis.md
+++ b/next/blog/es/como-fazer-uma-analise-geoespacial-com-qgis.md
@@ -1,0 +1,78 @@
+---
+title: Cómo empezar un análisis geoespacial con datos de BD y QGIS
+description: Aprenda a importar datos de BD en QGIS para crear mapas y visualizaciones
+slug: analisis-geoespacial-con-qgis
+date:
+  created: "2022-10-07"
+authors:
+  - name: Gustavo Alcântara
+    social: https://github.com/gustavoalcantara
+    role: Autor
+  - name: Giovane Caruso
+    social: https://medium.com/@giovanecaruso
+    role: Edición
+thumbnail: /blog/como-fazer-uma-analise-geoespacial-com-qgis/image_0.png
+categories: [tutorial]
+medium_slug: https://medium.com/@basedosdados/como-come%C3%A7ar-uma-an%C3%A1lise-geoespacial-com-dados-da-bd-e-o-qgis-4792877950e0
+published: true
+---
+
+<Image src="/blog/como-fazer-uma-analise-geoespacial-com-qgis/image_0.png" caption="Mapa con la cantidad de cabezas de ganado por estado en Brasil"/>
+
+## TL;DR
+
+En este artículo mostramos cómo usar los datos del paquete geobr, ya tratados y disponibles en el *datalake* público de Base de los Datos, junto con un Sistema de Información Geográfica (SIG) para construir análisis geoespaciales con más facilidad. Siga el paso a paso con un ejemplo práctico: cuántas cabezas de ganado había en cada estado brasileño en 2017.
+
+## ¿Qué son los datos de geobr?
+
+`geobr` es un paquete de R que permite acceder fácilmente a los shapefiles del Instituto Brasileño de Geografía y Estadística (IBGE) y a otros datos espaciales de Brasil. Ya tratado y disponible en BD, este conjunto permite análisis con distintos niveles de observación: biomas, escuelas, microrregiones, polígonos de sector censal y mucho más.
+
+Con datos de geobr elaboramos, por ejemplo, el análisis de los resultados geolocalizados de la prueba de matemáticas del SAEB de 2019 en Ceará.
+
+<Image src="/blog/como-fazer-uma-analise-geoespacial-com-qgis/image_1.png" caption="Competencia media por escuela en Ceará"/>
+
+Además de acceder a estos datos en Python, R y por BigQuery usando SQL, es posible exportarlos en `.csv` y cargarlos en su Sistema de Información Geográfica (SIG) preferido.
+
+Un SIG es un conjunto de software y hardware que permite visualizar y analizar datos geográficos para comprender relaciones, patrones y tendencias. Existen muchos tipos. En este artículo usamos [QGIS](https://qgis.org/pt_BR/site/about/index.html) por ser una plataforma de código abierto, colaborativa y gratuita para el análisis de datos geoespaciales.
+
+## Cómo construir su análisis con datos de geobr y QGIS
+
+Para mostrar cómo empezar a construir su propio análisis, usamos los datos del [Censo Agropecuario](/dataset/55a39c28-58f3-4804-827d-6eee5ed27b6b?table=5366d485-e7db-4367-911a-a6a0198dda13), la principal investigación estadística y territorial sobre la producción agropecuaria del país, también tratados y estandarizados en BD.
+
+El proceso es sencillo: para saber cuántas cabezas de ganado había en cada estado brasileño en 2017, ejecute la consulta siguiente en BigQuery y descargue el resultado en un archivo `.csv`.
+
+```sql
+SELECT censo.sigla_uf, sum(quantidade_bovinos_total) as gado, geometria
+FROM basedosdados.br_ibge_censo_agropecuario.municipio AS censo
+JOIN basedosdados.br_geobr_mapas.uf AS geo
+ON censo.sigla_uf = geo.sigla_uf #join da variável sigla_uf
+WHERE ano = 2017
+GROUP BY censo.sigla_uf, geo.sigla_uf, geometria
+```
+A partir del resultado de la consulta puede descargar el `.csv` en su computadora.
+
+Ahora vamos a cargar el archivo `.csv` con la geometría espacial en QGIS. Haga clic en `Añadir capa` y después en `Añadir capa de texto delimitado`.
+
+<Image src="/blog/como-fazer-uma-analise-geoespacial-com-qgis/image_2.png" caption="Añadir capa y Añadir capa de texto delimitado en QGIS"/>
+
+Con la ventana `Administrador de fuentes de datos` abierta, busque su archivo `.csv` donde lo haya guardado.
+
+<Image src="/blog/como-fazer-uma-analise-geoespacial-com-qgis/image_3.png" caption="Administrador de fuentes de datos de QGIS"/>
+
+Una vez cargado el `.csv`, la **Definición de la geometría** debe estar establecida como **Well Known Text** *(WKT)*. Después basta con indicar la variable de geometría en el `campo de geometría`.
+
+<Image src="/blog/como-fazer-uma-analise-geoespacial-com-qgis/image_4.png" caption="Definición de la geometría"/>
+
+La salida, o **Muestra de datos**, debe coincidir con el esquema de la imagen anterior. Puede verse que el campo de geometría define lo que representa cada fila. Como trabajamos con multipolígonos, la latitud y la longitud de cada multipolígono están en esa variable.
+
+<Image src="/blog/como-fazer-uma-analise-geoespacial-com-qgis/image_5.png" caption="Muestra de datos"/>
+
+Tras hacer clic en **añadir**, se obtiene un mapa con la cantidad de cabezas de ganado por estado en 2017, como en la imagen siguiente.
+
+<Image src="/blog/como-fazer-uma-analise-geoespacial-com-qgis/image_6.png" caption="Mapa con la cantidad de cabezas de ganado por estado en Brasil. Fuente: IBGE, Censo Agropecuario, 2017."/>
+
+Con el mapa a la vista resulta fácil identificar que Mato Grosso es el estado con mayor cantidad de cabezas de ganado de Brasil. Puede exportar el mapa en un archivo *.png* o *.tif* y continuar con su análisis.
+
+Conviene recordar que también es posible relacionar más de una base de datos con los archivos de geometría espacial de geobr a través de BD. Puede seguir el mismo proceso para cualquier base con datos a nivel de municipio, regiones y establecimientos de salud, microrregiones, mesorregiones, escuelas y mucho más.
+
+¿Tiene alguna duda sobre cómo usar los datos de geobr, o cualquier otro conjunto de BD? Tenemos un equipo preparado para ayudarle en nuestro canal de Discord. ¡Venga a formar parte!

--- a/next/blog/es/como-usar-os-diretorios-brasileiros.md
+++ b/next/blog/es/como-usar-os-diretorios-brasileiros.md
@@ -1,0 +1,96 @@
+---
+title: "Directorios Brasileños: cómo esta base facilita su análisis"
+description: >-
+  Conozca esta base que funciona como un perfil completo de unidades como
+  municipio, escuela, estado y más.
+slug: como-usar-los-directorios-brasilenos
+date:
+  created: "2021-08-16"
+authors:
+  - name: Crislane Alves
+    role: Equipo Base de los Datos
+    social: https://medium.com/@s.alvescrislane
+thumbnail: /blog/como-usar-os-diretorios-brasileiros/image_0.jpg
+categories: [tutorial]
+medium_slug: >-
+  https://medium.com/@basedosdados/diret%C3%B3rios-brasileiros-como-essa-base-facilita-sua-an%C3%A1lise-40dc8ce2ca2
+published: true
+---
+
+Conozca esta base que funciona como un perfil completo de unidades como municipio, escuela, estado y más.
+
+<Image src="/blog/como-usar-os-diretorios-brasileiros/image_0.jpg"/>
+
+## TL;DR
+
+En este artículo presentamos nuestra base de [Directorios Brasileños](/dataset/33b49786-fb5f-496f-bb7c-9811c985af8e?table=0a2d8187-f936-437d-89db-b4eb3a7e1735), disponible en nuestro datalake público junto a muchas otras bases públicas ya tratadas, organizadas e integradas para el análisis. También mostramos cómo esta base facilita el cruce entre tablas de distintos conjuntos y cómo aplicarla en su análisis, con un ejemplo práctico.
+
+## La base de Directorios Brasileños
+
+Esta base centraliza la información de las unidades básicas usadas en el análisis y funciona como un perfil completo de entidades como municipio, escuela, estado, sectores censales y más. Sus tablas enlazan códigos institucionales e información de distintas entidades brasileñas.
+
+Esto importa porque no existe un identificador único de municipios compartido entre las instituciones brasileñas. La base también resuelve los cambios de IDs y los nombres con erratas entre años e instituciones, además de los nuevos IDs de municipios que se crean con el tiempo.
+
+Para municipios, por ejemplo, enlaza registros de organizaciones como el IBGE, la Receita Federal, el Tribunal Superior Electoral (TSE), el Banco Central de Brasil, comarcas, regiones de salud y otras.
+
+Cada tabla de esta base representa una entidad de nuestro datalake público, como `UF`, `municipio`, `escola`, `distrito`, `setor_censitario`, las categorías `CID-10` y `CID-9`, `CBO-2002` y `CBO-1992`, entre otras.
+
+Los directorios crean de forma natural relaciones entre esas entidades. La tabla de municipios tiene una columna `sigla_uf`, por ejemplo, que indica a qué estado pertenece el municipio. Lo mismo vale para `escola`, donde se puede identificar en qué municipio está ubicada una escuela.
+
+Para ejemplificar cómo los Directorios Brasileños facilitan el cruce de distintos conjuntos, preparamos dos ejemplos de aplicación que muestran cómo usar esta herramienta en sus análisis, cada uno con una sola consulta SQL en BigQuery.
+
+## Ejemplos de aplicación
+
+### Indicadores de movilidad y transporte
+
+En el primer ejemplo cruzamos la tabla `municipio` de los Directorios Brasileños con la tabla `tempo_deslocamento_casa_trabalho` de la base de [Indicadores de Movilidad y Transporte](/dataset/e3edf621-c491-4d74-a03a-15a759f6e638?table=01114371-3b1b-4574-a3ea-3d7d2125b4f2) de [Mobilidados](https://mobilidados.org.br/), que contiene datos sobre el tiempo medio de desplazamiento casa-trabajo y el porcentaje de personas que dedican más de una hora a ese trayecto en 2010.
+
+Usamos como clave la columna `id_municipio`. El objetivo es añadir las columnas `regiao` y `municipio` al nuevo conjunto, de modo que además del nombre de los municipios se pueda agrupar por ciudad, gran región o estado y ver cuáles tienen un tiempo medio de desplazamiento mayor o menor.
+
+Vea a continuación la consulta utilizada:
+
+```sql
+SELECT
+  t1.ano,
+  t2.nome_uf AS estado,
+  t2.nome AS municipio,
+  t1.tempo_medio_deslocamento
+FROM
+  `basedosdados.br_mobilidados_indicadores.tempo_deslocamento_casa_trabalho` AS t1
+JOIN
+  `basedosdados.br_bd_diretorios_brasil.municipio` AS t2
+ON
+  t1.id_municipio = t2.id_municipio
+```
+### Datos de importaciones y exportaciones brasileñas
+
+En el segundo ejemplo usamos la tabla `pais` de los Directorios con la tabla `municipio_importacao` de la base [Comex Stat](/dataset/74827951-3f2c-4f9f-b3d0-56e3aa7aeb39?table=f4b08023-5530-4dc9-bced-3321e8928fd7), que contiene datos detallados de las exportaciones e importaciones brasileñas extraídos de [SISCOMEX](http://www.siscomex.gov.br/). Esa tabla en concreto aborda datos de importación detallados por municipio y empresa importadora.
+
+Aquí la clave es la columna `id_pais`, usada para extraer de los Directorios el **nombre** del país. Al ejecutar la consulta obtendremos, además del **ID del país** y el **valor de la importación**, el **nombre del país**, es decir, el origen de las importaciones de Brasil en 2020.
+
+Puede usar la consulta siguiente para ver el origen de las importaciones de Brasil en 2020:
+
+```sql
+SELECT
+  t1.ano,
+  t1.sigla_uf,
+  t2.nome AS pais,
+  SUM(valor_fob_dolar) AS importacao
+FROM
+  `basedosdados.br_me_comex_stat.municipio_importacao` AS t1
+JOIN
+  `basedosdados.br_bd_diretorios_brasil.pais` AS t2
+ON
+  t1.id_pais = t2.id_pais
+WHERE
+  ano = 2020
+GROUP BY
+  1,
+  2,
+  3
+ORDER BY
+  3 DESC
+```
+Acceda a la base de Directorios Brasileños [aquí](/dataset/33b49786-fb5f-496f-bb7c-9811c985af8e?table=0a2d8187-f936-437d-89db-b4eb3a7e1735).
+
+Conviene recordar que el cruce entre bases no es posible solo porque los Directorios funcionen como una especie de diccionario. Detrás está el **estándar de calidad de Base de los Datos**: compatibilizamos todos los datos para que puedan cruzarse entre tablas. La limpieza de las bases disponibles en nuestro datalake público implica un riguroso proceso de estandarización y compatibilización.

--- a/next/blog/es/curso-qgis.md
+++ b/next/blog/es/curso-qgis.md
@@ -1,0 +1,84 @@
+---
+title: Curso completo y gratuito de QGIS de BD
+description: Seis clases gratuitas sobre cómo empezar a crear análisis con QGIS y los datos de BD
+slug: curso-gratuito-de-qgis
+date:
+  created: '2026-03-30'
+authors:
+  - name: Thais Filipi
+    role: Profesora
+  - name: Marina Monteiro
+    role: Profesora
+thumbnail: /blog/curso-qgis/curso-qgis-thumb.png
+categories: [tutorial]
+medium_slug:
+published: true
+---
+
+<Image src="/blog/curso-qgis/curso-qgis-thumb.png" caption=""/>
+
+¿Alguna vez ha pensado en transformar datos en mapas interactivos y análisis geoespaciales? QGIS, un Sistema de Información Geográfica (SIG) de código abierto, gratuito y colaborativo, es la herramienta indicada para ello. Y la buena noticia es que hemos preparado un curso completo y totalmente gratuito para que inicie o perfeccione su recorrido en este campo.
+
+El curso está pensado para llevarle desde los conceptos fundamentales de la cartografía hasta la creación de animaciones complejas y la aplicación de QGIS en reportajes de investigación. A lo largo de seis clases prácticas aprenderá a manipular datos, generar visualizaciones de impacto y extraer hallazgos útiles.
+
+## Clase 1: Empezando a usar QGIS
+
+Esta primera clase presenta los conceptos esenciales de la cartografía, recorre la interfaz de QGIS, explica qué es un SIG, cubre los distintos tipos de datos geoespaciales y termina con la creación de su primer mapa. Es el punto de partida adecuado para quien nunca ha usado la herramienta.
+
+<Embed>
+<iframe width="1905" height="772" src="https://www.youtube.com/embed/nNXTYm06Wck" title="Como analisar Dados Georreferenciados com o QIGS - Aula Aberta" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" allowFullScreen></iframe>
+</Embed>
+
+## Clase 2: Datos sobre incendios
+
+Esta clase profundiza en un tema de gran relevancia: el análisis de datos sobre incendios. Aborda el monitoreo del INPE, discute qué permiten y qué no permiten estos datos, y recorre los marcos legales de la legislación ambiental que inciden en el análisis geoespacial. Una oportunidad para ver cómo se aplica QGIS a cuestiones socioambientales críticas.
+
+<Embed>
+<iframe width="1905" height="772" src="https://www.youtube.com/embed/WdHgqz59mPo" title="Como analisar Dados de Queimadas com o QGIS - Aula Aberta" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" allowFullScreen></iframe>
+</Embed>
+
+> **Acaba de encontrar su principal fuente de datos ya tratados y actualizados.**
+>
+> _BD Pro es la suscripción que ayuda a mantener nuestro proyecto y le da acceso a la versión más actualizada de conjuntos estratégicos de datos como Sicor, datos meteorológicos, datos de registro de empresas, CAGED y mucho más._
+>
+> **[Vea más](https://basedelosdatos.org/bdpro)** y apoye a BD con su suscripción.
+
+## Clase 3: Datos de BD en QGIS
+
+Descubra cómo integrar el acervo de Base de los Datos con QGIS. Aprenderá a importar datos de incendios directamente desde Base de los Datos y a manipularlos dentro de QGIS, lo que abre un abanico de posibilidades de análisis con datos públicos y tratados.
+
+<Embed>
+<iframe width="1905" height="772" src="https://www.youtube.com/embed/oCsAaZKjyvM" title="Como Importar Dados Públicos no QGIS utilizando o datalake da Base dos Dados - Aula Aberta" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" allowFullScreen></iframe>
+</Embed>
+
+## Clase 4: Creando mapas de calor en QGIS
+
+Los mapas de calor son una forma potente de identificar patrones y concentraciones. Esta clase cubre los conceptos que hay detrás de ellos y después le pone a construir sus propios mapas de calor en QGIS, convirtiendo datos brutos en visualizaciones que se leen de un vistazo.
+
+<Embed>
+<iframe width="1905" height="772" src="https://www.youtube.com/embed/7JJOaf4NNnc" title="Como criar mapas de calor com o QGIS - Aula Aberta" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" allowFullScreen></iframe>
+</Embed>
+
+## Clase 5: Animaciones para series históricas
+
+Lleve sus análisis más lejos con animaciones de series históricas. Esta clase le enseñará a crear animaciones dinámicas en QGIS para visualizar cómo evoluciona un fenómeno a lo largo del tiempo y contar una historia más envolvente con sus datos.
+
+<Embed>
+<iframe width="1905" height="772" src="https://www.youtube.com/embed/lKZKdwZfO30" title="Crie Mapas Animados de Séries Históricas no QGIS - Aula Aberta" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" allowFullScreen></iframe>
+</Embed>
+
+## Clase especial: QGIS en reportajes de investigación
+
+Para cerrar el curso, una clase especial con el invitado Fabio Bispo, reportero de Info.Amazônia. Comparte su experiencia y muestra cómo QGIS puede ser central en el reportaje de investigación, y cómo el análisis geoespacial abre nuevos ángulos en el periodismo de datos.
+
+<Embed>
+<iframe width="1905" height="772" src="https://www.youtube.com/embed/6eLzwmeLpqQ" title="Como Analisar Dados Geoespaciais Usando o QGIS - Aula Especial" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" allowFullScreen></iframe>
+</Embed>
+
+---
+
+**NUEVOS datos georreferenciados en BD**
+
+Los microdatos del Sistema de Operaciones de Crédito Rural (Sicor) ahora se actualizan automáticamente en BD, con información georreferenciada para sus análisis.
+
+Suscríbase a BD Pro para tener siempre acceso a la versión más reciente de conjuntos de datos que se actualizan automáticamente en nuestro datalake, como Sicor, INMET, datos de registro de empresas y más. [Conózcalo y haga una prueba gratuita](https://basedelosdatos.org/bdpro)

--- a/next/blog/es/entrevista-bdletter-35-karina-lima.md
+++ b/next/blog/es/entrevista-bdletter-35-karina-lima.md
@@ -1,0 +1,46 @@
+---
+title: "Entrevista: ¿el cambio climático contribuyó a las lluvias extremas en Rio Grande do Sul?"
+description: >-
+  Karina Lima habla sobre los desafíos del análisis de datos meteorológicos, las posibles relaciones entre el calentamiento global y los eventos extremos en Rio Grande do Sul, y más.
+slug: entrevista-cambio-climatico-y-lluvias-en-rio-grande-do-sul
+date:
+  created: "2024-08-30T18:18:06.419Z"
+thumbnail: 
+categories: [analise]
+authors:
+  - name: Marina Monteiro 
+    role: Preguntas
+    social: https://www.linkedin.com/in/ma-m-mendonca/
+  - name: Giovane Caruso
+    role: Texto y edición
+    social: https://www.linkedin.com/in/giovanecaruso/
+medium_slug: >-
+  https://medium.com/basedosdados/como-os-casos-de-dengue-evolu%C3%ADram-nos-%C3%BAltimos-10-anos-54a8145f2de7
+published: true
+---
+
+Además de contribuir al análisis sobre el cambio climático y las lluvias en Rio Grande do Sul, que puede leer [aquí](https://basedelosdatos.org/blog/analisando-chuvas-no-rio-grande-do-sul), Karina Lima profundizó en entrevista sobre los desafíos del análisis de datos meteorológicos y sobre su investigación.
+
+<Image src="/blog/entrevista-bdletter-35-karina-lima/foto_karina-1.png"/>
+
+Karina es doctoranda en Geografía en el área de Climatología por la Universidad Federal de Rio Grande do Sul (UFRGS), magíster en Geografía con énfasis en análisis ambiental y licenciada en Geografía por la misma institución. Trabaja en Climatología y Meteorología, con investigaciones sobre tormentas, eventos extremos, desastres y cambio climático. También integra grupos de investigación sobre los impactos de los eventos extremos en la salud humana y el proyecto de extensión "¿Qué harías si supieras lo que yo sé?", que comunica la crisis climática y combate el negacionismo.
+
+**Actualmente investiga tormentas, eventos extremos y desastres, y además hace divulgación científica sobre cambio climático. ¿Podría contarnos sobre el papel de los datos meteorológicos en la comprensión del cambio climático y sus impactos?**
+
+El tiempo meteorológico es el estado de las condiciones atmosféricas en un momento y lugar determinados, mientras que el clima describe las condiciones típicas; por eso hace falta una gran cantidad de datos meteorológicos para saber cómo suele comportarse el clima en una región. El estudio del cambio climático pasa entonces por analizar muchos datos meteorológicos para establecer qué cambió: las anomalías respecto a una media del pasado.
+
+**¿Cuáles son los principales desafíos que enfrenta, o ha enfrentado, en la recolección y el análisis de datos para su investigación? ¿Los datos disponibles hoy son suficientes y tienen la calidad necesaria para lograr precisión en las investigaciones sobre cambio climático?**
+
+Creo que depende mucho del área de estudio, pero en general, en Brasil las bases de datos relacionadas con el clima están desconectadas y muchas veces son insuficientes. El investigador brasileño tiene que ser creativo y, con bastante frecuencia, dedicar más tiempo del normal para poder hacer una investigación.
+
+**¿Cómo se identifica si hay interferencia del calentamiento global —y del cambio climático ya en curso— en los fenómenos meteorológicos que vivimos? Y en ese caso, ¿se puede relacionar con el calentamiento provocado por el exceso de CO2 que la actividad humana inyecta en la atmósfera?**
+
+En nuestro escenario actual, con un sistema más caliente por nuestras emisiones y, por tanto, con calentamiento de la atmósfera, el océano y la superficie terrestre, es muy difícil que un fenómeno no sufra algún grado de influencia. Para medir eso existen los estudios de atribución, que analizan cuánto el cambio climático antropogénico hizo que un evento determinado fuera más probable o más intenso. En el caso del desastre de abril-mayo de 2023 en Rio Grande do Sul, un estudio de atribución analizó dos ventanas de eventos que abarcaban todo el período de gran acumulación de lluvia sobre el estado y concluyó que la influencia humana hizo ambos eventos extremos más de dos veces más probables y entre un 6% y un 9% más intensos. Y eso sin contar la contribución humana en otros aspectos, como la reducción de la inversión en prevención, un sistema de alertas deficiente, legislación ambiental no respetada y falta de mantenimiento del sistema de protección contra inundaciones en Porto Alegre.
+
+**¿Podría contarnos sobre su investigación en climatología, especialmente en lo relativo a tormentas y eventos extremos? Además, ¿cómo ve la importancia de la divulgación científica en la concienciación pública sobre el cambio climático y sus impactos?**
+
+Mi investigación trata sobre eventos extremos de lluvia y desastres. Creo que es un área de gran relevancia porque necesitamos más estudios para tener mejor previsibilidad a mesoescala, especialmente en un mundo más caliente y con patrones que se modifican.
+
+Al igual que la investigación, la divulgación científica es esencial para que el conocimiento académico se democratice y llegue a todos, porque desde el momento en que las personas tienen acceso a información de calidad, toman mejores decisiones y transforman el mundo. Por eso veo la divulgación científica sobre la crisis climática como una cuestión moral: es esencial que las personas entiendan lo que está ocurriendo y sepan que solo con una gran adhesión popular lograremos superar esta crisis y garantizar la habitabilidad para nosotros, para las generaciones futuras y para todas las demás especies con las que compartimos nuestro hogar común, el planeta Tierra.
+
+_Esta entrevista fue publicada originalmente en nuestro boletín mensual, BDletter. [Suscríbase gratuitamente para no perderse los próximos](https://info.basedosdados.org/newsletter?_gl=1*11cufe3*_gcl_au*ODc4NTYyMTUxLjE3NDAzOTk0ODk.)._

--- a/next/blog/es/ferramenta-traz-mais-acessibilidade-aos-dados-de-impulsionamento-eleitoral-nas-redes.md
+++ b/next/blog/es/ferramenta-traz-mais-acessibilidade-aos-dados-de-impulsionamento-eleitoral-nas-redes.md
@@ -1,0 +1,52 @@
+---
+title: Una herramienta que hace más accesibles los datos de impulsión electoral en redes
+description: >-
+  Entrevista con Sérgio Spagnuolo sobre el Observatorio de Impulsión Electoral
+slug: datos-de-impulsion-electoral-mas-accesibles
+date:
+  created: "2024-10-30"
+thumbnail: /blog/ferramenta-traz-mais-acessibilidade-aos-dados-de-impulsionamento-eleitoral-nas-redes.md/image_1.png
+categories: [institucional]
+authors:
+  - name: Giovane Caruso
+    role: Texto y entrevista
+    social: https://www.linkedin.com/in/GiovaneCaruso/
+    avatar: 
+
+---
+
+_Esta entrevista se publicó en la BDletter de octubre. Suscríbase gratuitamente para estar al día de análisis y entrevistas sobre BD y la comunidad de datos abiertos en Brasil._
+
+Este mes de elecciones viene cargado de novedades para quien disfruta analizando datos de campañas, finanzas y resultados electorales. Solo en BD lanzamos [Siga o Dinheiro](https://www.sigaodinheiro.org/), un panel interactivo para seguir los ingresos y gastos de las elecciones, dimos una [clase abierta](https://www.youtube.com/watch?v=FGboC_4szhc&t=584s) sobre cómo investigar datos de candidatos y, por supuesto, actualizamos los datos del TSE, ya tratados y listos para el análisis en el mayor datalake público de Brasil.
+
+En esta entrevista conocemos otra herramienta creada para aportar transparencia y accesibilidad a los datos de financiación electoral. Conversamos con Sérgio Spagnuolo sobre el [Observatorio de Impulsión de Contenido](https://nucleo.jor.br/observatorio-de-impulsionamento-eleitoral/?utm_source=hs_email&utm_medium=email&_hsenc=p2ANqtz--K7d9YHXkRUu4u9_geagEUzW0JY63mOmg3Sreqf91-uz-5xVzSnqOMg4CY24Ngvw7dIqcCy4v9h0_YYiTCrm9fclqimIKN_X2A_kD4EaFPRl-Q9Rs), una aplicación creada por Núcleo Jornalismo para monitorear el gasto de las campañas electorales en impulsión de contenido en redes sociales.
+
+Con la aplicación, cualquier persona puede consultar cuánto gastan los candidatos en impulsar contenido en redes sociales, además de aplicar filtros geográficos, por partido y cargo, e incluso por nombre de la red social.
+
+<Image src="/blog/ferramenta-traz-mais-acessibilidade-aos-dados-de-impulsionamento-eleitoral-nas-redes/image_1.webp.webp" caption="Mecanismo de filtros del Observatorio de Impulsión Electoral"/>
+
+El resultado son visualizaciones y una tabla con los datos, extraídos automáticamente del sitio del TSE. También es posible descargar los datos de la plataforma en archivos .csv o .xls.
+
+<Image src="/blog/ferramenta-traz-mais-acessibilidade-aos-dados-de-impulsionamento-eleitoral-nas-redes/image_2.webp.webp" caption="Ejemplo de visualización del Observatorio de Impulsión de Contenido."/>
+
+Sérgio es periodista y director de Núcleo Jornalismo, una iniciativa que analiza e informa sobre el impacto de la tecnología digital en la vida de las personas, con el fin de ayudar a construir una internet mejor. En 2014 creó la agencia de newstech Volt Data Lab, fue Knight Fellow en el ICFJ y director en Abraji, además de colaborar con varios medios nacionales e internacionales.
+
+<Image src="/blog/ferramenta-traz-mais-acessibilidade-aos-dados-de-impulsionamento-eleitoral-nas-redes/image_3.webp.webp" caption="Foto de Sérgio Spagnuolo"/>
+
+## Entrevista
+
+**En estas elecciones se han declarado hasta ahora casi R$ 180 millones como gastos de impulsión de contenido de candidatos en redes sociales. El Observatorio de Impulsión Electoral ayuda a seguir esas cifras de forma práctica y accesible. ¿Cómo surgió la idea de la aplicación y cuáles fueron los principales desafíos durante su desarrollo?**
+
+El Observatorio surgió en las elecciones de 2022 por una necesidad que identificamos de mapear el uso de la partida específica de impulsión de publicaciones en redes sociales, creada en 2019. Fue la primera vez que se utilizó esa partida, y nos pareció importante hacer ese relevamiento de una nueva forma de publicidad política.
+
+**El Observatorio utiliza los datos del TSE para monitorear la impulsión de campañas en redes sociales. ¿Podría hablar un poco de la importancia de esos datos para garantizar la transparencia en las elecciones y de si existen limitaciones que aún dificultan la precisión de los análisis sobre impulsión de contenido de candidatos?**
+
+Esos datos son importantes porque las campañas en línea son cada vez más relevantes en períodos electorales. Las redes sociales son un campo muy fértil para la propaganda política, y hay que estar atentos a cómo se gastan los recursos en ello. Además, la impulsión en redes sociales es barata en comparación con los anuncios en televisión, por ejemplo, de modo que se puede lograr mucha eficiencia con una buena relación costo-beneficio. Un problema con los datos es que son autodeclarados, y a veces las redes sociales utilizadas como vector no se declaran adecuadamente, lo que enturbia un poco la agregación.
+
+**El panel del Observatorio presenta una interfaz interactiva con filtros y visualizaciones que hacen más accesible esta información. ¿Cómo evalúa el impacto que ha tenido el Observatorio en el seguimiento de los gastos electorales? ¿Hay algún ejemplo interesante que pueda mencionar?**
+
+El Observatorio ha sido utilizado por otras publicaciones y organizaciones para mapear gastos de impulsión en distintos lugares y esferas públicas. También se ha usado en investigaciones académicas, como un trabajo final de grado de la Universidad Federal de Pernambuco. Nuestro objetivo es proporcionar información para que otras personas y organizaciones puedan utilizarla.
+
+**Un aspecto destacable del Observatorio es la posibilidad de filtrar los gastos de impulsión por red social, un corte especialmente difícil con datos autodeclarados por los candidatos. ¿Podría contar algo sobre la solución empleada para hacerlo posible?**
+
+La solución es algo rudimentaria, porque no hay mucha información para inferir nada. Escaneamos varias columnas en busca de palabras clave para relacionar ese gasto con alguna red social, cuando existe esa referencia. También agrupamos por grupo económico, por ejemplo Meta (Facebook o Instagram), considerando que las redes sociales pueden tener razones sociales distintas.

--- a/next/blog/es/nota-risco-de-retrocessos-na-lei-de-acesso-a-informacao.md
+++ b/next/blog/es/nota-risco-de-retrocessos-na-lei-de-acesso-a-informacao.md
@@ -1,0 +1,50 @@
+---
+title: "Nota: riesgo de retroceso en la Ley de Acceso a la Información (LAI)"
+description: >-
+  El 13 de febrero, Base de los Datos firmó la Carta Abierta del Foro de Derecho de Acceso a Informaciones Públicas, posicionándose en contra del envío al Congreso del proyecto de ley para modificar la LAI.
+slug: nota-riesgo-de-retroceso-en-la-ley-de-acceso-a-la-informacion
+date:
+  created: "2025-02-21T13:58:09.699Z"
+authors:
+  - name: Giovane Caruso
+    role: Redacción
+thumbnail:
+categories: [institucional]
+medium_slug: >-
+  https://medium.com/@giovanecaruso/f362df78913f
+published: true
+---
+
+El 13 de febrero, Base de los Datos firmó la [Carta Abierta del Foro de Derecho de Acceso a Informaciones Públicas](https://informacaopublica.org.br/leia/organizacoes-de-transparencia-sao-contrarias-ao-envio-do-pl-para-alterar-a-lai-ao-congresso/), posicionándose en contra del envío al Congreso del proyecto de ley para modificar la Ley de Acceso a la Información (LAI) de Brasil.
+
+Creemos importante manifestar nuestra preocupación por la propuesta de modificación, que puede representar un grave retroceso para la transparencia pública en Brasil.
+
+## Para entender mejor
+
+El gobierno federal anunció recientemente un proyecto de ley que pretende modificar el artículo 31 de la LAI, que trata de la protección de informaciones personales. La propuesta incluye:
+
+* Reducir el plazo de reserva de 100 años a 5 años tras la muerte del titular.
+* Introducir un "test de daño" genérico para justificar la restricción de informaciones.
+
+Aunque el gobierno afirma que los cambios buscan modernizar la LAI, especialistas y organizaciones de la sociedad civil advierten de tres riesgos centrales:
+
+* *Apertura a retrocesos en el Congreso*: someter la LAI a un proceso legislativo puede permitir modificaciones que debiliten la transparencia pública, abriendo espacio a medidas oportunistas que comprometan el acceso a la información.
+
+* *Falta de claridad sobre la "reserva de 100 años"*: el problema no es el plazo en sí, sino la aplicación inconsistente de la ley. La propuesta actual no resuelve esa cuestión y puede generar más inseguridad jurídica.
+
+* *Un proceso sin participación efectiva de la sociedad civil*: pese a que el gobierno defiende la participación social, el proyecto se elaboró sin diálogo adecuado con el Consejo de Transparencia, Integridad y Combate a la Corrupción (CTICC) ni con otras entidades especializadas. Las contribuciones de la sociedad civil fueron ignoradas y el texto se cerró sin transparencia.
+
+Conviene subrayar que la LAI es un pilar fundamental de la democracia brasileña. En los últimos años ha garantizado:
+
+* Acceso a informaciones sobre políticas públicas.
+* Denuncias de irregularidades y combate a la corrupción.
+* Fortalecimiento del control social sobre el poder público.
+
+Cualquier modificación de la LAI debe ampliar derechos, no crear riesgos de retroceso. Por eso nos sumamos al pedido de diversas organizaciones de la sociedad civil y del Foro de Derecho de Acceso a Informaciones Públicas para que la Casa Civil de la Presidencia de la República reconsidere el envío del proyecto al Congreso y promueva un debate amplio y transparente con la sociedad.
+
+La transparencia no es negociable. Defender la LAI es defender la democracia.
+
+---
+## Sobre Base de los Datos
+
+Base de los Datos es una plataforma dedicada a promover el uso de datos abiertos y fortalecer la transparencia en Brasil. Creemos que el acceso a la información es esencial para una sociedad más justa y participativa.

--- a/next/blog/es/nota-sobre-divulgacao-dos-dados-do-inep.md
+++ b/next/blog/es/nota-sobre-divulgacao-dos-dados-do-inep.md
@@ -1,0 +1,37 @@
+---
+title: Nota sobre la publicación de los datos del Inep
+description: >-
+  El instituto retira del aire los datos del Censo Escolar y del Enem alegando
+  adecuación a la ley de protección de datos
+slug: nota-sobre-la-publicacion-de-los-datos-del-inep
+date:
+  created: "2022-03-09T21:02:04.375Z"
+authors:
+  - name: Base de los Datos
+    role: Equipo Base de los Datos
+categories: [institucional]
+thumbnail: 
+medum_slug: https://medium.com/@basedosdados/nota-sobre-divulga%C3%A7%C3%A3o-dos-dados-do-inep-9168291dbca0
+published: true
+order: 1
+---
+
+El sábado 19, el Instituto Nacional de Estudios e Investigaciones Educativas Anísio Teixeira (Inep) retiró del aire, sin aviso ni consulta previa, los microdatos históricos del Censo Escolar de la Educación Básica y del Enem, además de publicar los datos de la edición de 2021 con un volumen de información considerablemente reducido. Mientras los datos de la edición de 2020 alcanzaban casi 17 GB, el archivo de la edición de 2021 tiene apenas 164 MB.
+
+Los archivos se eliminaron alegando [adecuación a la Ley General de Protección de Datos Personales (LGPD)](https://www.gov.br/inep/pt-br/assuntos/noticias/institucional/nota-de-esclarecimento-divulgacao-dos-microdados), para reducir el riesgo potencial de identificación de las personas a las que se refieren los datos estadísticos. Según el instituto, el control de los datos se realizó a partir de análisis conjuntos con la Universidad Federal de Minas Gerais (UFMG). Puede consultarse la [investigación de la universidad](https://download.inep.gov.br/microdados/TED_8750-UFMG.pdf), que indica la posibilidad de identificar individuos mediante el uso combinado de indicadores del Censo Escolar de la Educación Básica, con un alto porcentaje de acierto. El organismo no informó de cuándo, o de si, volverá a poner los datos a disposición.
+
+La retirada de los datos generó un amplio debate sobre los límites entre la LGPD y la transparencia pública, con la participación de diversas organizaciones que trabajan en el tema, como [Open Knowledge Brasil](https://ok.org.br/noticia/nota-alerta-para-uso-equivocado-da-lgpd-pelo-inep-ao-suprimir-microdados/) y [Fiquem Sabendo](https://fiquemsabendo.com.br/). El Foro de Derecho de Acceso a Informaciones Públicas, integrado por esas iniciativas y otras 23 organizaciones, emitió una [nota oficial sobre la decisión del Inep](http://informacaopublica.org.br/?p=4315). Otras iniciativas del área educativa también se posicionaron en contra de la retirada mediante notas oficiales, como el [Iede](https://www.portaliede.com.br/nova-forma-de-divulgar-dados-do-enem-e-do-censo-escolar-pelo-inep-contraria-interesse-publico-e-inviabiliza-diversas-pesquisas/) (Interdisciplinariedad y Evidencias en el Debate Educacional) y la [Asociación de Periodistas de la Educación](https://jeduca.org.br/noticia/nota-sobre-a-retirada-de-microdados-do-site-do-inep) (Jeduca).
+
+## Base de los Datos y el Censo Escolar
+
+Base de los Datos ya es una referencia en el acceso a datos abiertos de calidad en Brasil. Defendemos la transparencia de la información mediante la publicación y el tratamiento de datos públicos, democratizando el acceso a miles de personas al eliminar barreras técnicas para producir análisis y evidencia. Tenemos en cuenta las cuestiones legales de nuestra actuación y nos limitamos a reproducir datos que cuentan con licencia abierta.
+
+En 2021 publicamos los microdatos del Censo Escolar de la Educación Básica, ya tratados y estandarizados, en nuestro datalake público. Entendemos que la situación en torno a los microdatos del Inep es nueva y todavía muy reciente para todos. Estamos estudiando las notas técnicas y referencias publicadas por el Inep y sus socios en la evaluación de privacidad sobre los microdatos, así como los estudios de organizaciones que defienden la transparencia y los datos abiertos.
+
+Entendemos la importancia de respetar la privacidad de toda persona. La promulgación y aplicación de la LGPD en Brasil fue un paso muy importante para garantizar derechos de libertad y seguridad. Las personas producen datos hoy de forma constante en plataformas digitales y aun así tienen poco control sobre quién los almacena y trata, cómo y cuándo los utiliza, entre otras cuestiones relevantes en un mundo hiperconectado y cada vez más digital.
+
+Por otro lado, la cultura y la promoción de los datos abiertos son de enorme importancia para la producción y promoción de políticas públicas, el desarrollo de investigación, la ciencia abierta y campos afines. Esta información se publicaba desde hacía años y no tenemos conocimiento de ninguna denuncia por violación de privacidad o riesgo para la seguridad de personas a partir de los microdatos del Inep. Entendemos la preocupación y la necesidad de revisar el tratamiento de los datos, pero nos sorprende la retirada fría y abrupta de todo su histórico, sin comunicación con la sociedad ni con las organizaciones que trabajan con esos datos para producir servicios y evidencia en educación. Tal como se hizo, la retirada de esta base de datos perjudicó el desarrollo de investigaciones y análisis de calidad en un área fundamental para nuestro país: la educación. Poder acompañar y comprender adecuadamente la efectividad de las políticas públicas educativas es un paso esencial para alcanzar lo que el artículo 205 y siguientes de la Constitución Federal nos aseguran.
+
+Seguimos defendiendo datos públicos, abiertos y accesibles para todas y todos, respetando siempre que sea necesario las cuestiones legales de confidencialidad y privacidad implicadas en la publicación de información. Por ello informamos de que, por ahora, mantendremos los datos tal como fueron publicados, bajo licencia de datos abiertos y mínimamente estandarizados en [código abierto](https://github.com/basedosdados/sdk/tree/master/bases). No obstante, quedamos plenamente a disposición de cualquier entidad gubernamental para conversar y evaluar la situación, y entender cómo podemos acompañar y ayudar en el proceso de tratamiento y reapertura de los microdatos.
+
+Subrayamos la importancia de que el Inep publique datos que contemplen las demandas de investigadores y especialistas de información amplia sobre el escenario educativo en Brasil, sin infringir los parámetros establecidos por la LGPD; establezca un entorno virtual seguro para el acceso a esa información; y garantice la total transparencia y la capacidad de fiscalización de la sociedad civil a lo largo del proceso de adecuación de estos datos.

--- a/next/blog/es/patchnotes_dez.md
+++ b/next/blog/es/patchnotes_dez.md
@@ -1,0 +1,85 @@
+---
+title: Patch Notes - Diciembre 🎲
+description: Manténgase al día de las actualizaciones técnicas de BD este mes
+slug: patch-notes-diciembre
+date:
+  created: "2025-12-07T15:00:00"
+authors:
+thumbnail: /blog/patchnotes_dez/thumb_patchnotes.png
+categories: [institucional]
+medium_slug: >-
+published: true
+order: 0
+---
+
+
+¡Hola, databaser!
+
+Llegamos al final del año con algunas actualizaciones interesantes, incluido el estreno de este nuevo formato de Patch Notes, que publicaremos periódicamente para mantener la transparencia con nuestra comunidad e informar sobre novedades técnicas en nuestro datalake público, los datos, los servicios y más. ¡Vamos allá!
+
+<Image src="/blog/patchnotes_dez/patchnotes_dez.png" />
+
+## Correcciones en pipelines
+
+Corregimos problemas que impedían la actualización automática de **7 conjuntos de datos**, con un total de **23 tablas**. Algunos de los destacados:
+
+*   **Datos de inflación ([IPCA](https://basedelosdatos.org/dataset/ea4d07ca-e779-4d77-bcfa-b0fd5ebea828?table=f1fd2eb7-467a-403b-8f1c-2de8eff354e6), [INPC](https://basedelosdatos.org/dataset/92945390-3b20-40e7-b71b-f6b58f3dc754), [IPCA-15](https://basedelosdatos.org/dataset/a7d9442f-a591-477e-82a1-bcf780ccd0dc))**
+    *   Conjuntos de datos actualizados: `br_ibge_ipca`, `br_ibge_ipca_br_ibge_inpc` y `"br_ibge_ipca15`
+    *   Tablas actualizadas:
+        * Mes Brasil;
+        * Mes Categoría Brasil;
+        * Mes Categoría Municipio;
+        * Región Metropolitana.
+    *   Actualizaciones:
+        *   Relleno de los metadatos de última verificación, última actualización en la fuente y última actualización en BD para todas las tablas;
+        * Activación de schedules;
+        * Seguimiento de la primera ejecución de la pipeline tras el cierre del PR.
+
+*   **[Catastro Nacional de Obras](https://basedelosdatos.org/dataset/062621e9-5aa0-4903-852d-619ae54393d2) (CNO)**
+    *   Conjunto de datos: ``br_rf_cno``
+    *   Actualizaciones:
+        *   Probamos distintas asignaciones de recursos en el pod que ejecuta el flow en Kubernetes;
+        * Seguimiento de la primera ejecución de la pipeline tras el cierre del PR.
+*   **[Fondos de Inversión](https://basedelosdatos.org/dataset/9c5a820f-09dd-4519-adfd-611819163ae0) (CVM)**
+    *   Conjunto de datos: ``br_cvm_fi``
+    *   Actualizaciones:
+        *   Depuración del problema que impide el registro del Flow;
+        * Seguimiento de la primera ejecución de la pipeline tras el cierre del PR.
+
+
+**¿Por qué importa?**
+Cuando una pipeline encuentra problemas, los datos pueden quedar desactualizados. Estas correcciones forman parte de nuestro trabajo continuo para mantener el datalake lo más actualizado posible.
+
+
+## Actualización de la RAIS
+
+Los datos parciales de la RAIS Establecimientos [2024](https://basedelosdatos.org/dataset/3e7c4d58-96ba-448e-b053-d385a829ef00?table=86b69f96-0bfe-45da-833b-6edc9a0af213) ya están disponibles. Eso significa acceso a los datos de establecimientos más recientes del mercado de trabajo formal en Brasil, con información sobre vínculos laborales, remuneraciones, sectores y mucho más. Si ya tenía un análisis con la RAIS anterior, es hora de actualizar los gráficos.
+
+## Actualización de los datos de Indicadores Educativos
+
+Actualizamos el conjunto de [Indicadores Educativos](https://basedelosdatos.org/dataset/63f1218f-c446-4835-b746-f109a338e3a1?table=cd65b1d2-45e8-432b-afe8-c3a706addbe8) del INEP con el relleno de los metadatos de última verificación, última actualización en la fuente y última actualización en BD para todas las tablas.
+
+Tablas actualizadas:
+
+* Brasil (2024);
+* Estado (2024);
+* Región (2024);
+* Brasil Tasa de Transición (2022);
+* Estado Tasa de Transición (2022);
+* Municipio Tasa de Transición (2022);
+* Región Tasa de Transición (2022).
+
+
+Los indicadores educativos son esenciales para la investigación, las políticas públicas y el análisis regional. Con los datos de 2024 ya disponibles, puede seguir la evolución reciente de la educación brasileña a nivel nacional, estatal y regional, y con metadatos claros para saber siempre la procedencia y la fecha de la última actualización.
+
+
+## Refactorización de los logs de DBT
+
+Refactorizamos los logs de ejecución de DBT (nuestra herramienta de transformación de datos) para que sean más limpios, estructurados e informativos. Ahora podemos identificar errores más rápido, sin tener que rastrear varias plataformas ni reproducir fallos localmente.
+
+**¿Por qué importa?**
+Para nuestro equipo de ingeniería significa menos tiempo depurando y más tiempo para desarrollar nuevas pipelines. Para usted, databaser, significa pipelines aún más fiables y una base de datos siempre consistente.
+
+- - - 
+
+¿Quiere estar al día también de nuestros análisis, entrevistas, clases y tutoriales? Suscríbase a la [BDletter](https://info.basedosdados.org/newsletter), llega gratis a su bandeja de entrada.

--- a/next/blog/es/patchnotes_janeiro.md
+++ b/next/blog/es/patchnotes_janeiro.md
@@ -1,0 +1,110 @@
+---
+title: Patch Notes - Enero/Febrero 🎲
+description: Manténgase al día de las actualizaciones técnicas de BD
+slug: patch-notes-enero-febrero
+date:
+  created: "2026-02-07T15:00:00"
+authors:
+thumbnail: /blog/patchnotes_dez/thumb_patchnotes.png
+categories: [institucional]
+medium_slug: >-
+published: true
+order: 0
+---
+
+
+¡Hola, *databaser*!
+
+Empezamos el año con una serie de actualizaciones importantes para garantizar la calidad y la disponibilidad de los datos de BD. Conozca las novedades técnicas que implementamos en enero y febrero.
+
+<Image src="/blog/patchnotes_janeiro/patchnotes_janeiro.png" />
+
+## Conjuntos y tablas actualizados
+
+### [Datos de población](https://basedelosdatos.org/dataset/d30222ad-7a5c-4778-a1ec-f0785371d1ca)
+
+Los datos más recientes del IBGE sobre la población brasileña ya están en BD: datos a nivel de municipio con las estimaciones de población del instituto. Puede cruzarlos para crear comparaciones con muchos otros indicadores.
+
+### [Emisiones de gases de efecto invernadero en Brasil](https://basedelosdatos.org/dataset/9a22474f-a763-4431-8e3d-667908a1c7ab)
+
+Los datos de la versión más reciente del Sistema de Estimación de Emisiones y Remociones de Gases de Efecto Invernadero (SEEG) ya están en BD: datos a nivel de municipio con información sobre emisiones por sector emisor, actividad económica y mucho más, ahora hasta 2024.
+
+### [Microdatos del SAEB](https://basedelosdatos.org/dataset/e083c9a2-1cee-4342-bedc-535cbad6f3cd)
+
+La última actualización del Sistema de Evaluación de la Educación Básica (Saeb) ya está en BD, con datos tratados y listos para su análisis. Son los registros individuales y anonimizados de las evaluaciones que el INEP aplica a alumnos, docentes y directores de escuelas públicas y privadas de Brasil.
+
+### [Datos de población del Ministerio de Salud](https://basedelosdatos.org/dataset/1e2b9a88-9dc7-4f0e-a3a5-e8d2a13869bf)
+
+El Ministerio de Salud también publica estimaciones anuales de población para los municipios, desagregadas por sexo y grupos de edad. Ahora puede acceder también a los datos más recientes, de 2025, a través de BD.
+
+### [Microdatos de la Evaluación de Alfabetización](https://basedelosdatos.org/dataset/073a39d4-89cf-4068-b1e8-34ed0d9c0b72)
+
+El Inep definió un estándar nacional de alfabetización a partir de la encuesta Alfabetiza Brasil (2023). El indicador se calcula con los resultados de las evaluaciones realizadas por los sistemas estatales y municipales, en cooperación técnica con el Inep, y estandarizados en la escala del Saeb.
+
+Son datos de 2023 y 2024 con resultados y metas de los estados y municipios, además de las tasas de alfabetización de la red pública por municipio y red.
+
+### [Microdatos de educación de la Pnad-C](https://basedelosdatos.org/dataset/9fa532fb-5681-4903-b99d-01dc45fd527a?table=18fbf773-f43f-4876-8511-8b3b2f0d42a6)
+
+Los datos de 2024 de la Encuesta Suplementaria Anual referidos a educación ya están listos para su análisis en BD. Recogidos trimestralmente por el IBGE, complementan el Censo Escolar con información sobre asistencia escolar, analfabetismo, escolaridad y acceso a la educación, incluso fuera del sistema formal.
+
+## Corrección de metadatos y métrica de actualización
+
+**¿Qué cambió en la práctica?**
+
+Eliminamos los "falsos positivos" del panel de monitoreo, de modo que las alertas de tablas desactualizadas ahora reflejan la realidad.
+
+**Detalles técnicos:**
+
+*   **Antes:** la discrepancia entre el metadato de "frecuencia de actualización" y la fecha de la última carga en la base generaba alertas incorrectas para tablas que estaban en perfecto estado.
+*   **Después:** los metadatos se ajustaron para corresponder al comportamiento real de las pipelines.
+*   **Impacto técnico:** la fórmula de cálculo (frecuencia vs. última actualización) ahora opera sobre parámetros correctos, saneando la métrica de monitoreo.
+
+**¿Por qué lo hicimos?**
+
+Para restaurar la confianza en los dashboards de calidad de datos, con una observabilidad precisa del estado de actualización.
+
+## Mantenimientos periódicos de pipelines
+
+**¿Qué cambió en la práctica?**
+
+Restablecimos pipelines que fallaron durante el receso de fin de año, con correcciones de modelado, ajustes de extracción (especialmente por el cambio de año) y resolución de errores en pruebas automatizadas.
+
+**Detalles técnicos:**
+
+*   **Antes:** los fallos de ejecución bloqueaban la actualización de varios conjuntos de datos por errores de prueba, problemas en la construcción de modelos y metadatos incorrectos.
+*   **Después:**
+    *   **Correcciones aplicadas (PRs #1355 y #1357):** ajustes en el modelado de profesionales (CNES), corrección en la extracción de microdatos de dengue (SINAN) y arreglo de los IDs de NCM (Comex Stat).
+    *   **Investigación y ajustes:** resolución de errores de prueba (Estban, Cafir), actualización de metadatos (CVM) y análisis de duplicidad/string matching (Denatran).
+    *   **Mapeo:** identificación de nuevas roturas para incluir en el backlog (Bolsa Família, BDMEP, etc.).
+*   **Impacto técnico:** integridad de las pipelines recuperada y flujo de ingesta diaria normalizado.
+
+**¿Por qué lo hicimos?**
+
+Para priorizar y resolver las interrupciones de servicio acumuladas durante el cambio de año, garantizando la disponibilidad de los datos más consultados.
+
+## Actualización y arreglo de las tablas de Indicadores Educativos
+
+**¿Qué cambió en la práctica?**
+
+Actualización y arreglo de datos, incluida la eliminación de datos duplicados en las tablas de indicadores educativos.
+
+**Detalles técnicos:**
+
+*   **Antes:** tablas de indicadores educativos con datos desactualizados y duplicados.
+*   **Después:** datos actualizados y duplicidades eliminadas, garantizando la integridad de la información.
+
+## Refactorización y estabilización de flows (nueva arquitectura)
+
+**¿Qué cambió en la práctica?**
+
+Migramos los flujos de datos a la nueva arquitectura con monitoreo asistido y corrección inmediata de fallos en la primera ejecución, aumentando la robustez del sistema.
+
+**Detalles técnicos:**
+
+*   **Antes:** flows adaptados preliminarmente o todavía en la arquitectura antigua, sujetos a errores de implementación.
+*   **Después:** flows refactorizados, validados en producción y con correcciones de runtime aplicadas en el mismo PR.
+*   **Impacto técnico:** cumplimiento del nuevo proceso de arquitectura y estabilidad en la ejecución de las pipelines.
+
+**¿Por qué lo hicimos?**
+
+Para reducir la incidencia de datos incorrectos en producción y asegurar la fiabilidad del datalake público.

--- a/next/blog/es/relembrando-o-datathon-bd-2021.md
+++ b/next/blog/es/relembrando-o-datathon-bd-2021.md
@@ -1,0 +1,51 @@
+---
+title: Recordando el Datathon BD 2021 🎲
+description: ¿Cómo pueden los datos abiertos contribuir a un desarrollo más igualitario en Brasil?
+slug: recordando-el-datathon-2021
+date:
+  created: "2021-03-06T15:00:00"
+authors:
+  - name: Giovane Caruso
+    role: Texto
+    social: https://medium.com/@giovanecaruso
+categories: [institucional]
+medium_slug: >-
+  https://medium.com/basedosdados/relembrando-o-datathon-bd-2021-ee46fe00ccc0
+published: true
+---
+
+La publicación de datos públicos pone en números la desigualdad en distintos aspectos de la sociedad, y es a partir de ahí que podemos empezar a elaborar soluciones e iniciativas para un desarrollo más democrático.
+
+Por eso, inspirados en el tema del Open Data Day 2021, decidimos abrir un espacio para que programadores, periodistas, investigadores y entusiastas de los datos pensaran con nosotros cómo identificar o combatir desigualdades en Brasil a partir de datos públicos.
+
+¿Y por dónde empezar? Nosotros dimos el punto de partida: los más de 30 conjuntos públicos que publicamos, tratados e integrados para uso de la sociedad, en nuestro *datalake* público. Recibimos en total más de 30 inscripciones de públicos diversos. ¡Gracias a todas y todos por participar!
+
+> **Atención: ninguno de estos análisis pretende aportar evidencia rigurosamente comprobada sobre los temas abordados, sino explorar y abrir posibles caminos para pensarlos.**
+
+## Y los ganadores fueron…
+
+### UFRJ Analytica
+
+Equipo: Erica Ferreira, Pedro Boechat, Pedro Borges y Rafael Ribeiro (estudiantes de grado y analistas/científicos de datos)
+
+> **Análisis: ¿de qué forma se manifiestan las diferencias en el acceso a una educación de calidad en distintas regiones del país?**
+
+Para entender mejor esta y otras preguntas sobre la calidad de la enseñanza y la inversión en educación, utilizaron cuatro bases publicadas en Base de los Datos: el [Atlas del Desarrollo Humano (ADH)](/dataset/cbfc7253-089b-44e2-8825-755e1419efc8?table=2b704f11-2b3a-485d-a492-71f86c7ea21a), el [Índice de Desarrollo de la Educación Básica (Ideb)](/dataset/96eab476-5d30-459b-82be-f888d4d0d6b9?table=bc84dea9-1126-4423-86d2-8835e6b19a72), [Finanzas de Brasil (Finbra)](/dataset/br-tesouro-finbra) y nuestra base de [directorios brasileños](/dataset/33b49786-fb5f-496f-bb7c-9811c985af8e?table=0a2d8187-f936-437d-89db-b4eb3a7e1735), que enlaza distintas identificaciones de municipios, estados y regiones del país.
+
+[➡️ Vea el análisis completo aquí](/ufrj-analytica/datathon-open-data-day-base-dos-dados-86079c93945f)
+
+[💻 Vea el código utilizado](https://github.com/UFRJ-Analytica/odd2021)
+
+### Felipe Macedo Dias (estudiante de Economía en la USP)
+
+> **Análisis: ¿la inflación fue mayor en los municipios más beneficiados por el Auxilio de Emergencia?**
+
+El auxilio de emergencia fue un gran tema socioeconómico durante la pandemia en el país, y el debate siguió sobre su permanencia en momentos posteriores. Felipe exploró la cuestión empezando por las capitales: ¿existe alguna correlación entre el aumento de los precios, con un mayor nivel de consumo, y la incidencia del auxilio en las capitales? Para ello usó las bases de [población estimada del IBGE](/dataset/d30222ad-7a5c-4778-a1ec-f0785371d1ca?table=2440d076-8934-471f-8cbe-51faae387c66), [Producto Interno Bruto (PIB)](/dataset/fcf025ca-8b19-4131-8e2d-5ddb12492347?table=fbbbe77e-d234-4113-8af5-98724a956943) y [datos del auxilio de emergencia por municipio](/dataset/1e768395-e834-4495-a80c-f96f6db57efb?table=5f29077d-6712-491c-9450-cc6bc1939cda).
+
+[➡️ Vea el análisis completo aquí](https://datastudio.google.com/s/lrVkgDD_URc)
+
+[💻 Vea el código utilizado](https://github.com/UFRJ-Analytica/odd2021)
+
+## ¿Qué es el Día de los Datos Abiertos?
+
+El [Día de los Datos Abiertos](https://opendataday.org/pt_br/) es una celebración anual de los datos abiertos en todo el mundo. Grupos de todas partes crean eventos locales ese día, en los que usan datos abiertos en sus comunidades. Es una oportunidad para mostrar los beneficios de los datos abiertos y fomentar la adopción de políticas de datos abiertos en el gobierno, las empresas y la sociedad civil. Todos los resultados son abiertos para que cualquiera los use y reutilice.

--- a/next/components/organisms/blog/Slug.js
+++ b/next/components/organisms/blog/Slug.js
@@ -255,13 +255,15 @@ function FigCaption(props) {
 }
 
 export function Toc({ headings }) {
+  const { t } = useTranslation('blog');
+
   return (
     <Box>
       <LabelText
         typography="large"
         marginBottom="2px"
       >
-        Tabela de conteúdo
+        {t('tableOfContents')}
       </LabelText>
       <Box as="hr" borderWidth="2px" borderColor="#DEDFE0" marginBottom="8px"/>
       <UnorderedList margin="0">

--- a/next/pages/api/blog/index.js
+++ b/next/pages/api/blog/index.js
@@ -27,8 +27,14 @@ export async function getAllPosts(locale = 'pt') {
           const { data } = matter(content);
 
           if (isDevelopment || data.published) {
+            const filename = file.replace(".md", "");
             return {
-              slug: file.replace(".md", ""),
+              // `slug` is the public URL segment; translated posts override it
+              // in frontmatter so English and Spanish get their own wording.
+              slug: data.slug || filename,
+              // `filename` is shared across locales and is what links the
+              // translations of one post together.
+              filename,
               frontmatter: data,
             };
           }
@@ -58,10 +64,61 @@ export async function getAllPosts(locale = 'pt') {
 }
 
 export async function getPostBySlug(slug, locale = 'pt') {
+  const blogpostsDir = path.join(root, `blog/${locale}`)
+
+  // Fast path: the URL segment is the filename (always true for pt).
   try {
-    const blogpostsDir = path.join(root, `blog/${locale}`)
-    const filepath = path.join(blogpostsDir, `${slug}.md`);
-    return await fs.readFile(filepath, "utf-8");
+    return await fs.readFile(path.join(blogpostsDir, `${slug}.md`), "utf-8");
+  } catch (error) {
+    // fall through to the frontmatter lookup
+  }
+
+  // Translated posts keep the Portuguese filename but publish under a
+  // localized `slug`, so scan for the file that declares this one.
+  try {
+    const files = await fs.readdir(blogpostsDir, "utf-8");
+    for (const file of files) {
+      if (!file.endsWith(".md")) continue;
+      const content = await fs.readFile(path.join(blogpostsDir, file), "utf-8");
+      if (matter(content).data.slug === slug) return content;
+    }
+  } catch (error) {
+    return null;
+  }
+
+  return null;
+}
+
+// The filename backing a URL segment, which is what the file on disk is
+// actually called. Equals the slug for pt and for untranslated posts.
+export async function getFilenameForSlug(slug, locale = 'pt') {
+  const blogpostsDir = path.join(root, `blog/${locale}`)
+  try {
+    await fs.access(path.join(blogpostsDir, `${slug}.md`));
+    return slug;
+  } catch (error) {
+    // not a filename; look for the post declaring it as its slug
+  }
+  try {
+    const files = await fs.readdir(blogpostsDir, "utf-8");
+    for (const file of files) {
+      if (!file.endsWith(".md")) continue;
+      const content = await fs.readFile(path.join(blogpostsDir, file), "utf-8");
+      if (matter(content).data.slug === slug) return file.replace(".md", "");
+    }
+  } catch (error) {
+    return null;
+  }
+  return null;
+}
+
+// The canonical URL segment for a post in a given locale, or null when that
+// locale has no translation of it.
+export async function getSlugForLocale(filename, locale) {
+  try {
+    const filepath = path.join(root, `blog/${locale}`, `${filename}.md`);
+    const content = await fs.readFile(filepath, "utf-8");
+    return matter(content).data.slug || filename;
   } catch (error) {
     return null;
   }

--- a/next/pages/blog/[slug].js
+++ b/next/pages/blog/[slug].js
@@ -8,7 +8,7 @@ import { MDXRemote } from "next-mdx-remote";
 import { useTranslation } from 'next-i18next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import { MainPageTemplate } from "../../components/templates/main";
-import { getAllPosts, getPostBySlug, serializePost } from "../api/blog";
+import { getAllPosts, getPostBySlug, getSlugForLocale, getFilenameForSlug, serializePost } from "../api/blog";
 import { categories } from "../api/blog/categories";
 import BodyText from "../../components/atoms/Text/BodyText";
 import Link from "../../components/atoms/Link";
@@ -51,11 +51,22 @@ export async function getStaticProps({ params, locale }) {
     };
   }
 
+  const canonicalSlug = await getSlugForLocale(slug, locale);
+  if (canonicalSlug && canonicalSlug !== slug) {
+    return {
+      redirect: {
+        destination: locale === "pt" ? `/blog/${canonicalSlug}` : `/${locale}/blog/${canonicalSlug}`,
+        permanent: false,
+      },
+    };
+  }
+
   const serialize = await serializePost(content);
 
   return {
     props: {
       slug,
+      filename: (await getFilenameForSlug(slug, locale)) || slug,
       locale,
       ...serialize,
       ...(await serverSideTranslations(locale, ['common', 'blog', 'menu'])),
@@ -63,15 +74,31 @@ export async function getStaticProps({ params, locale }) {
   };
 }
 
-export async function getStaticPaths() {
-  const allPosts = await getAllPosts();
-  return {
-    paths: allPosts.map(({ slug }) => ({ params: { slug } })),
-    fallback: "blocking"
-  };
+export async function getStaticPaths({ locales = ["pt"] }) {
+  const perLocale = await Promise.all(
+    locales.map(async (locale) => {
+      const posts = await getAllPosts(locale);
+      // Both forms resolve: the locale's own slug and the shared filename,
+      // which redirects to it.
+      return posts.flatMap(({ slug, filename }) =>
+        [slug, filename].filter(Boolean).map((s) => ({ params: { slug: s }, locale }))
+      );
+    })
+  );
+
+  const paths = [];
+  const seen = new Set();
+  for (const entry of perLocale.flat()) {
+    const key = `${entry.locale}:${entry.params.slug}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    paths.push(entry);
+  }
+
+  return { paths, fallback: "blocking" };
 }
 
-export default function Post({ slug, locale, mdxSource, headings }) {
+export default function Post({ slug, filename, locale, mdxSource, headings }) {
   const { t } = useTranslation('blog')
   const { frontmatter } = mdxSource;
 
@@ -189,7 +216,7 @@ export default function Post({ slug, locale, mdxSource, headings }) {
               <BodyText marginTop="24px">{t("noticedSomething")} </BodyText>
               <BodyText
                 as="a"
-                href={`https://github.com/basedosdados/website/edit/${repository()}/next/blog/${locale}/${slug}.md`}
+                href={`https://github.com/basedosdados/website/edit/${repository()}/next/blog/${locale}/${filename}.md`}
                 isexternal="true"
                 color="#0068C5"
                 _hover={{

--- a/next/public/locales/en/blog.json
+++ b/next/public/locales/en/blog.json
@@ -9,5 +9,6 @@
   "noCategories": "No category",
   "noticedSomething": "Notice something wrong or have a suggestion?",
   "contributeToBD": "Contribute to DB by editing this article via pull request on our GitHub.",
-  "seeAll": "See all"
+  "seeAll": "See all",
+  "tableOfContents": "Table of contents"
 }

--- a/next/public/locales/es/blog.json
+++ b/next/public/locales/es/blog.json
@@ -9,5 +9,6 @@
   "noCategories": "Sin categoría",
   "noticedSomething": "¿Notas algo mal o tienes alguna sugerencia?",
   "contributeToBD": "Contribuya a la BD editando este artículo mediante solicitud de extracción en nuestro GitHub.",
-  "seeAll": "Ver todo"
+  "seeAll": "Ver todo",
+  "tableOfContents": "Tabla de contenido"
 }

--- a/next/public/locales/pt/blog.json
+++ b/next/public/locales/pt/blog.json
@@ -9,5 +9,6 @@
   "noCategories": "Sem categoria",
   "noticedSomething": "Notou algo errado ou tem uma sugestão?",
   "contributeToBD": "Contribua com a BD editando este artigo via pull request no nosso GitHub.",
-  "seeAll": "Ver todos"
+  "seeAll": "Ver todos",
+  "tableOfContents": "Tabela de conteúdo"
 }


### PR DESCRIPTION
Translates the blog into English and Spanish, and adds the slug mapping that makes localized blog URLs possible.

**This branch is in progress: 21 of 54 posts are translated.** The remaining 33 will land as further commits on this same branch. It is opened now so the routing change can be reviewed before another 66 files come to depend on it.

## The slug mapping (the part worth reviewing)

Posts keep **one filename across locales** — that filename is what ties a post's translations together — and each translation declares its own public slug in frontmatter.

- `getAllPosts` now returns both `slug` (the URL segment, from frontmatter when present) and `filename` (shared across locales).
- `getPostBySlug` resolves by filename first, then falls back to scanning for the post whose frontmatter declares that slug, so both forms work.
- The post page redirects the filename form to the locale's own slug. This matters because the language switcher does `router.push(router.pathname, router.asPath, { locale })`, carrying the current slug across locales — without the redirect, switching language on a post would land on the blog index.
- `getStaticPaths` previously generated paths from the Portuguese filenames only, for every locale. It is now locale-aware.
- The "edit this page" link points at the real file rather than the localized slug.

Resolution was simulated against the real files. For example, with `blog/en/curso-qgis.md` declaring `slug: free-qgis-course`:

| Request | Result |
|---|---|
| `/blog/curso-qgis` (pt) | renders, unchanged |
| `/en/blog/free-qgis-course` | renders from `blog/en/curso-qgis.md` |
| `/en/blog/curso-qgis` (what the language switcher produces) | redirects to `/en/blog/free-qgis-course` |
| `/en/blog/<a pt slug with no en translation>` | redirects to the blog index, as before |

No redirect loops.

## Translations so far

21 posts in both `en` and `es` — 9 analyses, 6 institutional, 5 tutorials, 1 uncategorised.

One of them, `analisando-atividade-economica-do-rio-de-janeiro`, already had `en` and `es` files, but both contained the Portuguese body under a translated frontmatter. Those are rewritten properly.

Conventions applied throughout:

- SQL, R and Python blocks are **verbatim**. They reference real BigQuery tables and columns (`id_municipio`, `sigla_uf`, `id_pais`), which the surrounding prose names, so translating an identifier would silently break the tutorial.
- Brazilian institution and dataset names are kept: IBGE, RAIS, CNAE, INEP, INMET, SINAN, SEBRAE, Comex Stat, geobr, LAI.
- Values in reais are kept as reais.
- DB Pro callouts in the English posts use the English brand and the `/dbpro` URL from #1680.
- Portuguese wording is unchanged, including informal usages like "a BD".

## Also fixed

The blog table-of-contents heading was hardcoded as "Tabela de conteúdo" in `Slug.js`, so it rendered in Portuguese on every post in every language. It now reads from a new `blog.tableOfContents` key, added for all three locales.

## Testing

**Not built or run** — the working tree had no `node_modules`. Verification was static:

- Every edited JS file parses under Babel.
- A script checks each translated post: slug present, slug resolves, filename form redirects to it, no stray Portuguese in prose, and structural parity with the Portuguese source (same count of code blocks and images). All 42 post files pass.

The routing change needs a real `next build` before merge. Two specifics to look at:

- `getStaticPaths` now returns `{ params, locale }` entries rather than bare `{ params }`. That is the documented shape for i18n, but it is the kind of thing worth confirming against an actual build.
- `getPostBySlug`'s fallback reads every file in the locale directory when the fast path misses. That is fine at 54 posts and static build time, but it is a linear scan.

## Known gaps

- Screenshots and chart images are shared across locales and show Portuguese interfaces (BigQuery, Power BI, QGIS) and Portuguese ggplot axis labels. The prose is translated; the images are not. Localised images would be a separate piece of work.
- Two translated posts carry `published: false` in the source (`intro-ao-pacote-basedosdados-em-python`, `como-funciona-o-sistema-de-insercao-de-dados-na-bd`). They are translated for parity but stay invisible until that flag changes.
- `relembrando-o-datathon-bd-2021` links to `/ufrj-analytica/datathon-open-data-day-...`, which looks like a Medium URL missing its domain. Broken in the Portuguese original too; copied as-is rather than guessed at.
