### PR TITLE
fix(chatbot): style markdown headings, bold links and table headers

### DIFF
--- a/next/components/organisms/chatbot/markdown.js
+++ b/next/components/organisms/chatbot/markdown.js
@@ -60,9 +60,11 @@ export function CodeBlock({
   const { hasCopied, onCopy } = useClipboard(code);
   const hasHeader = title != null;
 
+  const canHighlight = !inline && !raw && Boolean(hljs.getLanguage(language));
+
   const highlighted = useMemo(
-    () => (inline || raw ? null : hljs.highlight(code, { language })),
-    [inline, raw, code, language]
+    () => (canHighlight ? hljs.highlight(code, { language }) : null),
+    [canHighlight, code, language]
   );
 
   if (inline) {
@@ -171,7 +173,7 @@ export function CodeBlock({
         }
         boxSizing="border-box"
       >
-        {raw ? (
+        {!canHighlight ? (
           <Box
             as="code"
             display="block"
@@ -202,35 +204,110 @@ export function CodeBlock({
 
 export const MemoCodeBlock = React.memo(CodeBlock);
 
+const headingStyles = {
+  h1: { fontSize: "24px", lineHeight: "32px", fontWeight: "700", marginTop: "24px" },
+  h2: { fontSize: "20px", lineHeight: "28px", fontWeight: "700", marginTop: "24px" },
+  h3: { fontSize: "18px", lineHeight: "26px", fontWeight: "600", marginTop: "20px" },
+  h4: { fontSize: "16px", lineHeight: "24px", fontWeight: "600", marginTop: "16px" },
+  h5: { fontSize: "15px", lineHeight: "22px", fontWeight: "600", marginTop: "16px" },
+  h6: { fontSize: "14px", lineHeight: "20px", fontWeight: "600", marginTop: "16px" },
+};
+
+// Chakra's CSS reset flattens h1-h6 to `font-size: inherit; font-weight: inherit`,
+// so every heading level needs an explicit style or it renders as body text.
+function makeHeading(level) {
+  const { marginTop, ...style } = headingStyles[level];
+  const Heading = ({ children }) => (
+    <Text
+      as={level}
+      fontFamily="Roboto"
+      color="#252A32"
+      margin={`${marginTop} 0 8px`}
+      _first={{ marginTop: 0 }}
+      {...style}
+    >
+      {children}
+    </Text>
+  );
+  Heading.displayName = `Markdown${level.toUpperCase()}`;
+  return Heading;
+}
+
+function getCodeLanguage(className) {
+  const match = /language-(\w+)/.exec(className || "");
+  return match ? match[1] : "sql";
+}
+
 export const componentsMk = {
+  h1: makeHeading("h1"),
+  h2: makeHeading("h2"),
+  h3: makeHeading("h3"),
+  h4: makeHeading("h4"),
+  h5: makeHeading("h5"),
+  h6: makeHeading("h6"),
   p: ({ children }) => (
-    <BodyText as="p" color="#252A32" marginBottom="4px">
+    <BodyText as="p" color="#252A32" marginBottom="8px" _last={{ marginBottom: 0 }}>
       {children}
     </BodyText>
   ),
   a: ({ children, href }) => (
-    <BodyText as="a" color="#0068C5" href={href} target="_blank" rel="noopener noreferrer">
+    <BodyText
+      as="a"
+      color="#0068C5"
+      fontSize="inherit"
+      lineHeight="inherit"
+      fontWeight="inherit"
+      textDecoration="underline"
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
       {children}
     </BodyText>
   ),
   strong: ({ children }) => (
-    <Text as="strong" fontWeight="bold" color="#252A32">
+    <Text as="strong" fontWeight="700" color="inherit">
       {children}
     </Text>
   ),
   em: ({ children }) => (
-    <Text as="em" fontStyle="italic" color="#252A32">
+    <Text as="em" fontStyle="italic" color="inherit">
       {children}
     </Text>
   ),
-  code: ({ children, inline }) => <MemoCodeBlock inline={inline} children={children} />,
+  blockquote: ({ children }) => (
+    <Box
+      as="blockquote"
+      borderLeft="3px solid #DEDFE0"
+      paddingLeft="12px"
+      margin="12px 0"
+      color="#464A51"
+    >
+      {children}
+    </Box>
+  ),
+  hr: () => <Box as="hr" borderTop="1px solid #DEDFE0" margin="16px 0" />,
+  del: ({ children }) => (
+    <Text as="del" textDecoration="line-through" color="inherit">
+      {children}
+    </Text>
+  ),
+  // react-markdown wraps fenced code in <pre>; CodeBlock renders its own <pre>.
+  pre: ({ children }) => <>{children}</>,
+  code: ({ children, inline, className }) => (
+    <MemoCodeBlock
+      inline={inline}
+      language={getCodeLanguage(className)}
+      children={children}
+    />
+  ),
   ul: ({ children }) => (
     <UnorderedList margin="8px 0 8px 20px">
       {children}
     </UnorderedList>
   ),
   ol: ({ children }) => (
-    <OrderedList >
+    <OrderedList margin="8px 0 8px 20px">
       {children}
     </OrderedList>
   ),
@@ -288,7 +365,7 @@ export const componentsMk = {
       textTransform="none"
       letterSpacing="inherit"
       fontFamily="Roboto"
-      fontWeight="400"
+      fontWeight="600"
       fontSize={{ base: "13px", md: "14px" }}
       lineHeight="20px"
       color="#252A32"


### PR DESCRIPTION
## Problem

Chatbot answers lose most of their markdown formatting. Headings render as plain body text, and bold disappears wherever a link sits inside a bold phrase.

The backend emits correct markdown — the loss happens in the renderer. `react-markdown` parses `## Resumo` into `<h2>` and `**x**` into `<strong>` as expected; `componentsMk` in `next/components/organisms/chatbot/markdown.js` then drops the formatting.

## Root causes

1. **Headings.** `componentsMk` maps `p, a, strong, em, code, ul, ol, li, table, …` but has no `h1`–`h6` entries. Chakra's CSS reset ships `h1,h2,h3,h4,h5,h6 { font-size: inherit; font-weight: inherit }` plus `margin: 0`, so unmapped headings render byte-identical to body text.

2. **Bold links.** `a` renders through `BodyText`, which hardcodes `fontWeight="400"` and `fontSize="16px"`. Inside `**[documentação](url)**` the `<a>`'s own declaration beats the bold inherited from `<strong>`, so the linked half of a bold phrase drops to regular weight. A link inside a heading also shrinks back to 16px.

3. **Table headers.** Markdown `th` was `fontWeight="400"`, while the tool-result tables in the same file use `600`.

## Changes

All in `next/components/organisms/chatbot/markdown.js` (one file, +87/-10):

- Add explicit `h1`–`h6` styles — Roboto at 24/20/18/16/15/14px, weights 700/700/600/600/600/600, with the first heading in a message not carrying a top margin.
- `a`, `strong` and `em` now inherit weight, size and colour from their context, so bold links stay bold and `[**text**](url)` keeps the link colour.
- `th` goes to `fontWeight="600"`, matching the tool-result tables.
- `ol` gets the same indent margin `ul` already had.
- Fenced code reads its language off `className` instead of always highlighting as SQL, and falls back to unhighlighted output when `highlight.js` does not know the language.
- Add `blockquote`, `hr` and `del`; stop nesting `CodeBlock`'s `<pre>` inside the `<pre>` react-markdown emits.
- Paragraph spacing goes from 4px to 8px, with no trailing margin on the last one.

<img width="1200" height="420" alt="mdbeforeafter" src="https://github.com/user-attachments/assets/fb2199e2-ae0d-4436-a591-b9b7ffc29cb2" />

## Testing

Verified the markdown parse step produces the right nodes, and confirmed the reset rules in `@chakra-ui/css-reset` that were flattening them. **Not yet checked against a live thread in a running app** — worth an eyeball on a real conversation before merge.

## Git Flow

This is the `main` PR. The same branch still needs its PRs into `development` and `staging`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
